### PR TITLE
handle NotAllowedToDisconnect exception

### DIFF
--- a/tethys_portal/middleware.py
+++ b/tethys_portal/middleware.py
@@ -12,7 +12,7 @@ from django.shortcuts import redirect
 from social.apps.django_app.middleware import SocialAuthExceptionMiddleware
 from django.http import HttpResponse
 from social import exceptions as social_exceptions
-from social.exceptions import AuthCanceled, AuthAlreadyAssociated
+from social.exceptions import AuthCanceled, AuthAlreadyAssociated, NotAllowedToDisconnect
 
 
 class TethysSocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
@@ -39,6 +39,13 @@ class TethysSocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
 
                 messages.success(request, blurb)
 
+                if request.user.is_anonymous():
+                    return redirect('accounts:login')
+                else:
+                    return redirect('user:settings', username=request.user.username)
+            elif isinstance(exception, NotAllowedToDisconnect):
+                blurb = 'Unable to disconnect from this social account.'
+                messages.success(request, blurb)
                 if request.user.is_anonymous():
                     return redirect('accounts:login')
                 else:


### PR DESCRIPTION
@swainn @sdc50 
We are having an issue on apps.hydroshare.org: HydroShare users login apps.hydroshare.org tethys server through OAuth, tethys will create a native tethys user and associate it with the HydroShare social account. If users try to disconnect the native tethys user from HydroShare social account, it will raise a NotAllowedToDisconnect exception, which results in a 500 error. 

I am guessing this is because the native tethys user created by HS OAuth is somehow different from the regular tethys user that was originally created via sign-up page and then got associated with HydroShare social account. At least the former user has no native tethys password, so it is useless without a HydroShare social account.

This patch handles the NotAllowedToDisconnect exception and displays a message to the users. It is still a short-term solution. A long-term solution might be let the user create a native tethys password before disconnecting from any social account.
 