### PR TITLE
block after_app_content

### DIFF
--- a/tethys_apps/templates/tethys_apps/app_base.html
+++ b/tethys_apps/templates/tethys_apps/app_base.html
@@ -89,7 +89,7 @@
     {% endcomment %}
 
     {% block styles %}
-      <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" />
+      <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" />
       <link href="{% static 'tethys_apps/css/app_base.css' %}" rel="stylesheet" />
       {% if tethys_app.enable_feedback %}
         <link href="{% static 'tethys_apps/css/feedback.css' %}" rel="stylesheet" />
@@ -99,7 +99,7 @@
 
     {% block global_scripts %}
       <script src="//code.jquery.com/jquery-2.2.4.min.js" type="text/javascript"></script>
-      <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" type="text/javascript"></script>
+      <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" type="text/javascript"></script>
       {% gizmo_dependencies global_js %}
     {% endblock %}
   </head>
@@ -189,6 +189,21 @@
         {% endblock %}
       </div>
     {% endblock %}
+
+
+    {% comment "after_app_content explanation" %}
+      Use this block for adding elements after the app content such as
+      bootstrap modals.
+
+      Example:
+        {% block after_app_content %}
+            {% gizmo my_modal %}
+        {% endblock %}
+    {% endcomment %}
+
+    {% block after_app_content %}
+    {% endblock %}
+
     {% block terms-of-service-override %}
       {% show_terms_if_not_agreed %}
     {% endblock %}

--- a/tethys_gizmos/gizmo_options/message_box.py
+++ b/tethys_gizmos/gizmo_options/message_box.py
@@ -52,8 +52,10 @@ class MessageBox(TethysGizmoOptions):
         {% load tethys_gizmos %}
 
         <a href="#sampleModal" role="button" class="btn btn-success" data-toggle="modal">Show Message Box</a>
-        {% gizmo message_box %}
 
+        {% block after_app_content %}
+            {% gizmo message_box %}
+        {% endblock %}
     """
     gizmo_name = "message_box"
 


### PR DESCRIPTION
1. Added block after_app_content to app base template for Modals & added instruction to modal gizmo
2. Upgraded Bootstrap from 3.2.0 to 3.3.7 in app base template