### PR TITLE
fix default draw layer styles on map view

### DIFF
--- a/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
@@ -274,9 +274,9 @@ var TETHYS_MAP_VIEW = (function() {
     // Constants
 ////////////////////////////////////////// Color of annotation tools and Button Spacing ////////////////////////////////
     var VALID_GEOMETRY_TYPES = ['Polygon', 'Point', 'LineString', 'Box'];
-    var INITIAL_FILL_COLOR = m_draw_options.fill_color,
-        INITIAL_STROKE_COLOR = m_draw_options.line_color,
-        INITIAL_POINT_FILL_COLOR = m_draw_options.point_color,
+    var INITIAL_FILL_COLOR = 'rgba(255, 255, 255, 0.2)',
+        INITIAL_STROKE_COLOR = '#ffcc33',
+        INITIAL_POINT_FILL_COLOR = '#ffcc33',
         BUTTON_SPACING = 30,
         BUTTON_OFFSET_UNITS = 'px';
 
@@ -285,6 +285,12 @@ var TETHYS_MAP_VIEW = (function() {
         initial_drawing_mode = 'Point';
 
     if (is_defined(m_draw_options)) {
+
+      // Customize styles
+      INITIAL_FILL_COLOR = m_draw_options.fill_color,
+      INITIAL_STROKE_COLOR = m_draw_options.line_color,
+      INITIAL_POINT_FILL_COLOR = m_draw_options.point_color,
+
       // Initialize the drawing layer
       m_drawing_source = new ol.source.Vector({wrapX: false});
 


### PR DESCRIPTION
Recent commits broke my app because I don't define an MVDraw object, since I don't need drawing on my map. The javascript was trying to assign fill_color, line_color, and point_color from a m_draw_options object, but that object was undefined. I propose the following to fix the bug.