### PR TITLE
added style modification ability from mapview gizmo

### DIFF
--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -129,6 +129,25 @@ class MapView(TethysGizmoOptions):
           ]
         }
 
+        # Define GeoJSON point layer
+        geojson_point_object = {
+          'type': 'FeatureCollection',
+          'crs': {
+            'type': 'name',
+            'properties': {
+              'name': 'EPSG:3857'
+            }
+          },
+          'features': [
+            {
+              'type': 'Feature',
+              'geometry': {
+                'type': 'Point',
+                'coordinates': [0, 0]
+              }
+            },
+          ]
+        }
         geojson_layer = MVLayer(source='GeoJSON',
                                 options=geojson_object,
                                 legend_title='Test GeoJSON',
@@ -136,6 +155,23 @@ class MapView(TethysGizmoOptions):
                                 legend_classes=[
                                     MVLegendClass('polygon', 'Polygons', fill='rgba(255,255,255,0.8)', stroke='#3d9dcd'),
                                     MVLegendClass('line', 'Lines', stroke='#3d9dcd')
+                                ])
+
+        geojson_point_layer = MVLayer(source='GeoJSON',
+                                options=geojson_point_object,
+                                legend_title='Test GeoJSON',
+                                legend_extent=[-46.7, -48.5, 74, 59],
+                                legend_classes=[
+                                    MVLegendClass('line', 'Lines', stroke='#3d9dcd')
+                                layer_options={'style': {'image':
+                                                         {'circle': {'radius': 5,
+                                                                     'fill': {'color': #3d9dcd},
+                                                                     'stroke': {'color': '#ffffff' ,
+                                                                                'width': 0},
+                                                                     }
+                                                          }
+                                                     }
+                                           }
                                 ])
 
         # Define GeoServer Layer
@@ -174,7 +210,7 @@ class MapView(TethysGizmoOptions):
                 controls=['ZoomSlider', 'Rotate', 'FullScreen',
                           {'MousePosition': {'projection': 'EPSG:4326'}},
                           {'ZoomToExtent': {'projection': 'EPSG:4326', 'extent': [-130, 22, -65, 54]}}],
-                layers=[geojson_layer, geoserver_layer, kml_layer, arc_gis_layer],
+                layers=[geojson_layer, geojson_point_layer, geoserver_layer, kml_layer, arc_gis_layer],
                 view=view_options,
                 basemap='OpenStreetMap',
                 draw=drawing_options,

--- a/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
@@ -449,6 +449,16 @@ var TETHYS_MAP_VIEW = (function() {
 
     var VECTOR_SOURCES = ['GeoJSON', 'KML', 'GPX', 'IGC', 'OSMXML', 'TopoJSON', 'ServerVector', 'TileVector'];
 
+    var STYLE_MAP = {
+        'fill'  : ol.style.Fill,
+        'stroke': ol.style.Stroke,
+        'text'  : ol.style.Text,
+    };
+
+    var STYLE_IMAGE_MAP = {
+        'circle': ol.style.Circle,
+    };
+
     if (is_defined(m_layers_options)) {
       for (var i = m_layers_options.length; i--; ) {
         var current_layer,
@@ -457,6 +467,28 @@ var TETHYS_MAP_VIEW = (function() {
         current_layer = m_layers_options[i];
         // Extract layer_options
         if ('layer_options' in current_layer && current_layer.layer_options) {
+          if ('style' in current_layer.layer_options) {
+            var style_options = current_layer.layer_options.style;
+            if ('image' in style_options) {
+                var image_options = current_layer.layer_options.style.image;
+                for (var ikey in image_options) {
+                    if (image_options.hasOwnProperty(ikey)) {
+                        if (ikey in STYLE_IMAGE_MAP) {
+                            for (var ckey in image_options[ikey]) {
+                                if (image_options[ikey].hasOwnProperty(ckey)) {
+                                    if (ckey in STYLE_MAP)
+                                    {
+                                        current_layer.layer_options.style.image[ikey][ckey] = new STYLE_MAP[ckey](image_options[ikey][ckey]);
+                                    }
+                                }
+                            }
+                            current_layer.layer_options.style.image = new STYLE_IMAGE_MAP[ikey](image_options[ikey]);
+                        }
+                    }
+                }
+            }
+            current_layer.layer_options.style = new ol.style.Style(current_layer.layer_options.style);
+          }
           current_layer_layer_options = current_layer.layer_options;
         } else {
           current_layer_layer_options = {};


### PR DESCRIPTION
Example usage:
```python
    gauge_layer = MVLayer(
        source='GeoJSON',
        options=feature_collection,
        legend_title=legend_title,
        feature_selection=True,
        legend_classes =[
            MVLegendClass('point', value=legend_title, fill=point_color),
        ],
        layer_options={'style': {'image':
                                     {'circle': {'radius': 4,
                                                 'fill': {'color': point_color},
                                                 'stroke': {'color': '#ffffff' ,
                                                            'width': 0},
                                                 }
                                      }
                                 }
                       }

    )
```