### PR TITLE
331-Create-APT-Token-for-new-USER-object

### DIFF
--- a/tethys_portal/views/__init__.py
+++ b/tethys_portal/views/__init__.py
@@ -7,3 +7,4 @@
 * License: BSD 2-Clause
 ********************************************************************************
 """
+from .receivers import create_auth_token

--- a/tethys_portal/views/receivers.py
+++ b/tethys_portal/views/receivers.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
+
+
+# create API Token for newly created django USER object
+# see: http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -69,8 +69,10 @@ def settings(request, username=None):
         form = UserSettingsForm(instance=request_user)
 
     # Create template context object
+    user_token, token_created = Token.objects.get_or_create(user=request_user)
     context = {'form': form,
-               'context_user': request.user}
+               'context_user': request.user,
+               'user_token': user_token.key}
 
     return render(request, 'tethys_portal/user/settings.html', context)
 


### PR DESCRIPTION
This PR addressed issue #331 .
1) A receiver (event callback) runs to create a API token once a new USER object is saved to DB
2) APT Token is visible (read-only) on both User profile's view page and edit page 