### PR TITLE
Update jobs api docs

### DIFF
--- a/docs/tethys_sdk/jobs/basic_job_type.rst
+++ b/docs/tethys_sdk/jobs/basic_job_type.rst
@@ -2,45 +2,32 @@
 Basic Job Type
 **************
 
-**Last Updated:** March 29, 2016
+**Last Updated:** December 27, 2018
 
-The Basic Job type is a sample job type for creating dummy jobs. It has all of the basic properties and methods of a job, but it doesn't have any mechanism for running jobs. It's primary purpose is for demonstration. There are no additional attributes for the BasicJob type other than the common set of job attributes. The only required parameter for the `BasicJobTemplate` class is ``name``, but it also supports passing in other job attributes as additional arguments.
+The Basic Job type is a sample job type for creating dummy jobs. It has all of the basic properties and methods of a job, but it doesn't have any mechanism for running jobs. It's primary purpose is for demonstration. There are no additional attributes for the BasicJob type other than the common set of job attributes.
 
-Setting up a BasicJobTemplate
-=============================
-::
-
-  from tethys_sdk.jobs import BasicJobTemplate
-
-  def job_templates(cls):
-      """
-      Example job_templates method with a BasicJob type.
-      """
-
-      job_templates = (BasicJobTemplate(name='example',
-                                        description='This is a sample basic job. It can't actually compute anything.',
-                                        extended_properties={'app_spcific_property': 'default_value',
-                                                             'persistent_store_id': None,  # Will be defined when job is created
-                                                             }
-                                        ),
-                      )
-
-      return job_templates
-
-Creating and Customizing a Job
-==============================
-To create a job call the ``create_job`` method on the job manager. The required parameters are ``name``, ``user`` and ``template_name``. Any other job attributes can also be passed in as `kwargs`.
+Creating a Basic Job
+====================
+To create a job call the ``create_job`` method on the job manager. The required parameters are ``name``, ``user`` and ``job_type``. Any other job attributes can also be passed in as `kwargs`.
 
 ::
 
     # create a new job
-    job = job_manager.create_job(name='unique_job_name', user=request.user, template_name='example', description='my first job')
+    job = job_manager.create_job(
+        name='unique_job_name',
+        user=request.user,
+        template_name='BASIC',
+        description='This is a sample basic job. It can't actually compute anything.',
+        extended_properties={
+            'app_spcific_property': 'default_value',
+        }
+    )
 
 Before a controller returns a response the job must be saved or else all of the changes made to the job will be lost (executing the job automatically saves it). If submitting the job takes a long time (e.g. if a large amount of data has to be uploaded to a remote scheduler) then it may be best to use AJAX to execute the job.
 
 API Documentation
 =================
 
-.. autoclass:: tethys_sdk.jobs.BasicJobTemplate
-
 .. autoclass:: tethys_compute.models.BasicJob
+
+.. autoclass:: tethys_sdk.jobs.BasicJobTemplate

--- a/docs/tethys_sdk/jobs/condor_job_description.rst
+++ b/docs/tethys_sdk/jobs/condor_job_description.rst
@@ -4,6 +4,8 @@ Condor Job Description
 
 **Last Updated:** March 29, 2016
 
+**DEPRECATED**
+
 Both the :doc:`./condor_job_type` or the :doc:`./condor_workflow_type` facilitate running jobs with HTCondor using the CondorPy library, and both use ``CondorJobDescription`` objects which stores attributes used to initialize the CondorPy job. The ``CondorJobDescription`` accepts as parameters any HTCondor job attributes.
 
 .. note::

--- a/docs/tethys_sdk/jobs/condor_job_type.rst
+++ b/docs/tethys_sdk/jobs/condor_job_type.rst
@@ -2,60 +2,68 @@
 Condor Job Type
 ***************
 
-**Last Updated:** March 29, 2016
+**Last Updated:** December 27, 2018
 
 
+The :doc:`condor_job_type` (and :doc:`condor_workflow_type`) enable the real power of the jobs API by combining it with the :doc:`../compute`. This make it possible for jobs to be offloaded from the main web server to a scalable computing cluster, which in turn enables very large scale jobs to be processed.
 
-Setting up a CondorJobTemplate
-==============================
-::
+.. seealso::
+    The Condor Job and the Condor Workflow job types use the CondorPy library to submit jobs to HTCondor compute pools. For more information on CondorPy and HTCondor see the `CondorPy documentation <http://condorpy.readthedocs.org/en/latest/>`_ and specifically the `Overview of HTCondor <http://condorpy.readthedocs.org/en/latest/htcondor.html>`_.
 
-  from tethys_sdk.jobs import CondorJobTemplate, CondorJobDescription
-  from tethys_sdk.compute import list_schedulers
 
-  def job_templates(cls):
-      """
-      Example job_templates method.
-      """
-      my_scheduler = list_schedulers()[0]
-
-      my_job_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                                remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                                executable='my_script.py',
-                                                transfer_input_files=('../input_1', '../input_2'),
-                                                transfer_output_files=('example_output1', example_output2),
-                                                )
-
-      job_templates = (CondorJobTemplate(name='example',
-                                         job_description=my_job_description,
-                                         scheduler=my_scheduler,
-                                        ),
-                      )
-
-      return job_templates
-
-Creating and Customizing a Job
-==============================
-To create a job call the ``create_job`` method on the job manager. The required parameters are ``name``, ``user`` and ``template_name``. Any other job attributes can also be passed in as `kwargs`.
+Creating a Condor Job
+=====================
+To create a job call the ``create_job`` method on the job manager. The required parameters are ``name``, ``user`` and ``job_type``. Any other job attributes can also be passed in as `kwargs`.
 
 ::
 
-    # create a new job
-    job = job_manager.create_job(name='job_name', user=request.user, template_name='example', description='my first job')
+    from tethys_sdk.compute import list_schedulers
+    from .app import MyApp as app
 
-    # customize the job using methods provided by the job type
-    job.set_attribute('arguments', 'input_2')
+    def some_controller(request):
 
-    # save or execute the job
-    job.save()
-    # or
-    job.execute()
+        # get the path to the app workspace to reference job files
+        app_workspace = app.get_app_workspace().path
+
+        # create a new job from the job manager
+        job = job_manager.create_job(
+            name='myjob_{id}',  # required
+            user=request.user,  # required
+            job_type='CONDOR',  # required
+
+            # any other properties can be passed in as kwargs
+            attributes=dict(
+                transfer_input_files=('../input_1', '../input_2'),
+                transfer_output_files=('example_output1', example_output2),
+            ),
+            condorpy_template_name='vanilla_transfer_files',
+            remote_input_files=(
+                os.path.join(app_workspace, 'my_script.py'),
+                os.path.join(app_workspace, 'input_1'),
+                os.path.join(app_workspace, 'input_2')
+            )
+        )
+
+        # properties can also be added after the job is created
+        job.extended_properties = {'one': 1, 'two': 2}
+
+        # each job type may provided methods to further specify the job
+        job.set_attribute('executable', 'my_script.py')
+
+        # get a scheduler for the job
+        my_scheduler = list_schedulers()[0]
+        job.scheduler = my_scheduler
+
+        # save or execute the job
+        job.save()
+        # or
+        job.execute()
 
 Before a controller returns a response the job must be saved or else all of the changes made to the job will be lost (executing the job automatically saves it). If submitting the job takes a long time (e.g. if a large amount of data has to be uploaded to a remote scheduler) then it may be best to use AJAX to execute the job.
 
 API Documentation
 =================
 
-.. autoclass:: tethys_sdk.jobs.CondorJobTemplate
-
 .. autoclass:: tethys_compute.models.CondorJob
+
+.. autoclass:: tethys_sdk.jobs.CondorJobTemplate

--- a/docs/tethys_sdk/jobs/condor_workflow_type.rst
+++ b/docs/tethys_sdk/jobs/condor_workflow_type.rst
@@ -2,155 +2,113 @@
 Condor Workflow Job Type
 ************************
 
-**Last Updated:** March 29, 2016
+**Last Updated:** December 27, 2018
 
 A Condor Workflow provides a way to run a group of jobs (which can have hierarchical relationships) as a single (Tethys) job. The hierarchical relationships are defined as parent-child relationships. For example, suppose a workflow is defined with three jobs: ``JobA``, ``JobB``, and ``JobC``, which must be run in that order. These jobs would be defined with the following relationships: ``JobA`` is the parent of ``JobB``, and ``JobB`` is the parent of ``JobC``.
 
 .. seealso::
     The Condor Workflow job type uses the CondorPy library to submit jobs to HTCondor compute pools. For more information on CondorPy and HTCondor see the `CondorPy documentation <http://condorpy.readthedocs.org/en/latest/>`_ and specifically the `Overview of HTCondor <http://condorpy.readthedocs.org/en/latest/htcondor.html>`_.
 
-Setting up a CondorWorkflowTemplate
-===================================
-Creating a `CondorWorkflowTemplate` involves 3 steps:
+Creating a Condor Workflow
+==========================
+Creating a Condor Workflow job involves 3 steps:
 
-    1. Define job descriptions for each of the sub-jobs using `CondorJobDescription` (see :doc:`condor_job_description`).
-    2. Create the sub-jobs and define relationships using `CondorWorkflowJobTemplate`.
-    3. Create the `CondorWorkflowTemplate`.
+    1. Create an empty Workflow job from the job manager.
+    2. Create the jobs that will make up the workflow with `CondorWorkflowJobNode`
+    3. Define the relationships among the nodes
+
+
+::
+
+    from tethys_sdk.jobs import CondorWorkflowJobNode
+    from .app import MyApp as app
+
+    def some_controller(request):
+
+        # get the path to the app workspace to reference job files
+        app_workspace = app.get_app_workspace().path
+
+        workflow = job_manager.create_job(
+            name='MyWorkflowABC',
+            user=request.user,
+            job_type='CONDORWORKFLOW',
+            scheduler=None,
+        )
+        workflow.save()
+
+        job_a = CondorWorkflowJobNode(
+            name='JobA',
+            workflow=workflow,
+            condorpy_template_name='vanilla_transfer_files',
+            remote_input_files=(
+                os.path.join(app_workspace, 'my_script.py'),
+                os.path.join(app_workspace, 'input_1'),
+                os.path.join(app_workspace, 'input_2')
+            ),
+            attributes=dict(
+                executable='my_script.py',
+                transfer_input_files=('../input_1', '../input_2'),
+                transfer_output_files=('example_output1', 'example_output2'),
+            )
+        )
+        job_a.save()
+
+        job_b = CondorWorkflowJobNode(
+            name='JobB',
+            workflow=workflow,
+            condorpy_template_name='vanilla_transfer_files',
+            remote_input_files=(
+                os.path.join(app_workspace, 'my_script.py'),
+                os.path.join(app_workspace, 'input_1'),
+                os.path.join(app_workspace, 'input_2')
+            ),
+            attributes=dict(
+                executable='my_script.py',
+                transfer_input_files=('../input_1', '../input_2'),
+                transfer_output_files=('example_output1', 'example_output2'),
+            ),
+        )
+        job_b.save()
+
+        job_c = CondorWorkflowJobNode(
+            name='JobC',
+            workflow=workflow,
+            condorpy_template_name='vanilla_transfer_files',
+            remote_input_files=(
+                os.path.join(app_workspace, 'my_script.py'),
+                os.path.join(app_workspace, 'input_1'),
+                os.path.join(app_workspace, 'input_2')
+            ),
+            attributes=dict(
+                executable='my_script.py',
+                transfer_input_files=('../input_1', '../input_2'),
+                transfer_output_files=('example_output1', 'example_output2'),
+            ),
+        )
+        job_c.save()
+
+        job_b.add_parent(job_a)
+        job_c.add_parent(job_b)
+
+        workflow.save()
+        # or
+        workflow.execute()
 
 .. note::
-    The `CondorWorkflowJobTemplate` is similar to a `CondorJobTemplate` in that it represents a single HTCondor job and requires a `CondorJobDescription` to define the attributes of that job. However, unlike a `CondorJobTemplate` a `CondorWorkflowJobTemplate` cannot be run independently; it can only be part of a `CondorWorkflowTemplate`. Also, note that the `CondorWorkflowJobTemplate` has a `parents` parameter, which is used to define relationships between jobs.
 
-The following code sample demonstrates how to set up a `CondorWorkflowTemplate`:
-
-::
-
-      Example job_templates method with a CondorWorkflow type.
-      """
-
-      job_a_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                               remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                               executable='my_script.py',
-                                               transfer_input_files=('../input_1', '../input_2'),
-                                               transfer_output_files=('example_output1', example_output2),
-                                               )
-      job_b_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                               remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                               executable='my_script.py',
-                                               transfer_input_files=('../input_1', '../input_2'),
-                                               transfer_output_files=('example_output1', example_output2),
-                                               )
-      job_c_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                               remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                               executable='my_script.py',
-                                               transfer_input_files=('../input_1', '../input_2'),
-                                               transfer_output_files=('example_output1', example_output2),
-                                               )
-      job_a = CondorWorkflowJobTemplate(name='JobA',
-                                        job_description=job_a_description,
-                                        )
-      job_b = CondorWorkflowJobTemplate(name='JobB',
-                                        job_description=job_b_description,
-                                        parents=[job_a]
-                                        )
-      job_c = CondorWorkflowJobTemplate(name='JobC',
-                                        job_description=job_c_description,
-                                        parents=[job_b]
-                                        )
-      job_templates = (CondorWorkflowTemplate(name='WorkflowABC',
-                                              job_list=[job_a, job_b, job_c],
-                                              scheduler=None,
-                                              ),
-                       )
-
-If the you want to use the same job both as part of a workflow and as a stand alone job then use the same job description in setting up the `CondorJobTemplate` and the `CondorWorkflowJobTemplate`. This process is demonstrated below:
-
-
-::
-
-  from tethys_sdk.jobs import CondorJobTemplate, CondorWorkflowTemplate, CondorWorkflowJobTemplate, CondorJobDescription
-  from tethys_sdk.compute import list_schedulers
-
-  def job_templates(cls):
-      """
-      Example job_templates method with a CondorWorkflow type.
-      """
-
-      reusable_job_a_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                                        remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                                        executable='my_script.py',
-                                                        transfer_input_files=('../input_1', '../input_2'),
-                                                        transfer_output_files=('example_output1', example_output2),
-                                                        )
-      job_b1_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                                remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                                executable='my_script.py',
-                                                transfer_input_files=('../input_1', '../input_2'),
-                                                transfer_output_files=('example_output1', example_output2),
-                                                )
-      job_b2_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                                remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                                executable='my_script.py',
-                                                transfer_input_files=('../input_1', '../input_2'),
-                                                transfer_output_files=('example_output1', example_output2),
-                                                )
-      job_c_description = CondorJobDescription(condorpy_template_name='vanilla_transfer_files',
-                                               remote_input_files=('$(APP_WORKSPACE)/my_script.py', '$(APP_WORKSPACE)/input_1', '$(USER_WORKSPACE)/input_2'),
-                                               executable='my_script.py',
-                                               transfer_input_files=('../input_1', '../input_2'),
-                                               transfer_output_files=('example_output1', example_output2),
-                                               )
-      job_a = CondorWorkflowJobTemplate(name='JobA',
-                                        job_description=reusable_job_a_description,
-                                        )
-      job_b1 = CondorWorkflowJobTemplate(name='JobB1',
-                                         job_description=reusable_job_a_description,
-                                         parents=[job_a]
-                                         )
-      job_b2 = CondorWorkflowJobTemplate(name='JobB2',
-                                         job_description=reusable_job_a_description,
-                                         parents=[job_a]
-                                         )
-      job_c = CondorWorkflowJobTemplate(name='JobC',
-                                        job_description=reusable_job_a_description,
-                                        parents=[job_b1, job_b2]
-                                        )
-      job_templates = (CondorWorkflowTemplate(name='DiamondWorkflow',
-                                              job_list=[job_a, job_b1, job_b2, job_c],
-                                              scheduler=None,
-                                              ),
-                       CondorJobTemplate(name='JobAStandAlone',
-                                         job_description=reusable_job_a_description,
-                                         scheduler=None,
-                                         ),
-                       )
-
-
-Creating and Customizing a Job
-==============================
-To create a job call the ``create_job`` method on the job manager. The required parameters are ``name``, ``user`` and ``template_name``. Any other job attributes can also be passed in as `kwargs`.
-
-::
-
-    # create a new job
-    job = job_manager.create_job(name='job_name', user=request.user, template_name='example', description='my first job')
-
-    # customize the job using methods provided by the job type
-    job.set_attribute('arguments', 'input_2')
-
-    # save or execute the job
-    job.save()
-    # or
-    job.execute()
+    The `CondorWorkflow` object must be saved before the `CondorWorkflowJobNode` objects can be instantiated, and the `CondorWorkflowJobNode` objects must be saved before you can define the relationships.
 
 Before a controller returns a response the job must be saved or else all of the changes made to the job will be lost (executing the job automatically saves it). If submitting the job takes a long time (e.g. if a large amount of data has to be uploaded to a remote scheduler) then it may be best to use AJAX to execute the job.
 
 API Documentation
 =================
 
+.. autoclass:: tethys_compute.models.CondorWorkflow
+
+.. autoclass:: tethys_compute.models.CondorWorkflowNode
+
+.. autoclass:: tethys_compute.models.CondorWorkflowJobNode
+
 .. autoclass:: tethys_sdk.jobs.CondorWorkflowTemplate
 
 .. autoclass:: tethys_sdk.jobs.CondorWorkflowJobTemplate
-
-.. autoclass:: tethys_compute.models.CondorWorkflow
-
-.. autoclass:: tethys_compute.models.CondorWorkflowJobNode

--- a/tests/unit_tests/test_tethys_compute/test_job_manager.py
+++ b/tests/unit_tests/test_tethys_compute/test_job_manager.py
@@ -70,8 +70,9 @@ class TestJobManager(unittest.TestCase):
         mock_ocj.assert_called_with('test_name', 'test_user', 'template_1')
 
         # Check if warning message is called
-        check_msg = 'The job template "{0}" was used in the "{1}" app. Using job templates is now deprecated. ' \
-                    'See docs: <<link>>.'.format('template_1', 'test_label')
+        check_msg = 'The job template "{0}" was used in the "{1}" app. Using job templates is now deprecated.'.format(
+            'template_1', 'test_label'
+        )
         rts_call_args = mock_warn.warn.call_args_list
         self.assertEqual(check_msg, rts_call_args[0][0][0])
         mock_print.assert_called_with(check_msg)

--- a/tethys_compute/job_manager.py
+++ b/tethys_compute/job_manager.py
@@ -38,7 +38,7 @@ class JobManager(object):
     A manager for interacting with the Jobs database providing a simple interface creating and retrieving jobs.
 
     Note:
-        Each app creates its own instance of the JobManager. the ``get_job_manager`` method returns the app.
+        Each app creates its own instance of the JobManager. The ``get_job_manager`` method returns the app.
 
         ::
 
@@ -70,9 +70,9 @@ class JobManager(object):
             A new job object of the type specified by job_type.
         """
         if template_name is not None:
-            msg = 'The job template "{0}" was used in the "{1}" app. Using job templates is now deprecated. ' \
-                  'See docs: <<link>>.'\
-                .format(template_name, self.app.package)
+            msg = 'The job template "{0}" was used in the "{1}" app. Using job templates is now deprecated.'.format(
+                template_name, self.app.package
+            )
             warnings.warn(msg, DeprecationWarning)
             print(msg)
             return self.old_create_job(name, user, template_name, **kwargs)
@@ -210,6 +210,7 @@ class JobManager(object):
 
 class JobTemplate(object):
     """
+    **DEPRECATED**
     A template from which to create a job.
 
     Args:
@@ -239,6 +240,7 @@ class JobTemplate(object):
 
 class BasicJobTemplate(JobTemplate):
     """
+    **DEPRECATED**
     A subclass of JobTemplate with the ``type`` argument set to BasicJob.
 
     Args:
@@ -254,6 +256,7 @@ class BasicJobTemplate(JobTemplate):
 
 class CondorJobDescription(object):
     """
+    **DEPRECATED**
     Helper class for CondorJobTemplate and CondorWorkflowJobTemplates. Stores job attributes.
     """
     def __init__(self, condorpy_template_name=None, remote_input_files=None, **kwargs):
@@ -267,6 +270,7 @@ class CondorJobDescription(object):
 
 class CondorJobTemplate(JobTemplate):
     """
+    **DEPRECATED**
     A subclass of the JobTemplate with the ``type`` argument set to CondorJob.
 
     Args:
@@ -289,6 +293,7 @@ class CondorJobTemplate(JobTemplate):
 
 class CondorWorkflowTemplate(JobTemplate):
     """
+    **DEPRECATED**
     A subclass of the JobTemplate with the ``type`` argument set to CondorWorkflow.
 
     Args:
@@ -343,6 +348,7 @@ NODE_TYPES = {'JOB': CondorWorkflowJobNode,
 
 class CondorWorkflowNodeBaseTemplate(object):
     """
+    **DEPRECATED**
     A template from which to create a job.
 
     Args:
@@ -380,6 +386,7 @@ class CondorWorkflowNodeBaseTemplate(object):
 
 class CondorWorkflowJobTemplate(CondorWorkflowNodeBaseTemplate):
     """
+    **DEPRECATED**
     A subclass of the CondorWorkflowNodeBaseTemplate with the ``type`` argument set to CondorWorkflowJobNode.
 
     Args:
@@ -395,15 +402,3 @@ class CondorWorkflowJobTemplate(CondorWorkflowNodeBaseTemplate):
 
     def process_parameters(self):
         pass
-
-
-class CondorWorkflowSubworkflowTemplate(CondorWorkflowNodeBaseTemplate):
-    pass
-
-
-class CondorWorkflowDataJobTemplate(CondorWorkflowNodeBaseTemplate):
-    pass
-
-
-class CondorWorkflowFinalTemplate(CondorWorkflowNodeBaseTemplate):
-    pass

--- a/tethys_compute/models.py
+++ b/tethys_compute/models.py
@@ -569,6 +569,27 @@ def condor_workflow_pre_delete(sender, instance, using, **kwargs):
 class CondorWorkflowNode(models.Model):
     """
     Base class for CondorWorkflow Nodes
+
+    Args:
+        name (str):
+        workflow (`CondorWorkflow`): instance of a `CondorWorkflow` that node belongs to
+        parent_nodes (list): list of `CondorWorkflowNode` objects that are prerequisites to this node
+        pre_script (str):
+        pre_script_args (str):
+        post_script (str):
+        post_script_args (str):
+        variables (dict):
+        priority (int):
+        category (str):
+        retry (int):
+        retry_unless_exit_value (int):
+        pre_skip (int):
+        abort_dag_on (int):
+        dir (str):
+        noop (bool):
+        done (bool):
+
+    For a description of the arguments see http://research.cs.wisc.edu/htcondor/manual/v8.6/2_10DAGMan_Applications.html
     """
     TYPES = (('JOB', 'JOB'),
              ('DAT', 'DATA'),

--- a/tethys_sdk/jobs.py
+++ b/tethys_sdk/jobs.py
@@ -9,17 +9,16 @@
 """
 # flake8: noqa
 # DO NOT ERASE
+from tethys_compute.job_manager import JobManager
+from tethys_compute.models import CondorWorkflowJobNode
+
+# Depricated imports
 from tethys_compute.job_manager import (
-    JobManager,
+    JobTemplate,
+    JOB_TYPES,
     BasicJobTemplate,
     CondorJobTemplate,
     CondorJobDescription,
     CondorWorkflowTemplate,
     CondorWorkflowJobTemplate,
-    # CondorWorkflowSubworkflowTemplate,
-    # CondorWorkflowDataJobTemplate,
-    # CondorWorkflowFinalTemplate,
 )
-
-# Depricated imports
-from tethys_compute.job_manager import (JobTemplate, JOB_TYPES)


### PR DESCRIPTION
Update docs to deprecate `JobTemplate` and provide examples using the way to create jobs without templates.

Closes #367 