### PR TITLE
Cesium gizmo bug fix

### DIFF
--- a/tethys_gizmos/gizmo_options/cesium_map_view.py
+++ b/tethys_gizmos/gizmo_options/cesium_map_view.py
@@ -249,7 +249,7 @@ class CesiumMapView(TethysGizmoOptions):
     gizmo_name = "cesium_map_view"
 
     # Set Cesium Default Release Version.
-    cesium_version = "1.51"
+    cesium_version = ""
 
     def __init__(self, options={}, view={}, layers=[], entities=[], terrain={}, models=[],
                  height='100%', width='100%', draw=False, attributes={}, classes=''):

--- a/tethys_gizmos/views/gizmo_showcase.py
+++ b/tethys_gizmos/views/gizmo_showcase.py
@@ -1200,17 +1200,9 @@ def cesium_map_view(request, type):
                    "czml_link": czml_link, "model_link": model_link, "model2_link": model2_link,
                    "page_type": type}
 
-    # Set Cesium_version to blank to use the build version
-    CesiumMapView.cesium_version = ''
-
-    # Use release Cesium version 1.51
-    # CesiumMapView.cesium_version = '1.51'
-
     # 1. Basic Map
     height = '600px'
     if (type == 'home'):
-        # Set Cesium_version to blank to use the build version
-        CesiumMapView.cesium_version = ''
         cesium_map_view = CesiumMapView(
             height=height,
             options={'timeline': True, 'homeButton': True}

--- a/tethys_gizmos/views/gizmo_showcase.py
+++ b/tethys_gizmos/views/gizmo_showcase.py
@@ -1200,8 +1200,11 @@ def cesium_map_view(request, type):
                    "czml_link": czml_link, "model_link": model_link, "model2_link": model2_link,
                    "page_type": type}
 
+    # Set Cesium_version to blank to use the build version
+    CesiumMapView.cesium_version = ''
+
     # Use release Cesium version 1.51
-    CesiumMapView.cesium_version = '1.51'
+    # CesiumMapView.cesium_version = '1.51'
 
     # 1. Basic Map
     height = '600px'


### PR DESCRIPTION
Found an issue with hard coding the default version of Cesium and using their CDN. When they release a new update, the old version is removed from the CDN, breaking the Cesium Map View gizmo. Instead, we will have the gizmo use the latest build version.