### PR TITLE
Cesium Support for Globe, Clock, and Constants

### DIFF
--- a/docs/tutorials/getting_started/advanced.rst
+++ b/docs/tutorials/getting_started/advanced.rst
@@ -264,7 +264,7 @@ g. Add **Persistent Store Service** to Tethys Portal:
     d. Click on the **Add Persistent Store Service** button.
     e. Give the **Persistent Store Service** a name and fill out the connection information.
 
-.. figure:: images/tutorial/advanced/Persistent_Store_Service.png
+.. figure:: ../../images/tutorial/advanced/Persistent_Store_Service.png
     :width: 600px
     :align: center
 
@@ -282,7 +282,7 @@ h. Assign **Persistent Store Service** to Dam Inventory App:
     e. Scroll down to the **Persistent Store Database Settings** section.
     f. Assign the **Persistent Store Service** that you created in Step 4 to the **primary_db**.
 
-.. figure:: images/tutorial/advanced/Assign_Persistent_Store_Service.png
+.. figure:: ../../images/tutorial/advanced/Assign_Persistent_Store_Service.png
     :width: 600px
     :align: center
 

--- a/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmo_showcase.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmo_showcase.py
@@ -137,7 +137,6 @@ class TestGizmoShowcase(unittest.TestCase):
         self.assertIn('home', render_call_args[0][0][2]['page_type'])
         self.assertIn('/developer/gizmos/model/cesium-map-view', render_call_args[0][0][2]['model_link'])
         self.assertIn('/developer/gizmos/home/cesium-map-view', render_call_args[0][0][2]['home_link'])
-        self.assertIn('homeButton', render_call_args[0][0][2]['cesium_map_view']['options'])
 
     @mock.patch('tethys_gizmos.views.gizmo_showcase.render')
     def test_cesium_map_view_map_layers(self, mock_render):

--- a/tethys_gizmos/gizmo_options/cesium_map_view.py
+++ b/tethys_gizmos/gizmo_options/cesium_map_view.py
@@ -13,12 +13,17 @@ class CesiumMapView(TethysGizmoOptions):
             height(str): Height of the map element. Any valid css unit of length (e.g.: '500px'). Defaults to '100%'.
             width(str): Width of the map element. Any valid css unit of length (e.g.: '100%'). Defaults to '100%'.
             options(dict): Viewer basic options. One item in dictionary per option.
+            globe(dict): Options to set on the Globe of the view.
             view(dict): Set the initial view of the map using various methods(e.g.: flyTo, setView)
             layers(dict): Add imagery layer to map. One item in dictionary per imagery layer.
             entities(dict):: Add entities to map. One item in dictionary per entity
             terrain(dict): Add terrain provider to the map.
             models(dict): Add 3D model to map. One item in dictionary per model.
+            clock(dict): Define custom clock options for viewer.
             draw(boolean): Turn drawing tools on/off.
+            attributes(dict): A dictionary representing additional HTML attributes to add to the primary element (e.g. {"onclick": "run_me();"}).
+            classes(str): Additional classes to add to the primary HTML element (e.g. "example-class another-class").
+
 
 
         **Cesium Version**
@@ -44,6 +49,28 @@ class CesiumMapView(TethysGizmoOptions):
             ::
 
                 options={'shouldAnimate': False, 'timeline': False, 'homeButton': False}
+                
+        **Globe**
+        
+        You can specify options that are often set on the Globe object associated with the Cesium viewer. For example, to achieve the equivalent of these calls in the Cesiumm JavaScript API:
+        
+        ::
+            
+            // Cesium JS Example
+            viewer.scene.globe.enableLighting = true;
+            viewer.scene.globe.depthTestAgainstTerrain = true;
+            
+        Pass the following Globe options to CesiumMapView:
+        
+        ::
+        
+            # Tethys CesiumMapView example
+            cesium_map_view = CesiumMapView(
+                globe={
+                    'enableLighting': True,
+                    'depthTestAgainstTerrain': True
+                }
+            )
 
         **View**
 
@@ -60,7 +87,7 @@ class CesiumMapView(TethysGizmoOptions):
                     }
                 });
 
-        In CesiumMapView, you can define this setting using python as follows
+        In Tethys CesiumMapView, you can define this setting using python as follows
 
             ::
 
@@ -210,6 +237,45 @@ class CesiumMapView(TethysGizmoOptions):
                 },
                 'position': {'Cesium.Cartesian3.fromDegrees': [-123.0744619, 44.0503706, 5000]},
             }}
+            
+        **Clock**
+        
+        You can customize the clock on the viewer such as specifying the starting date and time and specifying the time step interval. For example, to achieve the equivalent of these calls in the Cesiumm JavaScript API:
+        
+        ::
+            
+            // Cesium JS Example
+            var clock = new Cesium.Clock({
+                startTime : Cesium.JulianDate.fromIso8601('2017-07-11T00:00:00Z'),
+                stopTime : Cesium.JulianDate.fromIso8601('2017-07-11T24:00:00Z'),
+                currentTime : Cesium.JulianDate.fromIso8601('2017-07-11T10:00:00Z'),
+                clockRange : Cesium.ClockRange.LOOP_STOP,
+                clockStep : Cesium.ClockStep.SYSTEM_CLOCK_MULTIPLIER,
+                multiplier : 1000,
+                shouldAnimate : true
+            });
+            
+            var viewer = new Cesium.Viewer('cesiumContainer', {
+                clockViewModel : new Cesium.ClockViewModel(clock),
+            });
+            
+        Pass the following Clock options to CesiumMapView:
+        
+        ::
+        
+            # Tethys CesiumMapView example
+            
+            cesium_map_view = CesiumMapView(
+                clock = {'clock': {'Cesium.Clock': {
+                    'startTime': {'Cesium.JulianDate.fromIso8601': ['2017-07-11T00:00:00Z']},
+                    'stopTime': {'Cesium.JulianDate.fromIso8601': ['2017-07-11T24:00:00Z']},
+                    'currentTime': {'Cesium.JulianDate.fromIso8601': ['2017-07-11T10:00:00Z']},
+                    'clockRange': 'Cesium.ClockRange.LOOP_STOP',
+                    'clockStep': 'Cesium.ClockStep.SYSTEM_CLOCK_MULTIPLIER',
+                    'multiplier': 1000,
+                    'shouldAnimate': True
+                }}}
+            )
 
         **Drawing**
 
@@ -251,16 +317,18 @@ class CesiumMapView(TethysGizmoOptions):
     # Set Cesium Default Release Version.
     cesium_version = ""
 
-    def __init__(self, options={}, view={}, layers=[], entities=[], terrain={}, models=[],
+    def __init__(self, options={}, globe={}, view={}, layers={}, entities={}, terrain={}, models={}, clock={},
                  height='100%', width='100%', draw=False, attributes={}, classes=''):
         """
         Constructor
         """
         # Initialize super class
-        super().__init__(attributes=attributes, classes=classes)
+        super(CesiumMapView, self).__init__(attributes=attributes, classes=classes)
         self.height = height
         self.width = width
         self.options = options
+        self.globe = globe
+        self.clock = clock
         self.view = view
         self.layers = layers
         self.entities = entities

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/cesium_map_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/cesium_map_view.html
@@ -1,20 +1,26 @@
 {% load staticfiles tethys_gizmos %}
 
 
-<div id="cesium_map_view_outer_container">
+<div id="cesium_map_view_outer_container" style="height: 100%;">
     <div id="cesium_map_wrapper" style="height: {{ height|default:'100%' }}; width:{{ width|default:'100%'}};">
         <div id="cesium_map_view" style="width: 100%; height:100%; position: relative;"
-            {% if options %}data-options="{{ options|jsonify }}"{% endif %}
-            {% if view %}data-view="{{ view|jsonify }}"{% endif %}
-            {% if layers %}data-layer="{{ layers|jsonify }}"{% endif %}
-            {% if models %}data-models="{{ models|jsonify }}"{% endif %}
-            {% if entities %}data-entities="{{ entities|jsonify }}"{% endif %}
-            {% if terrain %}data-terrain="{{ terrain|jsonify }}"{% endif %}
-            {% if toolbar %}data-toolbar="{{ toolbar|jsonify }}"{% endif %}
-            {% if draw %}data-draw="{{ draw|jsonify }}"{% endif %}>
+            {% if classes %}class="{{ classes }}"{% endif %}
+            {% if attributes %}
+                {% for key, value in attributes.items %}
+                    {{ key }}="{{ value }}"
+                {% endfor %}
+            {% endif %}
+            data-options="{{ options|jsonify }}"
+            data-globe="{{ globe|jsonify }}"
+            data-view="{{ view|jsonify }}"
+            data-layer="{{ layers|jsonify }}"
+            data-models="{{ models|jsonify }}"
+            data-entities="{{ entities|jsonify }}"
+            data-terrain="{{ terrain|jsonify }}"
+            data-clock="{{ clock|jsonify }}"
+            data-draw="{{ draw|jsonify }}">
             <div id="cesium_map_view_toolbar"></div>
             <div id="cesium_map_view_logging" style="display:none"></div>
-            <!--<div id="cesium_drawing_status" value="{{ draw|jsonify }}"></div>-->
         </div>
         <textarea id="cesium_map_view_geometry" name="geometry" rows="4" cols="180" hidden></textarea>
     </div>

--- a/tethys_gizmos/views/gizmo_showcase.py
+++ b/tethys_gizmos/views/gizmo_showcase.py
@@ -1202,14 +1202,11 @@ def cesium_map_view(request, type):
 
     # 1. Basic Map
     height = '600px'
-    if (type == 'home'):
-        cesium_map_view = CesiumMapView(
-            height=height,
-            options={'timeline': True, 'homeButton': True}
-        )
+    if type == 'home':
+        cesium_map_view = CesiumMapView(height=height)
 
     # 2. Map Layers
-    if (type == 'map_layers'):
+    if type == 'map_layers':
         cesium_map_view = CesiumMapView(
             height=height,
             draw=True,
@@ -1224,7 +1221,7 @@ def cesium_map_view(request, type):
         )
 
     # 3. Terrain
-    if (type == 'terrain'):
+    if type == 'terrain':
         cesium_map_view = CesiumMapView(
             height=height,
             draw=True,
@@ -1245,7 +1242,7 @@ def cesium_map_view(request, type):
         )
 
     # 4. czml Object
-    if (type == 'czml'):
+    if type == 'czml':
         cesium_map_view = CesiumMapView(
             height=height,
             options={'shouldAnimate': True,
@@ -1262,7 +1259,7 @@ def cesium_map_view(request, type):
                     'Cesium.BingMapsImageryProvider': {
                         'url': 'https://dev.virtualearth.net',
                         'key': 'AnYTMwSuR3-CBMzhN0yAYrtl-28rEFe7Kxfg2IWC9csUBCn0nYDFXW1ioNakjX3W',
-                        'mapStyle': 'Aerial',
+                        'mapStyle': 'Cesium.BingMapsStyle.AERIAL',
                     },
                 }
             }},
@@ -1357,7 +1354,7 @@ def cesium_map_view(request, type):
         )
 
     # 5. Model.
-    if (type == 'model'):
+    if type == 'model':
         object1 = '/static/tethys_gizmos/cesium_models/CesiumAir/Cesium_Air.glb'
         cesium_map_view = CesiumMapView(
             height=height,
@@ -1391,9 +1388,18 @@ def cesium_map_view(request, type):
                     'position': {'Cesium.Cartesian3.fromDegrees': [-123.0744619, 44.0503706, 5000]},
                 },
             },
+            clock={'clock': {'Cesium.Clock': {
+                'startTime': {'Cesium.JulianDate.fromIso8601': ['2017-07-11T00:00:00Z']},
+                'stopTime': {'Cesium.JulianDate.fromIso8601': ['2017-07-11T24:00:00Z']},
+                'currentTime': {'Cesium.JulianDate.fromIso8601': ['2017-07-11T10:00:00Z']},
+                'clockRange': 'Cesium.ClockRange.LOOP_STOP',
+                'clockStep': 'Cesium.ClockStep.SYSTEM_CLOCK_MULTIPLIER',
+                'multiplier': 1000,
+                'shouldAnimate': True
+            }}}
         )
 
-    if (type == 'model2'):
+    if type == 'model2':
         object1 = '/static/tethys_gizmos/cesium_models/CesiumAir/Cesium_Air.glb'
         object2 = '/static/tethys_gizmos/cesium_models/CesiumBalloon/CesiumBalloon.glb'
         cesium_map_view = CesiumMapView(


### PR DESCRIPTION
Adds support on the Python end for:

- Globe options
- Clock options
- Use of Cesium constants

Also, fixes an issue with images in documentation that was introduced w/ PR #407 