### PR TITLE
add .idea/ to gitignore scaffold template

### DIFF
--- a/tethys_apps/cli/scaffold_templates/app_templates/default/.gitignore
+++ b/tethys_apps/cli/scaffold_templates/app_templates/default/.gitignore
@@ -7,3 +7,4 @@
 *.db
 *.sqlite
 *.DS_Store
+.idea/


### PR DESCRIPTION
Stops tracking the .idea folder created in the git repo of a new app by adding it to the .gitignore scaffold template