### PR TITLE
Fix for Issue 431 and Tweaks to Gen Command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,9 @@ ADD --chown=www:www static ${TETHYS_HOME}/src/static/
 RUN /bin/bash -c '. ${CONDA_HOME}/bin/activate ${CONDA_ENV_NAME} \
   ; tethys gen settings --production --allowed-host "${ALLOWED_HOSTS}" --db-username ${TETHYS_DB_USERNAME} --db-password ${TETHYS_DB_PASSWORD} --db-port ${TETHYS_DB_PORT} --overwrite \
   ; sed -i -e "s:#TETHYS_WORKSPACES_ROOT = .*$:TETHYS_WORKSPACES_ROOT = \"/usr/lib/tethys/workspaces\":" ${TETHYS_HOME}/src/tethys_portal/settings.py \
-  ; tethys gen nginx --overwrite \
-  ; tethys gen nginx_service --overwrite \
-  ; tethys gen asgi_service --overwrite \
+  ; tethys gen nginx --tethys-port ${TETHYS_PORT} --overwrite \
+  ; tethys gen nginx_service --tethys-port ${TETHYS_PORT} --overwrite \
+  ; tethys gen asgi_service --tethys-port ${TETHYS_PORT} --overwrite \
   ; tethys manage collectstatic'
 
 ############

--- a/tests/unit_tests/test_tethys_apps/test_cli/test_gen_commands.py
+++ b/tests/unit_tests/test_tethys_apps/test_cli/test_gen_commands.py
@@ -92,7 +92,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_os_path_exists.return_value = True
         mock_linux_distribution.return_value = ['redhat']
         # First open is for the Template, next two are for /etc/nginx/nginx.conf and /etc/passwd, and the final
@@ -108,7 +108,6 @@ class CLIGenCommandsTest(unittest.TestCase):
 
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
         mock_os_path_exists.assert_called_once_with('/etc/nginx/nginx.conf')
@@ -128,7 +127,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_os_path_exists.return_value = True
         mock_linux_distribution.return_value = 'ubuntu'
         # First open is for the Template, next two are for /etc/nginx/nginx.conf and /etc/passwd, and the final
@@ -144,7 +143,6 @@ class CLIGenCommandsTest(unittest.TestCase):
 
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
         mock_os_path_exists.assert_called_once_with('/etc/nginx/nginx.conf')
@@ -164,7 +162,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_os_path_exists.return_value = True
         mock_linux_distribution.side_effect = Exception
         # First open is for the Template, next two are for /etc/nginx/nginx.conf and /etc/passwd, and the final
@@ -180,7 +178,6 @@ class CLIGenCommandsTest(unittest.TestCase):
 
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
         mock_os_path_exists.assert_called_once_with('/etc/nginx/nginx.conf')
@@ -195,13 +192,12 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
 
         generate_command(args=mock_args)
 
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
 
@@ -215,14 +211,13 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_distribution.return_value = ('redhat', 'linux', '')
 
         generate_command(args=mock_args)
 
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
 
@@ -236,7 +231,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = '/foo/temp'
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_os_path_isdir.return_value = True
 
         generate_command(args=mock_args)
@@ -259,7 +254,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = '/foo/temp'
         mock_os_path_isfile.return_value = False
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_os_path_isdir.return_value = False
         # NOTE: to prevent our tests from exiting prematurely, we change the behavior of exit to raise an exception
         # to break the code execution, which we catch below.
@@ -276,7 +271,6 @@ class CLIGenCommandsTest(unittest.TestCase):
         self.assertIn('ERROR: ', rts_call_args[0][0][0])
         self.assertIn('is not a valid directory', rts_call_args[0][0][0])
 
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
 
@@ -293,7 +287,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.directory = None
         mock_args.overwrite = False
         mock_os_path_isfile.return_value = True
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
         mock_input.side_effect = ['foo', 'no']
         # NOTE: to prevent our tests from exiting prematurely, we change the behavior of exit to raise an exception
         # to break the code execution, which we catch below.
@@ -309,7 +303,6 @@ class CLIGenCommandsTest(unittest.TestCase):
         self.assertIn('Generation of', rts_call_args[0][0][0])
         self.assertIn('cancelled', rts_call_args[0][0][0])
 
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
 
@@ -322,13 +315,12 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_args.directory = None
         mock_args.overwrite = True
         mock_os_path_isfile.return_value = True
-        mock_env.side_effect = [8000, '/foo/conda', 'conda_env']
+        mock_env.side_effect = ['/foo/conda', 'conda_env']
 
         generate_command(args=mock_args)
 
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
-        mock_env.assert_any_call('TETHYS_PORT')
         mock_env.assert_any_call('CONDA_HOME')
         mock_env.assert_called_with('CONDA_ENV_NAME')
 

--- a/tests/unit_tests/test_tethys_apps/test_cli/test_manage_commands.py
+++ b/tests/unit_tests/test_tethys_apps/test_cli/test_manage_commands.py
@@ -82,15 +82,10 @@ class TestManageCommands(unittest.TestCase):
         # get the call arguments for the run process mock method
         process_call_args = mock_run_process.call_args_list
 
-        # intermediate process
+        # primary process
         self.assertEquals('python', process_call_args[0][0][0][0])
         self.assertIn('manage.py', process_call_args[0][0][0][1])
-        self.assertEquals('makemigrations', process_call_args[0][0][0][2])
-
-        # primary process
-        self.assertEquals('python', process_call_args[1][0][0][0])
-        self.assertIn('manage.py', process_call_args[1][0][0][1])
-        self.assertEquals('migrate', process_call_args[1][0][0][2])
+        self.assertEquals('migrate', process_call_args[0][0][0][2])
 
     @mock.patch('tethys_apps.cli.manage_commands.run_process')
     def test_manage_command_manage_manage_collectstatic(self, mock_run_process):

--- a/tethys_apps/cli/__init__.py
+++ b/tethys_apps/cli/__init__.py
@@ -79,11 +79,14 @@ def tethys_command():
                             help='Generate a new settings file for a production server.')
     gen_parser.add_argument('--open-portal', dest='open_portal',
                             help='Allow Open Portal Mode.')
+    gen_parser.add_argument('--tethys-port', dest='tethys_port',
+                            help='Port for the Tethys Server to run on in production. This is used when generating the '
+                                 'Daphne and nginx configuration files. Defaults to 8000.')
     gen_parser.add_argument('--overwrite', dest='overwrite', action='store_true',
                             help='Overwrite existing file without prompting.')
     gen_parser.set_defaults(func=generate_command, allowed_host=None, allowed_hosts=None, client_max_body_size='75M',
                             asgi_processes=4, db_username='tethys_default', db_password='pass', db_port=5436,
-                            production=False, open_portal=False, overwrite=False)
+                            production=False, open_portal=False, tethys_port=8000, overwrite=False)
 
     # Setup start server command
     manage_parser = subparsers.add_parser('manage', help='Management commands for Tethys Platform.')

--- a/tethys_apps/cli/gen_commands.py
+++ b/tethys_apps/cli/gen_commands.py
@@ -125,12 +125,11 @@ def generate_command(args):
 
     if args.type == GEN_NGINX_OPTION:
         hostname = str(settings.ALLOWED_HOSTS[0]) if len(settings.ALLOWED_HOSTS) > 0 else '127.0.0.1'
-        port = get_environment_value('TETHYS_PORT')
         workspaces_root = get_settings_value('TETHYS_WORKSPACES_ROOT')
         static_root = get_settings_value('STATIC_ROOT')
 
         context.update({'hostname': hostname,
-                        'port': port,
+                        'port': args.tethys_port,
                         'workspaces_root': workspaces_root,
                         'static_root': static_root,
                         'client_max_body_size': args.client_max_body_size
@@ -138,7 +137,6 @@ def generate_command(args):
 
     if args.type == GEN_ASGI_SERVICE_OPTION:
         hostname = str(settings.ALLOWED_HOSTS[0]) if len(settings.ALLOWED_HOSTS) > 0 else '127.0.0.1'
-        port = get_environment_value('TETHYS_PORT')
         conda_home = get_environment_value('CONDA_HOME')
         conda_env_name = get_environment_value('CONDA_ENV_NAME')
 
@@ -153,7 +151,7 @@ def generate_command(args):
 
         context.update({'nginx_user': nginx_user,
                         'hostname': hostname,
-                        'port': port,
+                        'port': args.tethys_port,
                         'asgi_processes': args.asgi_processes,
                         'conda_home': conda_home,
                         'conda_env_name': conda_env_name,

--- a/tethys_apps/cli/manage_commands.py
+++ b/tethys_apps/cli/manage_commands.py
@@ -61,9 +61,6 @@ def manage_command(args):
         else:
             primary_process = ['python', manage_path, 'runserver']
     elif args.command == MANAGE_SYNCDB:
-        intermediate_process = ['python', manage_path, 'makemigrations']
-        run_process(intermediate_process)
-
         primary_process = ['python', manage_path, 'migrate']
 
     elif args.command == MANAGE_COLLECTSTATIC:

--- a/tethys_compute/migrations/0003_auto_20190506_1714.py
+++ b/tethys_compute/migrations/0003_auto_20190506_1714.py
@@ -5,6 +5,80 @@ import django.contrib.postgres.fields.jsonb
 from django.db import migrations, models
 
 
+DATA = {}
+
+
+def data_export(apps, schema_editor):
+    CondorPyJob = apps.get_model('tethys_compute', 'CondorPyJob')
+    CondorPyWorkflow = apps.get_model('tethys_compute', 'CondorPyWorkflow')
+    CondorWorkflowNode = apps.get_model('tethys_compute', 'CondorWorkflowNode')
+    TethysJob = apps.get_model('tethys_compute', 'TethysJob')
+
+    condorpyjob_dict = dict()
+
+    for o in CondorPyJob.objects.raw('SELECT * FROM tethys_compute_condorpyjob'):
+        condorpyjob_dict[o.condorpyjob_id] = {
+            '_attributes': o._attributes,
+            '_remote_input_files': o._remote_input_files
+        }
+
+    DATA[CondorPyJob.__name__] = condorpyjob_dict
+
+    condorpyworkflow_dict = dict()
+
+    for o in CondorPyWorkflow.objects.raw('SELECT * FROM tethys_compute_condorpyworkflow'):
+        condorpyworkflow_dict[o.condorpyworkflow_id] = {
+            '_max_jobs': o._max_jobs
+        }
+
+    DATA[CondorPyWorkflow.__name__] = condorpyworkflow_dict
+
+    condorworkflownode_dict = dict()
+
+    for o in CondorWorkflowNode.objects.raw('SELECT * FROM tethys_compute_condorworkflownode'):
+        condorworkflownode_dict[o.id] = {
+            'variables': o.variables
+        }
+
+    DATA[CondorWorkflowNode.__name__] = condorworkflownode_dict
+
+    tethysjob_dict = dict()
+
+    for o in TethysJob.objects.raw('SELECT * FROM tethys_compute_tethysjob'):
+        tethysjob_dict[o.id] = {
+            'extended_properties': o.extended_properties
+        }
+
+    DATA[TethysJob.__name__] = tethysjob_dict
+
+
+def data_import(apps, schema_editor):
+    CondorPyJob = apps.get_model('tethys_compute', 'CondorPyJob')
+    CondorPyWorkflow = apps.get_model('tethys_compute', 'CondorPyWorkflow')
+    CondorWorkflowNode = apps.get_model('tethys_compute', 'CondorWorkflowNode')
+    TethysJob = apps.get_model('tethys_compute', 'TethysJob')
+
+    MODEL_NAME_MAP = {
+        CondorPyJob.__name__: (CondorPyJob, 'condorpyjob_id'),
+        CondorPyWorkflow.__name__: (CondorPyWorkflow, 'condorpyworkflow_id'),
+        CondorWorkflowNode.__name__: (CondorWorkflowNode, 'id'),
+        TethysJob.__name__: (TethysJob, 'id')
+    }
+
+    for model_name in DATA.keys():
+        records = DATA[model_name]
+        ModelClass, id_name = MODEL_NAME_MAP[model_name]
+
+        for id in records.keys():
+            record = records[id]
+            o = ModelClass.objects.get(**{id_name: id})
+
+            for attr, value in record.items():
+                setattr(o, attr, value)
+
+            o.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,29 +86,53 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
+        migrations.RunPython(data_export),
+        # Remove fields to clear data
+        migrations.RemoveField(
+            model_name='condorpyjob',
+            name='_attributes',
+        ),
+        migrations.RemoveField(
+            model_name='condorpyjob',
+            name='_remote_input_files',
+        ),
+        migrations.RemoveField(
+            model_name='condorpyworkflow',
+            name='_max_jobs',
+        ),
+        migrations.RemoveField(
+            model_name='condorworkflownode',
+            name='variables',
+        ),
+        migrations.RemoveField(
+            model_name='tethysjob',
+            name='extended_properties',
+        ),
+        # Add new versions of the fields
+        migrations.AddField(
             model_name='condorpyjob',
             name='_attributes',
             field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, null=True),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='condorpyjob',
             name='_remote_input_files',
             field=django.contrib.postgres.fields.ArrayField(base_field=models.CharField(blank=True, max_length=1024, null=True), default=list, size=None),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='condorpyworkflow',
             name='_max_jobs',
             field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, null=True),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='condorworkflownode',
             name='variables',
             field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, null=True),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='tethysjob',
             name='extended_properties',
             field=django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict, null=True),
         ),
+        migrations.RunPython(data_import),
     ]


### PR DESCRIPTION
* Handles data migration for migration added in #423.
* Removes makemigrations from syncdb command
* Adds tethys_port to optional argument for gen command, instead of getting it from environment.