### PR TITLE
allow user workspace to be assigned to an ID string

### DIFF
--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -773,10 +773,12 @@ class TethysAppBase(TethysBase):
             username = user.username
         elif isinstance(user, HttpRequest):
             username = user.user.username
+        elif isinstance(user, str):
+            username = user
         elif user is None:
             pass
         else:
-            raise ValueError("Invalid type for argument 'user': must be either an User or HttpRequest object.")
+            raise ValueError("Invalid type for argument 'user': must be a User or HttpRequest object, or an ID string.")
 
         if not username:
             username = 'anonymous_user'


### PR DESCRIPTION
This allows you to create a user workspace for any random string in place of a User or HTTP object. This is inspired by the BYU use-case where we want to let many people use a demo tethys account in training scenarios and they could all presumably be uploading shapefiles at the same time. Similarly, for open portals when you've disabled/removed the @login_required decorators there still needs to be a way to track which workspace path to use.

the way i'm using this now is to generate a random 10 digit string of numbers and lowercase letters in the python context dictionary as the instance_id. Then in base.html under scripts i've included instance_id = instance_id and added it to the cookie with Cookies.set("instance_id", instance_id). then any time you need to read/write/access the instance_id you can get in python scripts by accessing the cookie from the request object ==> request.META['HTTP_COOKIE'] which is a string of all the cookies and you can parse out the id, or you could pass 'instance_id' in ajax requests. (which you can do for backwards compatibility on tethys portals where this hasn't been installed)