### PR TITLE
Add normal user to `db configure` command in salt

### DIFF
--- a/docker/salt/tethyscore.sls
+++ b/docker/salt/tethyscore.sls
@@ -147,6 +147,8 @@ Prepare_Database_TethysCore:
     - name: >
         . {{ CONDA_HOME }}/bin/activate {{ CONDA_ENV_NAME }} &&
         PGPASSWORD="{{ POSTGRES_PASSWORD }}" {{ TETHYS_BIN_DIR }}/tethys db configure
+        -n {{ TETHYS_DB_USERNAME }}
+        -p {{ TETHYS_DB_PASSWORD }}
         -N {{ TETHYS_DB_SUPERUSER }}
         -P {{ TETHYS_DB_SUPERUSER_PASS }}
         {%- if PORTAL_SUPERUSER_NAME and PORTAL_SUPERUSER_PASSWORD %}


### PR DESCRIPTION
tethyscore.sls includes a call to `tethys db configure`, but does not pass in the default username/pass from the environment, meaning that the hardcoded defaults are used instead. This means that changing the default username/password elsewhere will cause the setup to fail.