### PR TITLE
Fixes for cesium map views

### DIFF
--- a/docs/tethys_sdk/gizmos/map_view.rst
+++ b/docs/tethys_sdk/gizmos/map_view.rst
@@ -6,6 +6,8 @@ Map View
 
 .. autoclass:: tethys_sdk.gizmos.MapView
 
+.. _gizmo_mvlayer:
+
 MVLayer
 -------
 

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_cesium_map_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_cesium_map_view.py
@@ -40,9 +40,9 @@ class TestCesiumMapView(unittest.TestCase):
         self.assertFalse(result['draw'])
 
         # Check sources
-        self.assertIn('https://cesiumjs.org/releases/1.51/Build/Cesium/Cesium.js',
+        self.assertIn('https://cesium.com/downloads/cesiumjs/releases/1.51/Build/Cesium/Cesium.js',
                       gizmo_map_view.CesiumMapView.get_vendor_js()[0])
-        self.assertIn('https://cesiumjs.org/releases/1.51/Build/Cesium/Widgets/widgets.css',
+        self.assertIn('https://cesium.com/downloads/cesiumjs/releases/1.51/Build/Cesium/Widgets/widgets.css',
                       gizmo_map_view.CesiumMapView.get_vendor_css()[0])
         self.assertIn('.js', gizmo_map_view.CesiumMapView.get_gizmo_js()[0])
         self.assertIn('.css', gizmo_map_view.CesiumMapView.get_vendor_css()[0])
@@ -73,10 +73,18 @@ class TestCesiumMapView(unittest.TestCase):
         self.assertTrue(result['draw'])
 
         # Check sources
-        self.assertIn('https://cesiumjs.org/Cesium/Build/Cesium/Cesium.js',
+        self.assertIn('https://cesium.com/downloads/cesiumjs/releases//Build/Cesium/Cesium.js',
                       gizmo_map_view.CesiumMapView.get_vendor_js()[0])
-        self.assertIn('https://cesiumjs.org/Cesium/Build/Cesium/Widgets/widgets.css',
+        self.assertIn('https://cesium.com/downloads/cesiumjs/releases//Build/Cesium/Widgets/widgets.css',
                       gizmo_map_view.CesiumMapView.get_vendor_css()[0])
         self.assertIn('.js', gizmo_map_view.CesiumMapView.get_gizmo_js()[0])
         self.assertIn('.css', gizmo_map_view.CesiumMapView.get_vendor_css()[0])
         self.assertIn('.css', gizmo_map_view.CesiumMapView.get_gizmo_css()[0])
+
+    def test_CMVEntity(self):
+        ent = gizmo_map_view.CMVEntity(
+            source='my_source',
+            document='my_document',
+            legend_title='Legend Title',
+        )
+        self.assertEqual(ent.source, 'my_source')

--- a/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmo_showcase.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmo_showcase.py
@@ -151,6 +151,25 @@ class TestGizmoShowcase(unittest.TestCase):
         self.assertIn('map_layers', render_call_args[0][0][2]['page_type'])
 
     @mock.patch('tethys_gizmos.views.gizmo_showcase.render')
+    def test_cesium_map_view_map_token(self, mock_render):
+        request = self.request_factory.get('/jobs', data={'cesium-ion-token': 'cesium-token-goes-here'})
+        request.user = self.user
+
+        # Execute
+        gizmo_showcase.cesium_map_view(request, 'map_layers')
+
+        # Check render
+        render_call_args = mock_render.call_args_list
+
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['home_link'])
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['map_layers_link'])
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['terrain_link'])
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['czml_link'])
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['geojson_link'])
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['model_link'])
+        self.assertIn('cesium-token-goes-here', render_call_args[0][0][2]['model2_link'])
+
+    @mock.patch('tethys_gizmos.views.gizmo_showcase.render')
     def test_cesium_map_view_terrain(self, mock_render):
         request = self.request_factory.get('/jobs')
         request.user = self.user
@@ -173,6 +192,18 @@ class TestGizmoShowcase(unittest.TestCase):
         # Check render
         render_call_args = mock_render.call_args_list
         self.assertIn('czml', render_call_args[0][0][2]['page_type'])
+
+    @mock.patch('tethys_gizmos.views.gizmo_showcase.render')
+    def test_cesium_map_view_geojson(self, mock_render):
+        request = self.request_factory.get('/jobs')
+        request.user = self.user
+
+        # Execute
+        gizmo_showcase.cesium_map_view(request, 'geojson')
+
+        # Check render
+        render_call_args = mock_render.call_args_list
+        self.assertIn('geojson', render_call_args[0][0][2]['page_type'])
 
     @mock.patch('tethys_gizmos.views.gizmo_showcase.render')
     def test_cesium_map_view_model(self, mock_render):

--- a/tethys_gizmos/gizmo_options/cesium_map_view.py
+++ b/tethys_gizmos/gizmo_options/cesium_map_view.py
@@ -1,4 +1,4 @@
-from .base import TethysGizmoOptions
+from .base import TethysGizmoOptions, SecondaryGizmoOptions
 import logging
 log = logging.getLogger('tethys.tethys_gizmos.gizmo_options.cesium_map_view')
 
@@ -10,21 +10,20 @@ class CesiumMapView(TethysGizmoOptions):
         Shapes that are drawn on the map by users can be retrieved from the map via a hidden text field named 'geometry' and it is updated every time the map is changed. If the Cesium Map View is embedded in a form, the geometry that is drawn on the map will automatically be submitted with the rest of the form via the hidden text field.
 
         Attributes:
-            height(str): Height of the map element. Any valid css unit of length (e.g.: '500px'). Defaults to '100%'.
-            width(str): Width of the map element. Any valid css unit of length (e.g.: '100%'). Defaults to '100%'.
+            cesium_ion_token(str): Cesium Ion Access Token. See: `Cesium Rest API - Authentication <https://cesium.com/docs/tutorials/rest-api/#authentication>`_.
             options(dict): Viewer basic options. One item in dictionary per option.
             globe(dict): Options to set on the Globe of the view.
             view(dict): Set the initial view of the map using various methods(e.g.: flyTo, setView)
-            layers(dict): Add imagery layer to map. One item in dictionary per imagery layer.
-            entities(dict):: Add entities to map. One item in dictionary per entity
+            layers(list): Add one or more imagery layers to the map.
+            entities(list):: Add one or more entities to the map.
             terrain(dict): Add terrain provider to the map.
             models(dict): Add 3D model to map. One item in dictionary per model.
             clock(dict): Define custom clock options for viewer.
+            height(str): Height of the map element. Any valid css unit of length (e.g.: '500px'). Defaults to '100%'.
+            width(str): Width of the map element. Any valid css unit of length (e.g.: '100%'). Defaults to '100%'.
             draw(boolean): Turn drawing tools on/off.
             attributes(dict): A dictionary representing additional HTML attributes to add to the primary element (e.g. {"onclick": "run_me();"}).
             classes(str): Additional classes to add to the primary HTML element (e.g. "example-class another-class").
-
-
 
         **Cesium Version**
 
@@ -32,7 +31,7 @@ class CesiumMapView(TethysGizmoOptions):
 
         ::
 
-            CesiumMapView.cesium_version = "1.51"
+            CesiumMapView.cesium_version = "1.63.1"
             my_cesium_view = CesiumMapView(...)
 
         Or you can choose to use the latest release by setting the version to the empty string:
@@ -41,6 +40,14 @@ class CesiumMapView(TethysGizmoOptions):
 
             CesiumMapView.cesium_version = ""
             my_cesium_view = CesiumMapView(...)
+
+        **Cesium Ion Token**
+
+        This is your Cesium Ion Access token that grants you access to the Cesium REST APIs. In newer version of Cesium this token is required for proper functioning of the map viewer. To learn how to obtain a token, see `Cesium REST API - Authentication <https://cesium.com/docs/tutorials/rest-api/#authentication>`_.
+
+        ::
+
+            cesium_access_token='mYf8k3t0KEn--asdfsdf98as7uj34n5a8-yvzhnj23q098-zdvnkj'
 
         **Options**
 
@@ -59,7 +66,7 @@ class CesiumMapView(TethysGizmoOptions):
             viewer.scene.globe.enableLighting = true;
             viewer.scene.globe.depthTestAgainstTerrain = true;
 
-        Pass the following Globe options to CesiumMapView:
+        Pass the following Globe options to ``CesiumMapView``:
 
         ::
 
@@ -73,7 +80,7 @@ class CesiumMapView(TethysGizmoOptions):
 
         **View**
 
-        Here is how the view option is defined using the Cesium JavaScript API (https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html?src=Camera.html):
+        Here is how the view option is defined using the Cesium JavaScript API (`Sandcastle - Camera <https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html?src=Camera.html>`_):
 
         ::
 
@@ -86,7 +93,7 @@ class CesiumMapView(TethysGizmoOptions):
                 }
             });
 
-        In Tethys CesiumMapView, you can define this setting using python as follows
+        In Tethys ``CesiumMapView``, you can define this setting using python as follows
 
         ::
 
@@ -101,12 +108,20 @@ class CesiumMapView(TethysGizmoOptions):
 
         **Layers**
 
-        CesiumMapView supports all the imagery layers in cesiumjs: https://cesiumjs.org/tutorials/Imagery-Layers-Tutorial/#imagery-providers
-        You can load a imagery layers using the following pattern:
+        ``CesiumMapView`` supports all the imagery layers in the CesiumJS API (see `Imagery Providers <https://cesiumjs.org/tutorials/Imagery-Layers-Tutorial/#imagery-providers>`_). It also support ``ImageWMS`` and ``TileWMS`` ``MVLayers`` (see: :ref:`gizmo_mvlayer`).
+        You can load one or more imagery layers using the following pattern:
 
         ::
 
-            layers={'Type of Imagery Layers (for your reference only)': {'imageryProvider': 'method/class to load the provider'}
+            layers=[
+                {<layer_name>: {
+                    'imageryProvider': {<imagery_provider_class>: {
+                        <option1>: <value1>,
+                        <option2>: <value2>
+                    }
+                },
+                <MVLayer Object>
+            ]
 
         Examples:
 
@@ -114,89 +129,221 @@ class CesiumMapView(TethysGizmoOptions):
 
         ::
 
-            layers={'BingMap': {
-                'imageryProvider': {'Cesium.BingMapsImageryProvider': {
-                    'url': 'https://dev.virtualearth.net',
-                    'key': 'YouR-api-KEy',
-                    'mapStyle': 'Aerial',
+            layers=[
+                {'Bing Map': {
+                    'imageryProvider': {'Cesium.BingMapsImageryProvider': {
+                        'url': 'https://dev.virtualearth.net',
+                        'key': 'YouR-api-KEy',
+                        'mapStyle': 'Aerial',
+                    }}
                 }}
-            }}
+            ]
 
         * ESRI:
 
         ::
 
-            layers={'EsriArcGISMapServer': {
-                'imageryProvider': {'Cesium.ArcGisMapServerImageryProvider': [{
-                    'url': 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
-                }]}
-            }}
+            layers=[
+                {'Esri Arc GIS Map Server': {
+                    'imageryProvider': {'Cesium.ArcGisMapServerImageryProvider': [{
+                        'url': 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+                    }]}
+                }}
+            ]
 
         * OpenStreetMap:
 
         ::
 
-            layers={'OpenStreetMap': {
-                'imageryProvider': {'Cesium.createOpenStreetMapImageryProvider':[]}
-            }}
+            layers=[
+                {'Open Street Map': {
+                    'imageryProvider': {'Cesium.OpenStreetMapImageryProvider': {
+                        'url': 'https://a.tile.openstreetmap.org/'
+                    }}
+                }}
+            ]
 
-        * MapQuest OpenStreetMap:
+        * WMS Imagery Service:
 
         ::
 
-            layers={'MapQuestOpenStreetMap': {
-                'imageryProvider': {Cesium.createOpenStreetMapImageryProvider: [{
-                    'url' : 'https://otile1-s.mqcdn.com/tiles/1.0.0/osm/'
-                }]}
-            }}
+            layers=[
+                {'WMS Imagery Provider': {
+                    'imageryProvider': {'Cesium.WebMapServiceImageryProvider': [{
+                        'url': 'https://sampleserver1.arcgisonline.com/ArcGIS/services/Specialty/ESRI_StatesCitiesRivers_USA/MapServer/WMSServer',
+                        'layers': '0',
+                        'proxy': {'Cesium.DefaultProxy': ['/proxy/']}
+                    }]}
+                }}
+            ]
 
-        * More examples can be found at https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html
+        * Mix with MVLayer Objects
+
+        ::
+
+            layers=[
+                {'Open Street Map': {
+                    'imageryProvider': {'Cesium.OpenStreetMapImageryProvider': {
+                        'url': 'https://a.tile.openstreetmap.org/'
+                    }}
+                }},
+                MVLayer(
+                    source='ImageWMS',
+                    legend_title='MVLayer ImageWMS',
+                    options={
+                        'url': 'https://demo.geo-solutions.it/geoserver/wms',
+                        'params': {'LAYERS': 'topp:states'},
+                        'serverType': 'geoserver'
+                    },
+                )
+            ]
+
+        * More examples can be found at `Sandcastle - Imagery Layers Manipulation <https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html>`_
 
         **Entities**
 
-        Support most entities in Cesium: https://cesiumjs.org/tutorials/Visualizing-Spatial-Data/#shapes-and-volumes
+        Supports CZML and GeoJSON entities. Also supports ``GeoJSON`` ``MVLayers`` (see: :ref:`gizmo_mvlayer`).
 
-        Example loading a czml:
+        * CZML Example:
 
         ::
 
-            entities={'czml': [
+            entities=[
                 {
-                    "id": "document",
-                    "name": "CZML Geometries: Polygon",
-                    "version": "1.0"
-                },
-                {
-                    "id": "redPolygon",
-                    "name": "Red polygon on surface",
-                    "polygon": {"positions": {
-                        "cartographicDegrees": [
-                            -115.0, 37.0, 0,
-                            -115.0, 32.0, 0,
-                            -107.0, 33.0, 0,
-                            -102.0, 31.0, 0,
-                            -102.0, 35.0, 0
-                        ]
-                    },
-                    "material": {
-                        "solidColor": {
-                            "color": {
-                                "rgba": [255, 0, 0, 255]
+                    'source': 'czml',
+                    'options': [
+                        {
+                            "id": "document",
+                            "name": "CZML Geometries: Polygon",
+                            "version": "1.0"
+                        },
+                        {
+                            "id": "whitePolygon",
+                            "name": "White polygon on surface",
+                            "polygon": {"positions": {
+                                "cartographicDegrees": [
+                                    -115.0, 37.0, 0,
+                                    -115.0, 32.0, 0,
+                                    -107.0, 33.0, 0,
+                                    -102.0, 31.0, 0,
+                                    -102.0, 35.0, 0
+                                ]
+                            }},
+                            "material": {
+                                "solidColor": {
+                                    "color": {
+                                        "rgba": [255, 0, 0, 255]
+                                    }
+                                }
                             }
                         }
+                    ]
+                }
+            ]
+
+        * GeoJSON Example:
+
+        ::
+
+            entities=[
+                {
+                    'source': 'geojson',
+                    'options': {
+                        'type': 'FeatureCollection',
+                        'crs': {
+                            'type': 'name',
+                            'properties': {
+                                'name': 'EPSG:4326'
+                            }
+                        },
+                        'features': [
+                            {
+                                'type': 'Feature',
+                                'geometry': {
+                                    'type': 'Point',
+                                    'coordinates': [0, 0]
+                                }
+                            },
+                            {
+                                'type': 'Feature',
+                                'geometry': {
+                                    'type': 'LineString',
+                                    'coordinates': [[35.9326113, -17.6789142], [71.8652227, 17.6789142]]
+                                }
+                            },
+                            {
+                                'type': 'Feature',
+                                'geometry': {
+                                    'type': 'Polygon',
+                                    'coordinates': [
+                                        [[-44.9157642, -8.9465739], [-35.9326114, 8.9465739], [-26.9494585, -8.9465739]]
+                                    ]
+                                }
+                            }
+                        ]
                     }
                 }
-            ]}
+            ]
+
+        * GeoJSON MVLayer
+
+        ::
+
+            entities=[
+                MVLayer(
+                    source='GeoJSON',
+                    legend_title='MVLayer GeoJSON Example',
+                    options={
+                        'type': 'FeatureCollection',
+                        'crs': {
+                            'type': 'name',
+                            'properties': {
+                                'name': 'EPSG:4326'
+                            }
+                        },
+                        'features': [
+                            {
+                                'type': 'Feature',
+                                'geometry': {
+                                    'type': 'Point',
+                                    'coordinates': [0, 0]
+                                }
+                            },
+                            {
+                                'type': 'Feature',
+                                'geometry': {
+                                    'type': 'LineString',
+                                    'coordinates': [[35.9326113, -17.6789142], [71.8652227, 17.6789142]]
+                                }
+                            },
+                            {
+                                'type': 'Feature',
+                                'geometry': {
+                                    'type': 'Polygon',
+                                    'coordinates': [
+                                        [[-44.9157642, -8.9465739], [-35.9326114, 8.9465739], [-26.9494585, -8.9465739]]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                )
+            ]
 
         **Terrain**
 
-        Support all the terrain provider available in Cesium: https://cesiumjs.org/tutorials/Terrain-Tutorial/#terrain-providers
+        Supports all the terrain providers available in Cesium (see `Cesium Terrain Providers <https://cesiumjs.org/tutorials/Terrain-Tutorial/#terrain-providers>`_
 
         You can load a terrain provider using the following pattern:
 
         ::
 
-            terrain={'terrainProvider': 'method/class and args to load the provider'}
+            terrain={
+                'terrainProvider': {<terrain_provider_class>: {
+                    <option1>: <value1>,
+                    <option2>: <value2>
+                }
+            }
 
         For example:
 
@@ -257,7 +404,7 @@ class CesiumMapView(TethysGizmoOptions):
                 clockViewModel : new Cesium.ClockViewModel(clock),
             });
 
-        Pass the following Clock options to CesiumMapView:
+        Pass the following Clock options to ``CesiumMapView``:
 
         ::
 
@@ -293,7 +440,7 @@ class CesiumMapView(TethysGizmoOptions):
 
         **Translate Cesium Attributes from Javascript to Python**
 
-        You can find a lots of way to define cesium attributes in the sandcastle page: https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html
+        You can find a lots of way to define cesium attributes in the sandcastle page: `Sandcastle <https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html>`_
 
         Here are a few things to remember:
 
@@ -308,15 +455,14 @@ class CesiumMapView(TethysGizmoOptions):
                 {'Cesium.Cartesian3.fromDegrees': [-123.0744619, 44.0503706, 5000]},
                 {'Cesium.HeadingPitchRoll': [{'Cesium.Math.toRadians' : 135}, 0, 0]}
             ]}
-
     """  # noqa: E501
     gizmo_name = "cesium_map_view"
 
     # Set Cesium Default Release Version.
-    cesium_version = ""
+    cesium_version = "1.63.1"
 
-    def __init__(self, options={}, globe={}, view={}, layers={}, entities={}, terrain={}, models={}, clock={},
-                 height='100%', width='100%', draw=False, attributes={}, classes=''):
+    def __init__(self, options={}, globe={}, view={}, layers=[], entities=[], terrain={}, models={}, clock={},
+                 height='100%', width='100%', draw=False, attributes={}, classes='', cesium_ion_token=''):
         """
         Constructor
         """
@@ -333,6 +479,7 @@ class CesiumMapView(TethysGizmoOptions):
         self.terrain = terrain
         self.models = models
         self.draw = draw
+        self.cesium_ion_token = cesium_ion_token
 
     @classmethod
     def get_vendor_js(cls):
@@ -340,11 +487,7 @@ class CesiumMapView(TethysGizmoOptions):
         JavaScript vendor libraries to be placed in the
         {% block global_scripts %} block
         """
-        # To use build version, cesium_version is blank. Otherwise, it will use the specified release version.
-        if cls.cesium_version:
-            cesium_js = 'https://cesiumjs.org/releases/' + cls.cesium_version + '/Build/Cesium/Cesium.js'
-        else:
-            cesium_js = 'https://cesiumjs.org/Cesium/Build/Cesium/Cesium.js'
+        cesium_js = 'https://cesium.com/downloads/cesiumjs/releases/' + cls.cesium_version + '/Build/Cesium/Cesium.js'
         return (cesium_js,)
 
     @staticmethod
@@ -363,10 +506,8 @@ class CesiumMapView(TethysGizmoOptions):
         CSS vendor libraries to be placed in the
         {% block styles %} block
         """
-        if cls.cesium_version:
-            cesium_css = 'https://cesiumjs.org/releases/' + cls.cesium_version + '/Build/Cesium/Widgets/widgets.css'
-        else:
-            cesium_css = 'https://cesiumjs.org/Cesium/Build/Cesium/Widgets/widgets.css'
+        cesium_css = 'https://cesium.com/downloads/cesiumjs/releases/' + cls.cesium_version + \
+                     '/Build/Cesium/Widgets/widgets.css'
         return (cesium_css,)
 
     @staticmethod
@@ -377,3 +518,71 @@ class CesiumMapView(TethysGizmoOptions):
         """
         return ('tethys_gizmos/css/cesium_map_view.min.css',
                 'tethys_gizmos/css/DrawHelper.min.css')
+
+
+class CMVEntity(SecondaryGizmoOptions):
+    """
+    CMVEntity objects are used to define map layers for the Map View Gizmo.
+
+    Attributes:
+        options (dict, required): A dictionary representation of the OpenLayers options object for ol.source.
+        layer_options (dict): A dictionary representation of the OpenLayers options object for ol.layer.
+        editable (bool): If true the layer will be editable with the tethys_map_view drawing/editing tools.
+        data (dict): Dictionary representation of layer data
+
+    Example
+
+    ::
+
+        # Define GeoJSON layer
+        geojson_object = {
+          'type': 'FeatureCollection',
+          'crs': {
+            'type': 'name',
+            'properties': {
+              'name': 'EPSG:3857'
+            }
+          },
+          'features': [
+            {
+              'type': 'Feature',
+              'geometry': {
+                'type': 'Point',
+                'coordinates': [0, 0]
+              }
+            },
+            {
+              'type': 'Feature',
+              'geometry': {
+                'type': 'LineString',
+                'coordinates': [[4e6, -2e6], [8e6, 2e6]]
+              }
+            },
+            {
+              'type': 'Feature',
+              'geometry': {
+                'type': 'Polygon',
+                'coordinates': [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
+              }
+            }
+          ]
+        }
+
+        geojson_layer = CMVLayer(source='GeoJSON',
+                                options=geojson_object,
+                                layer_options={'style_map': style_map},
+                                )
+    """  # noqa: E501
+
+    def __init__(self, source, document, legend_title, layer_options=None, editable=False, data=None):
+        """
+        Constructor
+        """
+        super().__init__()
+
+        self.source = source
+        self.document = document
+        self.legend_title = legend_title
+        self.editable = editable
+        self.layer_options = layer_options
+        self.data = data or dict()

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -25,15 +25,15 @@ class MapView(TethysGizmoOptions):
     Attributes:
         height(str): Height of the map element. Any valid css unit of length (e.g.: '500px'). Defaults to '520px'.
         width(str): Width of the map element. Any valid css unit of length (e.g.: '100%'). Defaults to '100%'.
-        basemap(str, dict or a list of strings and/or dicts): The base maps to display: choose from OpenStreetMap, MapQuest, or a Bing map. Valid values for the string option are: 'OpenStreetMap' and 'MapQuest'. If you wish to configure the base map with options, you must use the dictionary form. The dictionary form is required to use a Bing map, because an API key must be passed as an option. See below for more detail. A basemap switcher will automatically be provided if a list of more than one basemap is included.
         view(MVView): An MVView object specifying the initial view or extent for the map.
-        controls(list): A list of controls to add to the map. The list can be a list of strings or a list of dictionaries. Valid controls are ZoomSlider, Rotate, FullScreen, ScaleLine, ZoomToExtent, and 'MousePosition'. See below for more detail.
-        layers(list): A list of MVLayer objects.
         draw(MVDraw): An MVDraw object specifying the drawing options.
-        disable_basemap(bool): Render the map without a base map.
-        feature_selection(bool): A dictionary of global feature selection options. See below.
         attributes(dict): A dictionary representing additional HTML attributes to add to the primary element (e.g. {"onclick": "run_me();"}).
         classes(str): Additional classes to add to the primary HTML element (e.g. "example-class another-class").
+        layers(list): A list of MVLayer objects.
+        basemap(str, dict or a list of strings and/or dicts): The base maps to display: choose from OpenStreetMap, MapQuest, or a Bing map. Valid values for the string option are: 'OpenStreetMap' and 'MapQuest'. If you wish to configure the base map with options, you must use the dictionary form. The dictionary form is required to use a Bing map, because an API key must be passed as an option. See below for more detail. A basemap switcher will automatically be provided if a list of more than one basemap is included.
+        controls(list): A list of controls to add to the map. The list can be a list of strings or a list of dictionaries. Valid controls are ZoomSlider, Rotate, FullScreen, ScaleLine, ZoomToExtent, and 'MousePosition'. See below for more detail.
+        disable_basemap(bool): Render the map without a base map.
+        feature_selection(bool): A dictionary of global feature selection options. See below.
 
     **Options Dictionaries**
 

--- a/tethys_gizmos/templates/tethys_gizmos/gizmo_showcase/cesium_map_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmo_showcase/cesium_map_view.html
@@ -36,6 +36,9 @@
           margin-top: 60px;
           align: left;
         }
+        .gizmo-page-wrapper {
+            margin-top: 60px;
+        }
     </style>
 {% endblock %}
 
@@ -52,6 +55,7 @@
           <li><a href="{{ map_layers_link }}">Map Layers</a></li>
           <li><a href="{{ terrain_link }}">Terrain</a></li>
           <li><a href="{{ czml_link }}">CZML</a></li>
+          <li><a href="{{ geojson_link }}">GeoJSON</a></li>
           <li><a href="{{ model_link }}">Model</a></li>
           <li><a href="{{ model2_link }}">Models</a></li>
           <li><a href="{% url 'gizmos:showcase'%}">Back</a></li>
@@ -61,6 +65,16 @@
   </nav>
 
 <div class="gizmo-page-wrapper">
+    {% if not cesium_ion_token %}
+    <form action="" method="get">
+        <div class="form-group has-warning">
+            <label for="cesium-ion-token">Please enter a valid Cesium Ion Access Token to enable Cesium demos:</label>
+            <textarea id="cesium-ion-token" name="cesium-ion-token" class="form-control"></textarea>
+            <span id="cesium-ion-token-help" class="help-block">To obtain a token, see: <a href="https://cesium.com/docs/tutorials/rest-api/#authentication" target="_blank">Cesium ion REST API: Authentication</a></span>
+        </div>
+        <button type="submit" class="btn btn-default">Submit</button>
+    </form>
+    {% endif %}
     <form action="" method="post">
         {% csrf_token %}
         <div id="cesium-title"><h2>Cesium Map View</h2></div>
@@ -75,6 +89,9 @@
         {% endif %}
         {%if page_type == 'czml' %}
             <div id="example_description">This example displays multiple <a href="https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Guide">CZML data</a> on 3D Map with CesiumJS.</div>
+        {% endif %}
+        {%if page_type == 'geojson' %}
+            <div id="example_description">This example displays GeoJSON data on a 3D Map with CesiumJS.</div>
         {% endif %}
         {%if page_type == 'model' %}
             <div id="example_description">This example displays a GLB 3D model on 3D Map with CesiumJS. </div>
@@ -97,7 +114,7 @@
             {% endfor %}
           </div>
         {% endif %}
-        <input type="submit" name="submit" style="margin-top: 20px;">
+        <input type="submit" name="submit" class="btn btn-default" style="margin-top: 20px;">
     </form>
 </div>
 {% endblock %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/cesium_map_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/cesium_map_view.html
@@ -10,6 +10,7 @@
                     {{ key }}="{{ value }}"
                 {% endfor %}
             {% endif %}
+            data-cesium-ion-token="{{ cesium_ion_token }}"
             data-options="{{ options|jsonify }}"
             data-globe="{{ globe|jsonify }}"
             data-view="{{ view|jsonify }}"

--- a/tethys_gizmos/views/gizmo_showcase.py
+++ b/tethys_gizmos/views/gizmo_showcase.py
@@ -1232,41 +1232,67 @@ def esri_map(request):
 
 @login_required()
 def cesium_map_view(request, type):
+    # Get the access token
+    cesium_ion_token = request.GET.get('cesium-ion-token', '')
+
     # Define nav link
     home_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'home'})
     map_layers_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'map_layers'})
     terrain_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'terrain'})
     czml_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'czml'})
+    geojson_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'geojson'})
     model_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'model'})
     model2_link = reverse('gizmos:cesium_map_view', kwargs={'type': 'model2'})
 
+    # Add cesium ion token GET parameters of all header links if provided
+    if cesium_ion_token:
+        home_link += f'?cesium-ion-token={cesium_ion_token}'
+        map_layers_link += f'?cesium-ion-token={cesium_ion_token}'
+        terrain_link += f'?cesium-ion-token={cesium_ion_token}'
+        czml_link += f'?cesium-ion-token={cesium_ion_token}'
+        geojson_link += f'?cesium-ion-token={cesium_ion_token}'
+        model_link += f'?cesium-ion-token={cesium_ion_token}'
+        model2_link += f'?cesium-ion-token={cesium_ion_token}'
+
     header_link = {"home_link": home_link, "map_layers_link": map_layers_link, "terrain_link": terrain_link,
-                   "czml_link": czml_link, "model_link": model_link, "model2_link": model2_link,
-                   "page_type": type}
+                   "czml_link": czml_link, "geojson_link": geojson_link, "model_link": model_link,
+                   "model2_link": model2_link, "page_type": type}
 
     # 1. Basic Map
     height = '600px'
+
     if type == 'home':
-        cesium_map_view = CesiumMapView(height=height)
+        cesium_map_view = CesiumMapView(cesium_ion_token=cesium_ion_token, height=height)
 
     # 2. Map Layers
     if type == 'map_layers':
         cesium_map_view = CesiumMapView(
+            cesium_ion_token=cesium_ion_token,
             height=height,
             draw=True,
             options={'shouldAnimate': False, 'timeline': False, 'homeButton': False},
-            layers={'EsriArcGISMapServer': {
-                'imageryProvider': {
-                    'Cesium.ArcGisMapServerImageryProvider': [{
-                        'url': 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
-                    }]
-                }
-            }}
+            layers=[
+                {'Open Street Map': {
+                    'imageryProvider': {'Cesium.OpenStreetMapImageryProvider': {
+                        'url': 'https://a.tile.openstreetmap.org/'
+                    }}
+                }},
+                MVLayer(
+                    source='ImageWMS',
+                    legend_title='US States',
+                    options={
+                        'url': 'https://demo.geo-solutions.it/geoserver/wms',
+                        'params': {'LAYERS': 'topp:states'},
+                        'serverType': 'geoserver'
+                    },
+                )
+            ]
         )
 
     # 3. Terrain
     if type == 'terrain':
         cesium_map_view = CesiumMapView(
+            cesium_ion_token=cesium_ion_token,
             height=height,
             draw=True,
             options={'shouldAnimate': False, 'timeline': False, 'homeButton': False},
@@ -1285,9 +1311,92 @@ def cesium_map_view(request, type):
             }}
         )
 
-    # 4. czml Object
+    # 4. CZML Object
     if type == 'czml':
+        czml_doc = [
+            {
+                "id": "document",
+                "name": "CZML Geometries: Polygon",
+                "version": "1.0"
+            },
+            {
+                "id": "redPolygon",
+                "name": "Red polygon on surface",
+                "polygon": {
+                    "positions": {
+                        "cartographicDegrees": [
+                            -115.0, 37.0, 0,
+                            -115.0, 32.0, 0,
+                            -107.0, 33.0, 0,
+                            -102.0, 31.0, 0,
+                            -102.0, 35.0, 0
+                        ]
+                    },
+                    "material": {
+                        "solidColor": {
+                            "color": {
+                                "rgba": [255, 0, 0, 255]
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "id": "greenPolygon",
+                "name": "Green extruded polygon",
+                "polygon": {
+                    "positions": {
+                        "cartographicDegrees": [
+                            -108.0, 42.0, 0,
+                            -100.0, 42.0, 0,
+                            -104.0, 40.0, 0
+                        ]
+                    },
+                    "material":
+                        {
+                            "solidColor":
+                                {
+                                    "color": {
+                                        "rgba": [0, 255, 0, 255]
+                                    }
+                                }
+                        },
+                    "extrudedHeight": 500000.0,
+                    "closeTop": False,
+                    "closeBottom": False
+                }
+            },
+            {
+                "id": "orangePolygon",
+                "name": "Orange polygon with per-position heights and outline",
+                "polygon": {
+                    "positions": {
+                        "cartographicDegrees": [
+                            -108.0, 25.0, 100000,
+                            -100.0, 25.0, 100000,
+                            -100.0, 30.0, 100000,
+                            -108.0, 30.0, 300000
+                        ]
+                    },
+                    "material": {
+                        "solidColor": {
+                            "color": {
+                                "rgba": [255, 100, 0, 100]
+                            }
+                        }
+                    },
+                    "extrudedHeight": 0,
+                    "perPositionHeight": True,
+                    "outline": True,
+                    "outlineColor": {
+                        "rgba": [0, 0, 0, 255]
+                    }
+                }
+            }
+        ]
+
         cesium_map_view = CesiumMapView(
+            cesium_ion_token=cesium_ion_token,
             height=height,
             options={'shouldAnimate': True,
                      'timeline': False,
@@ -1295,7 +1404,7 @@ def cesium_map_view(request, type):
                      'shadows': True,
                      },
             view={'lookAt': {
-                'center': {'Cesium.Cartesian3.fromDegrees': [-58.0, 40.0]},
+                'center': {'Cesium.Cartesian3.fromDegrees': [-98.0, 40.0]},
                 'offset': {'Cesium.Cartesian3': [0.0, -4790000.0, 3930000.0]},
             }},
             layers={'BingMap': {
@@ -1307,100 +1416,84 @@ def cesium_map_view(request, type):
                     },
                 }
             }},
-            entities={'czml': [
+            entities=[
                 {
-                    "id": "document",
-                    "name": "CZML Geometries: Polygon",
-                    "version": "1.0"
-                },
-                {
-                    "id": "redPolygon",
-                    "name": "Red polygon on surface",
-                    "polygon":
-                        {
-                            "positions":
-                                {
-                                    "cartographicDegrees": [
-                                        -115.0, 37.0, 0,
-                                        -115.0, 32.0, 0,
-                                        -107.0, 33.0, 0,
-                                        -102.0, 31.0, 0,
-                                        -102.0, 35.0, 0
-                                    ]
-                                },
-                            "material":
-                                {
-                                    "solidColor":
-                                        {
-                                            "color":
-                                                {
-                                                    "rgba": [255, 0, 0, 255]
-                                                }
-                                        }
-                                }
-                        }
-                },
-                {
-                    "id": "greenPolygon",
-                    "name": "Green extruded polygon",
-                    "polygon":
-                        {
-                            "positions": {
-                                "cartographicDegrees": [
-                                    -108.0, 42.0, 0,
-                                    -100.0, 42.0, 0,
-                                    -104.0, 40.0, 0
-                                ]
-                            },
-                            "material":
-                                {
-                                    "solidColor":
-                                        {
-                                            "color": {
-                                                "rgba": [0, 255, 0, 255]
-                                            }
-                                        }
-                                },
-                            "extrudedHeight": 500000.0,
-                            "closeTop": False,
-                            "closeBottom": False
-                        }
-                },
-                {
-                    "id": "orangePolygon",
-                    "name": "Orange polygon with per-position heights and outline",
-                    "polygon":
-                        {
-                            "positions": {
-                                "cartographicDegrees": [
-                                    -108.0, 25.0, 100000,
-                                    -100.0, 25.0, 100000,
-                                    -100.0, 30.0, 100000,
-                                    -108.0, 30.0, 300000
-                                ]
-                            },
-                            "material": {
-                                "solidColor": {
-                                    "color": {
-                                        "rgba": [255, 100, 0, 100]
-                                    }
-                                }
-                            },
-                            "extrudedHeight": 0,
-                            "perPositionHeight": True,
-                            "outline": True,
-                            "outlineColor": {
-                                "rgba": [0, 0, 0, 255]
-                            }
-                        }
-                }]
-            },
+                    'source': 'czml',
+                    'options': czml_doc
+                }
+            ],
         )
 
-    # 5. Model.
+    # 5. GeoJSON Object
+    if type == 'geojson':
+        geojson_object = {
+            'type': 'FeatureCollection',
+            'crs': {
+                'type': 'name',
+                'properties': {
+                    'name': 'EPSG:4326'
+                }
+            },
+            'features': [
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [0, 0]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'LineString',
+                        'coordinates': [[35.9326113, -17.6789142], [71.8652227, 17.6789142]]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Polygon',
+                        'coordinates': [
+                            [[-44.9157642, -8.9465739], [-35.9326114, 8.9465739], [-26.9494585, -8.9465739]]
+                        ]
+                    }
+                }
+            ]
+        }
+
+        cesium_map_view = CesiumMapView(
+            cesium_ion_token=cesium_ion_token,
+            height=height,
+            options={'shouldAnimate': True,
+                     'timeline': False,
+                     'homeButton': False,
+                     'shadows': True,
+                     },
+            view={'flyTo': {
+                'destination': {'Cesium.Cartesian3.fromDegrees': [0, 0, 20000000.0]},
+            }},
+            layers={'BingMap': {
+                'imageryProvider': {
+                    'Cesium.BingMapsImageryProvider': {
+                        'url': 'https://dev.virtualearth.net',
+                        'key': 'AnYTMwSuR3-CBMzhN0yAYrtl-28rEFe7Kxfg2IWC9csUBCn0nYDFXW1ioNakjX3W',
+                        'mapStyle': 'Cesium.BingMapsStyle.AERIAL',
+                    },
+                }
+            }},
+            entities=[
+                {
+                    'source': 'geojson',
+                    'options': geojson_object
+                }
+            ],
+        )
+
+    # 6. Model
     if type == 'model':
         object1 = '/static/tethys_gizmos/cesium_models/CesiumAir/Cesium_Air.glb'
         cesium_map_view = CesiumMapView(
+            cesium_ion_token=cesium_ion_token,
             height=height,
             options={
                 'shouldAnimate': True,
@@ -1443,10 +1536,12 @@ def cesium_map_view(request, type):
             }}}
         )
 
+    # 7. Multiple Models
     if type == 'model2':
         object1 = '/static/tethys_gizmos/cesium_models/CesiumAir/Cesium_Air.glb'
         object2 = '/static/tethys_gizmos/cesium_models/CesiumBalloon/CesiumBalloon.glb'
         cesium_map_view = CesiumMapView(
+            cesium_ion_token=cesium_ion_token,
             height='80%',
             width='80%',
             options={'shouldAnimate': True,
@@ -1505,7 +1600,10 @@ def cesium_map_view(request, type):
     if submitted_geometry is not None:
         messages.info(request, submitted_geometry)
 
-    context = {"cesium_map_view": cesium_map_view}
+    context = {
+        "cesium_map_view": cesium_map_view,
+        "cesium_ion_token": cesium_ion_token
+    }
     context.update(header_link)
 
     return render(request, 'tethys_gizmos/gizmo_showcase/cesium_map_view.html', context)


### PR DESCRIPTION
- Added cesium token parameter
- Updated the URL for cesium dependencies
- Changed layers and entities to take lists
- Updated the default version of cesium to 1.63.1
- Added support for GeoJSON entities
- Added support for TileWMS and ImageWMS to MVLayers for layers
- Added support for GeoJSON to MVLayers for entities
- Added a GeoJSON example for cesium to the gizmo showcase
- Added input of cesium token to the gizmo showcase


