### PR TITLE
Add coveralls call back to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,18 @@ install:
   - tethys db start
   # install test dependencies
   - pip install coveralls
-after_success:
-  - >
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      # generate test coverage information
-      cd $TRAVIS_BUILD_DIR
-      coveralls
-    fi
+  - cd $TRAVIS_BUILD_DIR
 
 script:
   # command to run tests
   - tethys test -c -u -v 2
+
+after_success:
+  - >
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      # generate test coverage information
+      coveralls
+    fi
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - conda list
   - tethys db start
   # install test dependencies
-  - pip install python-coveralls
+  - pip install coveralls
 after_success:
   - >
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ install:
   - tethys db start
   # install test dependencies
   - pip install python-coveralls
+after_success:
+  - >
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      # generate test coverage information
+      coveralls
+    fi
 
 script:
   # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ after_success:
   - >
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       # generate test coverage information
+      cd $TRAVIS_BUILD_DIR
       coveralls
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ sudo: false
 notifications:
   email: false
 
-addons:
-  artifacts:
-    debug: true
-    paths:
-      - $TRAVIS_BUILD_DIR/conda.recipe
-
 os:
   - linux
   - osx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tethys-platform
-version = 3.0.0
+version = 3.0.1
 license = BSD 2-Clause License
 summary =  Primary Tethys Platform Django Site Project
 description-file = README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tethys-platform
-version = 3.0.1
+version = 3.1.0
 license = BSD 2-Clause License
 summary =  Primary Tethys Platform Django Site Project
 description-file = README.rst


### PR DESCRIPTION
* @msouff discovered that Coveralls has not been updated since November.
* The lines were inadvertently removed when refactoring the meta.yaml generation.
* Adds coveralls call back in.
* Changes version of master branch from 3.0.0 to 3.1.0