### PR TITLE
add example code for opening ssl port

### DIFF
--- a/docs/installation/production/ssl_config.rst
+++ b/docs/installation/production/ssl_config.rst
@@ -36,7 +36,12 @@ Change the listen port to 443 and enable ssl with the following options:
 
 .. important::
 
-    SSL goes through port 443, hence the server block above listens on 443 instead of 80. Be sure to update your firewall accordingly if applicable.
+    SSL goes through port 443, hence the server block above listens on 443 instead of 80. Be sure to update your firewall accordingly if applicable. If you followed the production installation instructions exactly, this means you'll need to run:
+
+::
+
+    sudo firewall-cmd --permanent --zone=public --add-service=https
+    sudo firewall-cmd --reload
 
 .. tip::
 


### PR DESCRIPTION
it took me a while to figure this one out. i forgot the production install had me use this firewall utility. I think it would be wise to have the SSL instructions mirror the standard http instructions so save confusion like this.