### PR TITLE
Broken uri hotfix - as_view() method

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_decorators.py
+++ b/tests/unit_tests/test_tethys_apps/test_decorators.py
@@ -159,24 +159,31 @@ class DecoratorsTest(unittest.TestCase):
 
     @mock.patch('tethys_apps.decorators.tethys_portal_error', return_value=False)
     @mock.patch('tethys_apps.decorators.has_permission', return_value=False)
+    @override_settings(DEBUG=True)
     def test_permission_required_exception_403(self, _, mock_tp_error):
         request = self.request_factory.get('/apps/test-app')
         request.user = self.user
 
-        if not getattr(settings, 'DEBUG', False):
-            @permission_required('create_projects', raise_exception=True)
-            def exception_404(request, *args, **kwargs):
-                return "expected_result"
+        @permission_required('create_projects', raise_exception=True)
+        def exception_403(request, *args, **kwargs):
+            return "expected_result"
 
-            exception_404(request)
-            mock_tp_error.handler_404.assert_called_with(request)
-        else:
-            @permission_required('create_projects', raise_exception=True)
-            def exception_403(request, *args, **kwargs):
-                return "expected_result"
+        exception_403(request)
+        mock_tp_error.handler_403.assert_called_with(request)
 
-            exception_403(request)
-            mock_tp_error.handler_403.assert_called_with(request)
+    @mock.patch('tethys_apps.decorators.tethys_portal_error', return_value=False)
+    @mock.patch('tethys_apps.decorators.has_permission', return_value=False)
+    @override_settings(DEBUG=False)
+    def test_permission_required_exception_404(self, _, mock_tp_error):
+        request = self.request_factory.get('/apps/test-app')
+        request.user = self.user
+
+        @permission_required('create_projects', raise_exception=True)
+        def exception_404(request, *args, **kwargs):
+            return "expected_result"
+
+        exception_404(request)
+        mock_tp_error.handler_404.assert_called_with(request)
 
     def test_permission_required_no_request(self):
         @permission_required('create_projects')

--- a/tests/unit_tests/test_tethys_portal/test_urls.py
+++ b/tests/unit_tests/test_tethys_portal/test_urls.py
@@ -37,11 +37,25 @@ class TestUrls(TethysTestCase):
         self.assertEqual('PasswordResetView', resolver.func.__name__)
         self.assertEqual('django.contrib.auth.views', resolver.func.__module__)
 
+    def test_account_urls_accounts_password_reset_done(self):
+        url = reverse('accounts:password_reset_done')
+        resolver = resolve(url)
+        self.assertEqual('/accounts/password/reset/done/', url)
+        self.assertEqual('PasswordResetDoneView', resolver.func.__name__)
+        self.assertEqual('django.contrib.auth.views', resolver.func.__module__)
+
     def test_account_urls_accounts_password_confirm(self):
         url = reverse('accounts:password_confirm', kwargs={'uidb64': 'f00Bar', 'token': 'tok'})
         resolver = resolve(url)
         self.assertEqual('/accounts/password/reset/f00Bar-tok/', url)
         self.assertEqual('PasswordResetConfirmView', resolver.func.__name__)
+        self.assertEqual('django.contrib.auth.views', resolver.func.__module__)
+
+    def test_account_urls_accounts_password_done(self):
+        url = reverse('accounts:password_done')
+        resolver = resolve(url)
+        self.assertEqual('/accounts/password/done/', url)
+        self.assertEqual('PasswordResetCompleteView', resolver.func.__name__)
         self.assertEqual('django.contrib.auth.views', resolver.func.__module__)
 
     def test_user_urls_profile(self):

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -8,6 +8,7 @@
 ********************************************************************************
 """
 from django.conf.urls import include, url
+from django.urls import reverse_lazy
 from django.views.decorators.cache import never_cache
 from django.contrib import admin
 from django.contrib.auth.views import PasswordResetView, PasswordResetDoneView, PasswordResetConfirmView, \
@@ -40,11 +41,13 @@ account_urls = [
     url(r'^login/$', tethys_portal_accounts.login_view, name='login'),
     url(r'^logout/$', tethys_portal_accounts.logout_view, name='logout'),
     url(r'^register/$', tethys_portal_accounts.register, name='register'),
-    url(r'^password/reset/$', never_cache(PasswordResetView.as_view()),
-        {'post_reset_redirect': '/accounts/password/reset/done/'}, name='password_reset'),
+    url(r'^password/reset/$', never_cache(PasswordResetView.as_view(
+        success_url=reverse_lazy('accounts:password_reset_done'))
+    ), name='password_reset'),
     url(r'^password/reset/done/$', never_cache(PasswordResetDoneView.as_view()), name='password_reset_done'),
-    url(r'^password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$', never_cache(PasswordResetConfirmView.as_view()),
-        {'post_reset_redirect': '/accounts/password/done/'}, name='password_confirm'),
+    url(r'^password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$', never_cache(PasswordResetConfirmView.as_view(
+        success_url=reverse_lazy('accounts:password_done'))
+    ), name='password_confirm'),
     url(r'^password/done/$', never_cache(PasswordResetCompleteView.as_view()), name='password_done'),
 ]
 

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -42,10 +42,10 @@ account_urls = [
     url(r'^register/$', tethys_portal_accounts.register, name='register'),
     url(r'^password/reset/$', never_cache(PasswordResetView.as_view()),
         {'post_reset_redirect': '/accounts/password/reset/done/'}, name='password_reset'),
-    url(r'^password/reset/done/$', never_cache(PasswordResetDoneView.as_view())),
+    url(r'^password/reset/done/$', never_cache(PasswordResetDoneView.as_view()), name='password_reset_done'),
     url(r'^password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$', never_cache(PasswordResetConfirmView.as_view()),
         {'post_reset_redirect': '/accounts/password/done/'}, name='password_confirm'),
-    url(r'^password/done/$', never_cache(PasswordResetCompleteView.as_view())),
+    url(r'^password/done/$', never_cache(PasswordResetCompleteView.as_view()), name='password_done'),
 ]
 
 user_urls = [


### PR DESCRIPTION
Django changed the way arguments are passed into class-based views when using the .as_view() method. The parameter success_url needs to be set for this functionality to work properly. This has been tested using a local_only configuration of postfix.