### PR TITLE
Password Recovery URI - Hotfix

### DIFF
--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -8,6 +8,7 @@
 ********************************************************************************
 """
 from django.conf.urls import include, url
+from django.urls import reverse_lazy
 from django.views.decorators.cache import never_cache
 from django.contrib import admin
 from django.contrib.auth.views import PasswordResetView, PasswordResetDoneView, PasswordResetConfirmView, \
@@ -40,11 +41,13 @@ account_urls = [
     url(r'^login/$', tethys_portal_accounts.login_view, name='login'),
     url(r'^logout/$', tethys_portal_accounts.logout_view, name='logout'),
     url(r'^register/$', tethys_portal_accounts.register, name='register'),
-    url(r'^password/reset/$', never_cache(PasswordResetView.as_view()),
-        {'post_reset_redirect': '/accounts/password/reset/done/'}, name='password_reset'),
+    url(r'^password/reset/$', never_cache(PasswordResetView.as_view(
+        success_url=reverse_lazy('accounts:password_reset_done'))
+    ), name='password_reset'),
     url(r'^password/reset/done/$', never_cache(PasswordResetDoneView.as_view()), name='password_reset_done'),
-    url(r'^password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$', never_cache(PasswordResetConfirmView.as_view()),
-        {'post_reset_redirect': '/accounts/password/done/'}, name='password_confirm'),
+    url(r'^password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$', never_cache(PasswordResetConfirmView.as_view(
+        success_url=reverse_lazy('accounts:password_done'))
+    ), name='password_confirm'),
     url(r'^password/done/$', never_cache(PasswordResetCompleteView.as_view()), name='password_done'),
 ]
 


### PR DESCRIPTION
Django changed the way arguments are passed into class-based views when using the .as_view() method. The parameter success_url needs to be set for this functionality to work properly. This functionality has been tested using a local_only configuration of postfix.