### PR TITLE
Pin Bokeh to Version that works with 3.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 
 # plotting dependencies
 - plotly
-- bokeh>=1.3.5*
+- bokeh>=1.4.0*
 
 # external services dependencies
 - tethys_dataset_services>=2.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 
 # plotting dependencies
 - plotly
-- bokeh>=1.4.0*
+- bokeh=1.4.*
 
 # external services dependencies
 - tethys_dataset_services>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tethys-platform
-version = 3.0.4
+version = 3.0.5
 license = BSD 2-Clause License
 summary =  Primary Tethys Platform Django Site Project
 description-file = README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tethys-platform
-version = 3.0.3
+version = 3.0.4
 license = BSD 2-Clause License
 summary =  Primary Tethys Platform Django Site Project
 description-file = README.rst


### PR DESCRIPTION
* Environment in release is configured in such a way that Bokeh allows major upgrades.
* Pin Bokeh to version 1.4.0 for the 3.0 release.