### PR TITLE
Improve Docker Build and Extendability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,19 @@
 image: docker:git
 
 stages:
-  - build
+  - Lint
+  - Build
+  - Test
+
+include:
+  - project: 'tethys/kubernetes/gl-k8s-integration'
+    ref: 1.3.0-rc2
+    file: '/test-tethys.yml'
+
+variables:
+  CONDA_HOME: '/opt/conda'
+  TETHYS_HOME: '/usr/lib/tethys'
+  POSTGRES_VERSION: '9.6'
 
 before_script:
   # Set up ssh-agent for use when checking out other repos
@@ -15,15 +27,43 @@ before_script:
   - mkdir -p ~/.ssh
   - '[[ -f /.dockerenv ]] && echo "$SSH_SERVER_HOSTKEYS" > ~/.ssh/known_hosts'
 
-build:
-  stage: build
+.kaniko_prep: &kaniko_prep
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+  before_script:
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+
+Build:
+  stage: Build
+  <<: *kaniko_prep
   script:
-    # Docker Stuff
-    - docker build --squash -t $CI_REGISTRY_IMAGE/tethyscore:$CI_COMMIT_TAG -t $CI_REGISTRY_IMAGE/tethyscore:latest .
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker push $CI_REGISTRY_IMAGE/tethyscore:$CI_COMMIT_TAG
-    - docker push $CI_REGISTRY_IMAGE/tethyscore:latest
-  tags:
-    - docker
+    - /kaniko/executor
+        --context $CI_PROJECT_DIR
+        --dockerfile $CI_PROJECT_DIR/Dockerfile
+        --destination $CI_REGISTRY_IMAGE/dev:$CI_COMMIT_SHORT_SHA
+        --cache
+        --cache-repo $CI_REGISTRY_IMAGE/cache
+  except:
+    - tags
+
+"Build and Push":
+  stage: Build
+  <<: *kaniko_prep
+  script:
+    - /kaniko/executor
+        --context $CI_PROJECT_DIR
+        --dockerfile $CI_PROJECT_DIR/Dockerfile
+        --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+        --destination $CI_REGISTRY_IMAGE:latest
+        --cache
+        --cache-repo $CI_REGISTRY_IMAGE/cache
   only:
     - tags
+
+"Unit Test":
+  script:
+    - echo "Run Tests"
+    - tethys test -cu

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,17 +30,17 @@ ENV  BASH_PROFILE=".bashrc" \
 
 # Tethys settings arguments
 ENV  DEBUG="False" \
-     ALLOWED_HOSTS="localhost 127.0.0.1" \
+     ALLOWED_HOSTS="\"[localhost, 127.0.0.1]\"" \
      BYPASS_TETHYS_HOME_PAGE="True" \
-     ADD_DJANGO_APPS=None \
+     ADD_DJANGO_APPS="\"[]\"" \
      SESSION_WARN=1500 \
      SESSION_EXPIRE=1800 \
      STATIC_ROOT="${TETHYS_PERSIST}/static" \
      WORKSPACE_ROOT="${TETHYS_PERSIST}/workspaces" \
-     QUOTA_HANDLERS=None \
-     DJANGO_ANALYTICAL=None \
-     ADD_BACKENDS=None \
-     OAUTH_OPTIONS=None \
+     QUOTA_HANDLERS="\"[]\"" \
+     DJANGO_ANALYTICAL="\"{}\"" \
+     ADD_BACKENDS="\"[]\"" \
+     OAUTH_OPTIONS="\"{}\"" \
      CHANNEL_LAYER="" \
      RECAPTCHA_PRIVATE_KEY="" \
      RECAPTCHA_PUBLIC_KEY=""

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,4 +22,5 @@ services:
     image: postgres
     restart: always
     environment:
-      POSTGRES_PASSWORD: pass
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "pass"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,43 +8,88 @@ echo_status() {
   tput sgr0
 }
 
+db_max_count=24;
+no_daemon=true;
+skip_perm=false;
+test=false;
+USAGE="USAGE: . run.sh [options]
+OPTIONS:
+--background              \t run supervisord in background.
+--skip-perm               \t skip fixing permissions step.
+--db-max-count <INT>      \t number of attempt to connect to the database. Default is at 24.
+--test                    \t only run test.
+"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skip-perm)
+      skip_perm=true;
+    ;;
+    --background)
+      no_daemon=false;
+    ;;
+    --db-max-count)
+      shift # shift from key to value
+      db_max_count=$1;
+    ;;
+    --test)
+      test=true;
+    ;;
+    *)
+      echo -e "${USAGE}"
+      return 0
+  esac
+  shift
+done
+
 echo_status "Starting up..."
 
-# Set extra ENVs
-export NGINX_USER=$(grep 'user .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}')
-
 # Create Salt Config
-echo "file_client: local" > /etc/salt/minion 
-echo "postgres.host: '${TETHYS_DB_HOST}'" >> /etc/salt/minion 
+echo "file_client: local" > /etc/salt/minion
+echo "postgres.host: '${TETHYS_DB_HOST}'" >> /etc/salt/minion
 echo "postgres.port: '${TETHYS_DB_PORT}'" >> /etc/salt/minion
-echo "postgres.user: '${TETHYS_DB_USERNAME}'" >> /etc/salt/minion 
-echo "postgres.pass: '${TETHYS_DB_PASSWORD}'" >> /etc/salt/minion 
-echo "postgres.bins_dir: '${CONDA_HOME}/envs/${CONDA_ENV_NAME}/bin'" >> /etc/salt/minion 
+echo "postgres.user: '${TETHYS_DB_USERNAME}'" >> /etc/salt/minion
+echo "postgres.pass: '${TETHYS_DB_PASSWORD}'" >> /etc/salt/minion
+echo "postgres.bins_dir: '${CONDA_HOME}/envs/${CONDA_ENV_NAME}/bin'" >> /etc/salt/minion
 
-# Apply States
-echo_status "Checking if DB is ready"
-db_check_count=0
-until ${CONDA_HOME}/envs/${CONDA_ENV_NAME}/bin/pg_isready -h ${TETHYS_DB_HOST} -p ${TETHYS_DB_PORT} -U postgres; do
-  if [ $db_check_count -gt 24 ]; then
-    >&2 echo "DB was not available in time - exiting"
-    exit 1
-  fi
-  >&2 echo "DB is unavailable - sleeping"
-  db_check_count=`expr $db_check_count + 1`
-  sleep 5
-done
+if [[ $test = false ]]; then
+  # Set extra ENVs
+  export NGINX_USER=$(grep 'user .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}')
+
+  # Apply States
+  echo_status "Checking if DB is ready"
+
+  db_check_count=0
+
+  until ${CONDA_HOME}/envs/${CONDA_ENV_NAME}/bin/pg_isready -h ${TETHYS_DB_HOST} -p ${TETHYS_DB_PORT} -U postgres; do
+    if [[ $db_check_count -gt $db_max_count ]]; then
+      >&2 echo "DB was not available in time - exiting"
+      exit 1
+    fi
+    >&2 echo "DB is unavailable - sleeping"
+    db_check_count=`expr $db_check_count + 1`
+    sleep 5
+  done
+fi
+
 echo_status "Enforcing start state... (This might take a bit)"
 salt-call --local state.apply
-echo_status "Fixing permissions"
-find ${TETHYS_HOME} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
 
-echo_status "Starting supervisor"
+if [[ $test = false ]]; then
+  if [[ $skip_perm = false ]]; then
+    echo_status "Fixing permissions"
+    find ${TETHYS_HOME} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+  fi
 
-# Start Supervisor
-/usr/bin/supervisord -n
+  echo_status "Starting supervisor"
 
-echo_status "Done!"
+  # Start Supervisor
+  /usr/bin/supervisord $([[ $no_daemon = true ]] && printf %s "-n")
 
-# Watch Logs
-echo_status "Watching logs"
-tail -qF /var/log/supervisor/* /var/log/nginx/* /var/log/tethys/*
+  echo_status "Done!"
+
+  # Watch Logs
+  echo_status "Watching logs"
+  tail -qF /var/log/supervisor/* /var/log/nginx/* /var/log/tethys/*
+fi
+

--- a/docker/salt/post_app.sls
+++ b/docker/salt/post_app.sls
@@ -1,0 +1,67 @@
+{% set TETHYS_HOME = salt['environ.get']('TETHYS_HOME') %}
+{% set CONDA_ENV_NAME = salt['environ.get']('CONDA_ENV_NAME') %}
+{% set CONDA_HOME = salt['environ.get']('CONDA_HOME') %}
+{% set TETHYS_PERSIST = salt['environ.get']('TETHYS_PERSIST') %}
+
+Persist_Portal_Config_Post_App:
+  file.rename:
+    - source: {{ TETHYS_HOME }}/portal_config.yml
+    - name: {{ TETHYS_PERSIST }}/portal_config.yml
+    - unless: /bin/bash -c "[ -f "${TETHYS_PERSIST}/portal_config.yml" ];"
+
+Restore_Portal_Config_Post_App:
+  file.symlink:
+    - name: {{ TETHYS_HOME }}/portal_config.yml
+    - target: {{ TETHYS_PERSIST }}/portal_config.yml
+    - force: True
+
+Chown_Portal_Config_Post_App:
+  cmd.run:
+    - name: chown www:www {{ TETHYS_HOME }}/portal_config.yml
+    - shell: /bin/bash
+
+Collect_Static:
+  cmd.run:
+    - name: . {{ CONDA_HOME }}/bin/activate {{ CONDA_ENV_NAME }} && cat {{ TETHYS_HOME }}/portal_config.yml && cat {{ TETHYS_HOME }}/tethys/tethys_portal/settings.py && tethys manage collectstatic --noinput
+    - shell: /bin/bash
+
+Collect_Workspaces:
+  cmd.run:
+    - name: . {{ CONDA_HOME }}/bin/activate {{ CONDA_ENV_NAME }} && cat {{ TETHYS_HOME }}/portal_config.yml && cat {{ TETHYS_HOME }}/tethys/tethys_portal/settings.py && tethys manage collectworkspaces
+    - shell: /bin/bash
+
+Persist_NGINX_Config_Post_App:
+  file.rename:
+    - source: {{ TETHYS_HOME }}/tethys_nginx.conf
+    - name: {{ TETHYS_PERSIST }}/tethys_nginx.conf
+    - unless: /bin/bash -c "[ -f "${TETHYS_PERSIST}/tethys_nginx.conf" ];"
+
+Link_NGINX_Config_Post_App:
+  file.symlink:
+    - name: /etc/nginx/sites-enabled/tethys_nginx.conf
+    - target: {{ TETHYS_PERSIST }}/tethys_nginx.conf
+    - force: True
+
+Persist_NGINX_Supervisor_Post_App:
+  file.rename:
+    - source: {{ TETHYS_HOME }}/nginx_supervisord.conf
+    - name: {{ TETHYS_PERSIST }}/nginx_supervisord.conf
+    - unless: /bin/bash -c "[ -f "${TETHYS_PERSIST}/nginx_supervisord.conf" ];"
+
+Link_NGINX_Supervisor_Post_App:
+  file.symlink:
+    - name: /etc/supervisor/conf.d/nginx_supervisord.conf
+    - target: {{ TETHYS_PERSIST }}/nginx_supervisord.conf
+    - force: True
+
+Persist_ASGI_Supervisor_Post_App:
+  file.rename:
+    - source: {{ TETHYS_HOME }}/asgi_supervisord.conf
+    - name: {{ TETHYS_PERSIST }}/asgi_supervisord.conf
+    - unless: /bin/bash -c "[ -f "${TETHYS_PERSIST}/asgi_supervisord.conf" ];"
+
+Link_ASGI_Supervisor_Post_App:
+  file.symlink:
+    - name: /etc/supervisor/conf.d/asgi_supervisord.conf
+    - target: {{ TETHYS_PERSIST }}/asgi_supervisord.conf
+    - force: True

--- a/docker/salt/pre_tethys.sls
+++ b/docker/salt/pre_tethys.sls
@@ -1,0 +1,24 @@
+{% set STATIC_ROOT = salt['environ.get']('STATIC_ROOT') %}
+{% set WORKSPACE_ROOT = salt['environ.get']('WORKSPACE_ROOT') %}
+{% set TETHYS_HOME = salt['environ.get']('TETHYS_HOME') %}
+{% set TETHYS_PERSIST = salt['environ.get']('TETHYS_PERSIST') %}
+
+Create_Static_Root_On_Mounted_Pre_Tethys:
+  cmd.run:
+    - name: mkdir -p {{ STATIC_ROOT }}
+    - shell: /bin/bash
+    - unless: /bin/bash -c "[ -d "${STATIC_ROOT}" ];"
+
+Create_Workspace_Root_On_Mounted_Pre_Tethys:
+  cmd.run:
+    - name: mkdir -p {{ WORKSPACE_ROOT }}
+    - shell: /bin/bash
+    - unless: /bin/bash -c "[ -d "${WORKSPACE_ROOT}" ];"
+
+Chown_Static_Workspaces_On_Mounted_Pre_Tethys:
+  cmd.run:
+    - name: >
+        export NGINX_USER=$(grep 'user .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}') ;
+        find {{ WORKSPACE_ROOT }} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {} ;
+        find {{ STATIC_ROOT }} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+    - shell: /bin/bash

--- a/docker/salt/top.sls
+++ b/docker/salt/top.sls
@@ -1,3 +1,5 @@
 base:
   '*':
+    - pre_tethys
     - tethyscore
+    - post_app

--- a/docker/test-docker.sh
+++ b/docker/test-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo_status() {
+  local args="${@}"
+  tput setaf 4
+  tput bold
+  echo -e "- $args"
+  tput sgr0
+}
+
+echo_status "Starting up..."
+
+# Create Salt Config
+echo "file_client: local" > /etc/salt/minion
+echo "postgres.host: '${TETHYS_DB_HOST}'" >> /etc/salt/minion
+echo "postgres.port: '${TETHYS_DB_PORT}'" >> /etc/salt/minion
+echo "postgres.user: '${TETHYS_DB_USERNAME}'" >> /etc/salt/minion
+echo "postgres.pass: '${TETHYS_DB_PASSWORD}'" >> /etc/salt/minion
+echo "postgres.bins_dir: '${CONDA_HOME}/envs/${CONDA_ENV_NAME}/bin'" >> /etc/salt/minion
+
+# Apply States
+echo_status "Enforcing start state... (This might take a bit)"
+salt-call --local state.apply

--- a/tests/unit_tests/test_tethys_cli/test__init__.py
+++ b/tests/unit_tests/test_tethys_cli/test__init__.py
@@ -120,7 +120,8 @@ class TethysCommandTests(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.generate_command')
     def test_generate_subcommand_nginx_settings_verbose_options(self, mock_gen_command):
         testargs = ['tethys', 'gen', 'nginx', '-d', '/tmp/foo/bar', '--client-max-body-size', '123M',
-                    '--asgi-processes', '4', '--overwrite', '--tethys-port', '8080']
+                    '--asgi-processes', '4', '--conda-prefix', '/path/to/conda/env', '--tethys-port', '8080',
+                    '--overwrite']
 
         with mock.patch.object(sys, 'argv', testargs):
             tethys_command()
@@ -132,6 +133,7 @@ class TethysCommandTests(unittest.TestCase):
         self.assertTrue(call_args[0][0][0].overwrite)
         self.assertEqual('nginx', call_args[0][0][0].type)
         self.assertEqual('4', call_args[0][0][0].asgi_processes)
+        self.assertEqual('/path/to/conda/env', call_args[0][0][0].conda_prefix)
         self.assertEqual('8080', call_args[0][0][0].tethys_port)
 
     @mock.patch('sys.stdout', new_callable=StringIO)

--- a/tests/unit_tests/test_tethys_cli/test_gen_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_gen_commands.py
@@ -111,7 +111,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     def test_generate_command_asgi_service_option_nginx_conf_redhat(self, mock_os_path_isfile, mock_file, mock_env,
                                                                     mock_os_path_exists, mock_linux_distribution,
                                                                     mock_render_template, mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
@@ -142,7 +142,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     def test_generate_command_asgi_service_option_nginx_conf_ubuntu(self, mock_os_path_isfile, mock_file, mock_env,
                                                                     mock_os_path_exists, mock_linux_distribution,
                                                                     mock_render_template, mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
@@ -173,7 +173,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     def test_generate_command_asgi_service_option_nginx_conf_not_linux(self, mock_os_path_isfile, mock_file, mock_env,
                                                                        mock_os_path_exists, mock_linux_distribution,
                                                                        mock_render_template, mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
@@ -199,7 +199,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.open', new_callable=mock.mock_open)
     @mock.patch('tethys_cli.gen_commands.os.path.isfile')
     def test_generate_command_asgi_service_option(self, mock_os_path_isfile, mock_file, mock_env, mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
@@ -220,7 +220,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.os.path.isfile')
     def test_generate_command_asgi_service_option_distro(self, mock_os_path_isfile, mock_file, mock_env,
                                                          mock_distribution, mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_os_path_isfile.return_value = False
@@ -242,7 +242,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.os.path.isfile')
     def test_generate_command_asgi_settings_option_directory(self, mock_os_path_isfile, mock_file, mock_env,
                                                              mock_os_path_isdir, mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = '/foo/temp'
         mock_os_path_isfile.return_value = False
@@ -265,7 +265,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.os.path.isfile')
     def test_generate_command_asgi_settings_option_bad_directory(self, mock_os_path_isfile, mock_env,
                                                                  mock_os_path_isdir, mock_exit, mock_write_error):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = '/foo/temp'
         mock_os_path_isfile.return_value = False
@@ -296,7 +296,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     def test_generate_command_asgi_settings_pre_existing_input_exit(self, mock_os_path_isfile, mock_env,
                                                                     mock_input, mock_exit, mock_write_warning,
                                                                     mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_args.overwrite = False
@@ -324,7 +324,7 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.os.path.isfile')
     def test_generate_command_asgi_settings_pre_existing_overwrite(self, mock_os_path_isfile, mock_file, mock_env,
                                                                    mock_write_info):
-        mock_args = mock.MagicMock()
+        mock_args = mock.MagicMock(conda_prefix=False)
         mock_args.type = GEN_ASGI_SERVICE_OPTION
         mock_args.directory = None
         mock_args.overwrite = True
@@ -370,6 +370,7 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_os_path_isfile.assert_called_once()
         mock_file.assert_called()
 
+    @mock.patch('tethys_cli.gen_commands.os.path.join')
     @mock.patch('tethys_cli.gen_commands.write_info')
     @mock.patch('tethys_cli.gen_commands.Template')
     @mock.patch('tethys_cli.gen_commands.safe_load')
@@ -378,12 +379,13 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.os.path.isfile')
     @mock.patch('tethys_cli.gen_commands.print')
     def test_generate_command_metayaml(self, mock_print, mock_os_path_isfile, mock_file, mock_run_command,
-                                       mock_load, mock_Template, mock_write_info):
+                                       mock_load, mock_Template, _, mock_os_path_join):
         mock_args = mock.MagicMock()
         mock_args.type = GEN_META_YAML_OPTION
         mock_args.directory = None
         mock_args.pin_level = 'minor'
         mock_os_path_isfile.return_value = False
+        mock_os_path_join.return_value = "conda.recipe"
         stdout = '# packages in environment at /home/nswain/miniconda/envs/tethys:\n' \
                  '#\n' \
                  '# Name                    Version                   Build  Channel\n' \
@@ -393,7 +395,6 @@ class CLIGenCommandsTest(unittest.TestCase):
         mock_run_command.return_value = (stdout, '', 0)
         mock_load.return_value = {'dependencies': ['foo', 'bar=4.5', 'goo']}
         mock_Template().render.return_value = 'out'
-
         generate_command(args=mock_args)
 
         mock_run_command.assert_any_call('list', 'foo')
@@ -411,8 +412,8 @@ class CLIGenCommandsTest(unittest.TestCase):
             ]
         }
         self.assertDictEqual(expected_context, render_context)
-
         mock_file.assert_called()
+        mock_os_path_join.assert_called()
 
     @mock.patch('tethys_cli.gen_commands.write_info')
     @mock.patch('tethys_cli.gen_commands.derive_version_from_conda_environment')

--- a/tests/unit_tests/test_tethys_cli/test_install_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_install_commands.py
@@ -489,7 +489,7 @@ class TestInstallServicesCommands(TestCase):
 
     @mock.patch('tethys_cli.cli_colors.pretty_output')
     def test_run_services_path_none(self, mock_pretty_output):
-        args = mock.MagicMock(services_file=None, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(services_file=None, no_db_sync=False, only_dependencies=False, without_dependencies=False)
 
         self.mock_path.exists.return_value = False
 
@@ -502,7 +502,8 @@ class TestInstallServicesCommands(TestCase):
     @mock.patch('tethys_cli.cli_colors.pretty_output')
     @mock.patch('tethys_cli.install_commands.open_file')
     def test_run_services(self, mock_open_file, mock_pretty_output, _):
-        args = mock.MagicMock(services_file='services_file', only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(services_file='services_file', no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
 
         self.mock_path.exists.return_value = True
         mock_open_file.side_effect = ['service_file', '']
@@ -532,7 +533,8 @@ class TestInstallCommands(TestCase):
     @mock.patch('tethys_cli.install_commands.exit')
     @mock.patch('tethys_cli.install_commands.call')
     def test_install_file_not_generate(self, mock_call, mock_exit, _, __):
-        args = mock.MagicMock(file=None, quiet=False, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(file=None, quiet=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
 
         mock_exit.side_effect = SystemExit
 
@@ -546,7 +548,8 @@ class TestInstallCommands(TestCase):
     @mock.patch('tethys_cli.install_commands.call')
     @mock.patch('tethys_cli.install_commands.exit')
     def test_install_file_generate(self, mock_exit, mock_call, _, __):
-        args = mock.MagicMock(file=None, quiet=False, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(file=None, quiet=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
         check_call = ['tethys', 'gen', 'install']
 
         mock_exit.side_effect = SystemExit
@@ -561,16 +564,18 @@ class TestInstallCommands(TestCase):
     @mock.patch('tethys_cli.cli_colors.pretty_output')
     def test_no_conda_input_file(self, mock_pretty_output, mock_exit, _, __):
         file_path = os.path.join(self.root_app_path, 'install-no-dep.yml')
-        args = mock.MagicMock(file=file_path, verbose=False, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(file=file_path, verbose=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
         mock_exit.side_effect = SystemExit
 
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
-        self.assertIn("Running application install....", po_call_args[0][0][0])
-        self.assertIn("Quiet mode: No additional service setting validation will be performed.", po_call_args[1][0][0])
-        self.assertIn("Services Configuration Completed.", po_call_args[2][0][0])
-        self.assertIn("Skipping syncstores.", po_call_args[3][0][0])
+        self.assertEqual("Installing dependencies...", po_call_args[0][0][0])
+        self.assertIn("Running application install....", po_call_args[1][0][0])
+        self.assertIn("Quiet mode: No additional service setting validation will be performed.", po_call_args[2][0][0])
+        self.assertIn("Services Configuration Completed.", po_call_args[3][0][0])
+        self.assertIn("Skipping syncstores.", po_call_args[4][0][0])
         mock_exit.assert_called_with(0)
 
     @mock.patch('tethys_cli.install_commands.run_services')
@@ -579,18 +584,21 @@ class TestInstallCommands(TestCase):
     @mock.patch('tethys_cli.cli_colors.pretty_output')
     def test_input_file_with_post(self, mock_pretty_output, mock_exit, _, __):
         file_path = os.path.join(self.root_app_path, 'install-with-post.yml')
-        args = mock.MagicMock(file=file_path, verbose=False, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(file=file_path, verbose=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
         mock_exit.side_effect = SystemExit
 
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
-        self.assertIn("Running application install....", po_call_args[1][0][0])
-        self.assertIn("Quiet mode: No additional service setting validation will be performed.", po_call_args[2][0][0])
-        self.assertIn("Services Configuration Completed.", po_call_args[3][0][0])
-        self.assertIn("Skipping syncstores.", po_call_args[4][0][0])
-        self.assertIn("Running post installation tasks...", po_call_args[5][0][0])
-        self.assertIn("Post Script Result: b'test\\n'", po_call_args[6][0][0])
+        self.assertEqual("Installing dependencies...", po_call_args[0][0][0])
+        self.assertEqual("Skipping package installation, Skip option found.", po_call_args[1][0][0])
+        self.assertIn("Running application install....", po_call_args[2][0][0])
+        self.assertIn("Quiet mode: No additional service setting validation will be performed.", po_call_args[3][0][0])
+        self.assertIn("Services Configuration Completed.", po_call_args[4][0][0])
+        self.assertIn("Skipping syncstores.", po_call_args[5][0][0])
+        self.assertIn("Running post installation tasks...", po_call_args[6][0][0])
+        self.assertIn("Post Script Result: b'test\\n'", po_call_args[7][0][0])
         mock_exit.assert_called_with(0)
 
     @mock.patch('tethys_cli.install_commands.run_services')
@@ -605,18 +613,21 @@ class TestInstallCommands(TestCase):
         file_path = os.path.join(self.root_app_path, 'install-skip-setup.yml')
         mock_exit.side_effect = SystemExit
 
-        args = mock.MagicMock(file=file_path, verbose=False, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(file=file_path, verbose=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
-        args = mock.MagicMock(file=file_path, develop=False, only_dependencies=False, without_dependencies=False)
+        args = mock.MagicMock(file=file_path, develop=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
         args = mock.MagicMock(file=file_path, verbose=False, develop=False, force_services=False, quiet=False,
-                              no_sync=False, only_dependencies=False, without_dependencies=False)
+                              no_sync_stores=False, no_db_sync=False, only_dependencies=False,
+                              without_dependencies=False)
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
-        self.assertEqual("Skipping package installation, Skip option found.", po_call_args[0][0][0])
+        self.assertEqual("Skipping package installation, Skip option found.", po_call_args[1][0][0])
         mock_exit.assert_called_with(0)
 
     @mock.patch('tethys_cli.install_commands.run_services')
@@ -627,7 +638,7 @@ class TestInstallCommands(TestCase):
     def test_conda_and_pip_package_install(self, mock_pretty_output, mock_exit, mock_conda_run, mock_call, _):
         file_path = os.path.join(self.root_app_path, 'install-dep.yml')
         args = mock.MagicMock(file=file_path, develop=False, verbose=False, services_file=None, update_installed=False,
-                              only_dependencies=False, without_dependencies=False)
+                              no_db_sync=False, only_dependencies=False, without_dependencies=False)
         mock_exit.side_effect = SystemExit
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
@@ -635,13 +646,14 @@ class TestInstallCommands(TestCase):
                                           use_exception_handler=False, stdout=None, stderr=None)
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
-        self.assertEqual("Running conda installation tasks...", po_call_args[0][0][0])
-        self.assertIn("Warning: Packages installation ran into an error.", po_call_args[1][0][0])
-        self.assertEqual("Running pip installation tasks...", po_call_args[2][0][0])
-        self.assertEqual("Running application install....", po_call_args[3][0][0])
+        self.assertEqual("Installing dependencies...", po_call_args[0][0][0])
+        self.assertEqual("Running conda installation tasks...", po_call_args[1][0][0])
+        self.assertIn("Warning: Packages installation ran into an error.", po_call_args[2][0][0])
+        self.assertEqual("Running pip installation tasks...", po_call_args[3][0][0])
+        self.assertEqual("Running application install....", po_call_args[4][0][0])
         self.assertEqual("Quiet mode: No additional service setting validation will be performed.",
-                         po_call_args[4][0][0])
-        self.assertEqual("Services Configuration Completed.", po_call_args[5][0][0])
+                         po_call_args[5][0][0])
+        self.assertEqual("Services Configuration Completed.", po_call_args[6][0][0])
 
         self.assertEqual(['pip', 'install', 'see'], mock_call.mock_calls[0][1][0])
         self.assertEqual(['python', 'setup.py', 'clean', '--all'], mock_call.mock_calls[1][1][0])
@@ -658,7 +670,7 @@ class TestInstallCommands(TestCase):
     def test_without_dependencies(self, mock_pretty_output, mock_exit, mock_conda_run, mock_call, _):
         file_path = os.path.join(self.root_app_path, 'install-dep.yml')
         args = mock.MagicMock(file=file_path, develop=False, verbose=False, services_file=None, update_installed=False,
-                              only_dependencies=False, without_dependencies=True)
+                              no_db_sync=False, only_dependencies=False, without_dependencies=True)
         mock_exit.side_effect = SystemExit
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
@@ -670,11 +682,11 @@ class TestInstallCommands(TestCase):
 
         # Validate output displayed to the user
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
-        self.assertEqual("Skipping package installation.", po_call_args[0][0][0])
-        self.assertEqual("Running application install....", po_call_args[1][0][0])
+        self.assertEqual("Skipping package installation.", po_call_args[1][0][0])
+        self.assertEqual("Running application install....", po_call_args[2][0][0])
         self.assertEqual("Quiet mode: No additional service setting validation will be performed.",
-                         po_call_args[2][0][0])
-        self.assertEqual("Services Configuration Completed.", po_call_args[3][0][0])
+                         po_call_args[3][0][0])
+        self.assertEqual("Services Configuration Completed.", po_call_args[4][0][0])
 
         # Verify that the application install still happens
         self.assertEqual(['python', 'setup.py', 'clean', '--all'], mock_call.mock_calls[0][1][0])
@@ -692,7 +704,7 @@ class TestInstallCommands(TestCase):
                                                              mock_call, _):
         file_path = os.path.join(self.root_app_path, 'install-dep.yml')
         args = mock.MagicMock(file=file_path, develop=False, verbose=False, services_file=None, update_installed=False,
-                              only_dependencies=True, without_dependencies=False)
+                              no_db_sync=False, only_dependencies=True, without_dependencies=False)
         mock_exit.side_effect = SystemExit
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
@@ -700,10 +712,11 @@ class TestInstallCommands(TestCase):
                                           use_exception_handler=False, stdout=None, stderr=None)
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
-        self.assertEqual("Running conda installation tasks...", po_call_args[0][0][0])
-        self.assertIn("Warning: Packages installation ran into an error.", po_call_args[1][0][0])
-        self.assertEqual("Running pip installation tasks...", po_call_args[2][0][0])
-        self.assertEqual("Installed dependencies only. Skipping remaining installation.", po_call_args[3][0][0])
+        self.assertEqual("Installing dependencies...", po_call_args[0][0][0])
+        self.assertEqual("Running conda installation tasks...", po_call_args[1][0][0])
+        self.assertIn("Warning: Packages installation ran into an error.", po_call_args[2][0][0])
+        self.assertEqual("Running pip installation tasks...", po_call_args[3][0][0])
+        self.assertEqual("Successfully installed dependencies for test_app.", po_call_args[4][0][0])
 
         self.assertEqual(1, len(mock_call.mock_calls))
         self.assertEqual(['pip', 'install', 'see'], mock_call.mock_calls[0][1][0])
@@ -719,7 +732,7 @@ class TestInstallCommands(TestCase):
                                                             mock_call, _):
         file_path = os.path.join(self.root_app_path, 'install-dep.yml')
         args = mock.MagicMock(file=file_path, develop=False, verbose=False, services_file=None, update_installed=True,
-                              only_dependencies=False, without_dependencies=False)
+                              no_db_sync=True, only_dependencies=False, without_dependencies=False)
         mock_exit.side_effect = SystemExit
         self.assertRaises(SystemExit, install_commands.install_command, args)
 
@@ -727,20 +740,18 @@ class TestInstallCommands(TestCase):
                                           stdout=None, stderr=None)
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
+        self.assertEqual("Installing dependencies...", po_call_args[0][0][0])
         self.assertEqual("Warning: Updating previously installed packages. This could break your Tethys environment.",
-                         po_call_args[0][0][0])
-        self.assertEqual("Running conda installation tasks...", po_call_args[1][0][0])
-        self.assertIn("Warning: Packages installation ran into an error.", po_call_args[2][0][0])
-        self.assertEqual("Running pip installation tasks...", po_call_args[3][0][0])
-        self.assertEqual("Running application install....", po_call_args[4][0][0])
-        self.assertEqual("Quiet mode: No additional service setting validation will be performed.",
-                         po_call_args[5][0][0])
-        self.assertEqual("Services Configuration Completed.", po_call_args[6][0][0])
+                         po_call_args[1][0][0])
+        self.assertEqual("Running conda installation tasks...", po_call_args[2][0][0])
+        self.assertIn("Warning: Packages installation ran into an error.", po_call_args[3][0][0])
+        self.assertEqual("Running pip installation tasks...", po_call_args[4][0][0])
+        self.assertEqual("Running application install....", po_call_args[5][0][0])
+        self.assertEqual("Successfully installed test_app.", po_call_args[6][0][0])
 
         self.assertEqual(['pip', 'install', 'see'], mock_call.mock_calls[0][1][0])
         self.assertEqual(['python', 'setup.py', 'clean', '--all'], mock_call.mock_calls[1][1][0])
         self.assertEqual(['python', 'setup.py', 'install'], mock_call.mock_calls[2][1][0])
-        self.assertEqual(['tethys', 'db', 'sync'], mock_call.mock_calls[3][1][0])
 
         mock_exit.assert_called_with(0)
 

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -249,7 +249,7 @@ def create_ps_database_setting(app_package, name, description='', required=False
     except Exception as e:
         print(e)
         with pretty_output(FG_RED) as p:
-            p.write('The above error was encountered. Aborted.'.format(app_package))
+            p.write('The above error was encountered. Aborted.')
         return False
 
 

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -161,7 +161,7 @@ def purge_db_server(**kwargs):
     stop_db_server(**kwargs)
     if kwargs['db_dir']:
         write_error("This action will permanently delete the database. DATA WILL BE LOST!")
-        response = 'y' if kwargs['no_confirmation'] else input(f"Are you sure you want to continue? [y/N]: ")
+        response = 'y' if kwargs['no_confirmation'] else input("Are you sure you want to continue? [y/N]: ")
         if response.lower() in ['y', 'yes']:
             shutil.rmtree(kwargs['db_dir'])
 

--- a/tethys_cli/docker_commands.py
+++ b/tethys_cli/docker_commands.py
@@ -886,7 +886,7 @@ def log_pull_stream(stream):
     """
     if platform.system() == 'Windows':  # i.e. can't uses curses
         for block in stream:
-            lines = [l for l in block.split(b'\r\n') if l]
+            lines = [line for line in block.split(b'\r\n') if line]
             for line in lines:
                 json_line = json.loads(line)
                 current_id = "{}:".format(json_line['id']) if 'id' in json_line else ''
@@ -918,7 +918,7 @@ def log_pull_stream(stream):
 
         try:
             for block in stream:
-                lines = [l for l in block.split(b'\r\n') if l]
+                lines = [line for line in block.split(b'\r\n') if line]
                 for line in lines:
                     json_line = json.loads(line)
                     current_id = json_line['id'] if 'id' in json_line else None

--- a/tethys_cli/gen_commands.py
+++ b/tethys_cli/gen_commands.py
@@ -73,12 +73,14 @@ def add_gen_parser(subparsers):
                             help='Populate the client_max_body_size parameter for nginx config. Defaults to "75M".')
     gen_parser.add_argument('--asgi-processes', dest='asgi_processes',
                             help='The maximum number of asgi worker processes. Defaults to 4.')
+    gen_parser.add_argument('--conda-prefix', dest='conda_prefix',
+                            help='The path to the Tethys conda environment. Required if $CONDA_PREFIX is not defined.')
     gen_parser.add_argument('--tethys-port', dest='tethys_port',
                             help='Port for the Tethys Server to run on in production. This is used when generating the '
                                  'Daphne and nginx configuration files. Defaults to 8000.')
     gen_parser.add_argument('--overwrite', dest='overwrite', action='store_true',
                             help='Overwrite existing file without prompting.')
-    gen_parser.set_defaults(func=generate_command, client_max_body_size='75M', asgi_processes=4,
+    gen_parser.set_defaults(func=generate_command, client_max_body_size='75M', asgi_processes=4, conda_prefix=False,
                             tethys_port=8000, overwrite=False, pin_level='none')
 
 
@@ -128,7 +130,7 @@ def gen_asgi_service(args):
                     nginx_user = tokens[1].strip(';')
                     break
 
-    conda_prefix = get_environment_value('CONDA_PREFIX')
+    conda_prefix = args.conda_prefix if args.conda_prefix else get_environment_value('CONDA_PREFIX')
     conda_home = Path(conda_prefix).parents[1]
 
     user_option_prefix = ''

--- a/tethys_gizmos/templatetags/tethys_gizmos.py
+++ b/tethys_gizmos/templatetags/tethys_gizmos.py
@@ -123,9 +123,9 @@ def isstring(value):
 
 
 @register.filter
-def return_item(l, i):
+def return_item(container, i):
     try:
-        return l[i]
+        return container[i]
     except Exception:
         return None
 


### PR DESCRIPTION
* Adds additional options to run.sh script to allow it to be run in different modes (no daemon, test, etc.) to facilitate testing.
* Adds --no-db-sync option to the install command to allow for installing apps without the database sync portion (helpful in Docker builds that have no database)
* Adds pre_tethys.sls and post_app.sls scripts and simplifies tethyscore.sls, accordingly.
    * pre_tethys.sls - syncs persisted configuration files that have been persisted in tethys_persist directory to appropriate locations
    * post_app.sls - persists configuration files and runs post app installation steps (collectstatic and collectworkspaces)