### PR TITLE
Tweaks to MFA Recent Implementation

### DIFF
--- a/docs/tethys_portal/configuration.rst
+++ b/docs/tethys_portal/configuration.rst
@@ -155,9 +155,9 @@ The following is a list of keys that can be added to the :file:`portal_config.ym
 
   * **MFA_CONFIG**:
 
-    * **MFA_REQUIRED**: Are users required to set up MFA to be able to use the Tethys portal. Defaults to False.
-    * **ADMIN_MFA_REQUIRED**: Are admin (staff) users required to set up MFA when MFA_REQUIRED is True. Defaults to True.
-    * **SSO_MFA_REQUIRED**: Are users logged in with SSO required to set up MFA when MFA_REQUIRED is True. Defaults to False.
+    * **MFA_REQUIRED**: Are users required to set up MFA to be able to use the Tethys portal. Defaults to ``False``.
+    * **ADMIN_MFA_REQUIRED**: Are admin (staff) users required to set up MFA when MFA_REQUIRED is ``True``. Defaults to ``True``.
+    * **SSO_MFA_REQUIRED**: Are users logged in with SSO required to set up MFA when MFA_REQUIRED is ``True``. Defaults to ``False``.
     * **MFA_RECHECK**: Allow random rechecking of the user.
     * **MFA_RECHECK_MIN**: Minimum recheck interval in seconds.
     * **MFA_RECHECK_MAX**: Maximum recheck interval in seconds.
@@ -206,7 +206,7 @@ The following is a list of keys that can be added to the :file:`portal_config.ym
 
     * **AXES_ENABLED**: Disabled when ``DEBUG`` is on, and enabled when ``DEBUG`` is off.
     * **AXES_FAILURE_LIMIT**: Number of failed login attempts to allow before locking. Default ``3``.
-    * **AXES_COOLOFF_TIME**: Time to elapse before locked user is allowed to attempt logging in again. Default is 30 minutes.
+    * **AXES_COOLOFF_TIME**: Time to elapse before locked user is allowed to attempt logging in again. In the :file:`portal_config.yml` this setting accepts only integers or `ISO 8601 time duration formatted strings <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_ (e.g.: ``"PT30M"``). Default is 30 minutes.
     * **AXES_ONLY_USER_FAILURES**: Only lock based on username and do not lock based on IP when True. Defaults to ``True``.
     * **AXES_ENABLE_ADMIN**: Enable the Django Axes admin interface. Defaults to ``True``.
     * **AXES_VERBOSE**: More logging for Axes when True. Defaults to ``True``.

--- a/docs/tethys_portal/configuration.rst
+++ b/docs/tethys_portal/configuration.rst
@@ -155,13 +155,15 @@ The following is a list of keys that can be added to the :file:`portal_config.ym
 
   * **MFA_CONFIG**:
 
-    * **MFA_REQUIRED**: Is a user required to setup MFA in order to be able to use the Tethys portal.
+    * **MFA_REQUIRED**: Are users required to set up MFA to be able to use the Tethys portal. Defaults to False.
+    * **ADMIN_MFA_REQUIRED**: Are admin (staff) users required to set up MFA when MFA_REQUIRED is True. Defaults to True.
+    * **SSO_MFA_REQUIRED**: Are users logged in with SSO required to set up MFA when MFA_REQUIRED is True. Defaults to False.
     * **MFA_RECHECK**: Allow random rechecking of the user.
     * **MFA_RECHECK_MIN**: Minimum recheck interval in seconds.
     * **MFA_RECHECK_MAX**: Maximum recheck interval in seconds.
     * **MFA_QUICKLOGIN**: Allow quick login for returning users by provide only their 2FA.
-    * **TOKEN_ISSUER_NAME**: TOTP Issuer name.
-    * **MFA_UNALLOWED_METHODS**: A list of MFA methods to be disallowed.
+    * **TOKEN_ISSUER_NAME**: TOTP Issuer name to display in the app. Defaults to ``Tethys Portal``.
+    * **MFA_UNALLOWED_METHODS**: A list of MFA methods to be disallowed. Valid methods are include ``U2F``, ``FIDO2``, ``Email``, ``Trusted_Devices``, and ``TOTP``. All but ``TOPT`` are disabled by default.
 
   * **ANALYTICS_CONFIG**: the Django Analytical configuration settings for enabling analytics services on the Tethys Portal (see: `Enabling Services - Django Analytical <https://django-analytical.readthedocs.io/en/latest/install.html#enabling-the-services>`_. The following is a list of settings for some of the supported services that can be enabled.
 

--- a/docs/tethys_portal/configuration.rst
+++ b/docs/tethys_portal/configuration.rst
@@ -204,13 +204,13 @@ The following is a list of keys that can be added to the :file:`portal_config.ym
 
     * **AXES_ENABLED**: Disabled when ``DEBUG`` is on, and enabled when ``DEBUG`` is off.
     * **AXES_FAILURE_LIMIT**: Number of failed login attempts to allow before locking. Default ``3``.
-    * **AXES_COOLOFF_TIME**: Time to elapse before locked user is allowed to attempt logging in again. Default 30 minutes.
-    * **AXES_ONLY_USER_FAILURES**: Only lock based on username and do not lock based on IP when True. Defaults to ``False``.
+    * **AXES_COOLOFF_TIME**: Time to elapse before locked user is allowed to attempt logging in again. Default is 30 minutes.
+    * **AXES_ONLY_USER_FAILURES**: Only lock based on username and do not lock based on IP when True. Defaults to ``True``.
     * **AXES_ENABLE_ADMIN**: Enable the Django Axes admin interface. Defaults to ``True``.
-    * **AXES_LOCKOUT_TEMPLATE**: Template to render when user is locked out. Defaults to ``'tethys_portal/accounts/lockout.html'``
     * **AXES_VERBOSE**: More logging for Axes when True. Defaults to ``True``.
-    * **AXES_RESET_ON_SUCCESS**: Successful login will reset the number of failed logins when True. Defaults to ``True``.
-    * **AXES_LOGGER**: The logger Axes to use. Defaults to ``'tethys.watch_login'``.
+    * **AXES_RESET_ON_SUCCESS**: Successful login (after the cooloff time has passed) will reset the number of failed logins when True. Defaults to ``True``.
+    * **AXES_LOCKOUT_TEMPLATE**: Template to render when user is locked out. Defaults to ``'tethys_portal/accounts/lockout.html'``
+    * **AXES_LOGGER**: The logger for Django Axes to use. Defaults to ``'tethys.watch_login'``.
 
   * **CHANNEL_LAYERS**: the Django Channels `CHANNEL_LAYERS <https://channels.readthedocs.io/en/latest/topics/channel_layers.html#channel-layers>`_ setting.
 

--- a/tests/unit_tests/test_tethys_portal/test_middleware.py
+++ b/tests/unit_tests/test_tethys_portal/test_middleware.py
@@ -341,12 +341,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user()
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for all users
         mock_redirect.assert_called_once_with('mfa_home')
@@ -358,12 +358,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(with_sso=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for all users
         mock_redirect.assert_called_once_with('mfa_home')
@@ -375,12 +375,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(is_staff=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for all users
         mock_redirect.assert_called_once_with('mfa_home')
@@ -392,12 +392,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = False
         mock_settings.SSO_MFA_REQUIRED = False
         mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user()
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required
         mock_redirect.assert_not_called()
@@ -409,12 +409,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = False
         mock_settings.SSO_MFA_REQUIRED = False
         mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(with_sso=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required
         mock_redirect.assert_not_called()
@@ -426,12 +426,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = False
         mock_settings.SSO_MFA_REQUIRED = False
         mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(is_staff=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required
         mock_redirect.assert_not_called()
@@ -443,12 +443,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = False
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user()
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required for all users user
         mock_redirect.assert_not_called()
@@ -460,12 +460,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = False
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(with_sso=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required for all users user
         mock_redirect.assert_not_called()
@@ -477,12 +477,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = False
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(is_staff=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required for all users user
         mock_redirect.assert_not_called()
@@ -494,12 +494,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = False
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user()
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for non-sso users
         mock_redirect.assert_called_once_with('mfa_home')
@@ -511,12 +511,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = False
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(with_sso=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required for SSO user
         mock_redirect.assert_not_called()
@@ -528,12 +528,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = False
         mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(is_staff=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for admins/staff user
         mock_redirect.assert_called_once_with('mfa_home')
@@ -545,12 +545,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user()
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for non admin/staff user
         mock_redirect.assert_called_once_with('mfa_home')
@@ -562,12 +562,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(with_sso=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # required for sso users
         mock_redirect.assert_called_once_with('mfa_home')
@@ -579,12 +579,12 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_get_response = mock.MagicMock()
         mock_request = self.mock_request_with_user(with_sso=True)
 
         mock_has_mfa.return_value = False
 
-        obj = TethysMfaRequiredMiddleware(mock_request)
-        obj.__call__(mock_request)
+        TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
         # not required for admin/staff user
         mock_redirect.assert_not_called()
@@ -597,6 +597,7 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = False
         mock_has_mfa.return_value = False
+        mock_get_response = mock.MagicMock()
 
         excluded_paths = [
             '/',
@@ -611,8 +612,7 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
 
         for path in excluded_paths:
             mock_request = self.mock_request_with_user(path=path)
-            obj = TethysMfaRequiredMiddleware(mock_request)
-            obj.__call__(mock_request)
+            TethysMfaRequiredMiddleware(mock_get_response)(mock_request)
 
             # do not react on these paths
             mock_redirect.assert_not_called()

--- a/tests/unit_tests/test_tethys_portal/test_middleware.py
+++ b/tests/unit_tests/test_tethys_portal/test_middleware.py
@@ -323,16 +323,296 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
 
         self.assertEqual(mock_404.call_args_list[0][0][1], PermissionDenied)
 
+    @staticmethod
+    def mock_request_with_user(path='/apps', with_sso=False, is_staff=False):
+        """
+        Build a mock request with a mock user.
+        """
+        mock_request = mock.MagicMock(path=path)
+        mock_request.user = mock.MagicMock()
+        mock_request.user(is_staff=is_staff)
+        mock_request.user.social_auth.count = mock.MagicMock(return_value=1 if with_sso else 0)
+        return mock_request
+
     @mock.patch('tethys_portal.middleware.redirect')
     @mock.patch('tethys_portal.middleware.has_mfa')
     @mock.patch('tethys_portal.middleware.settings')
-    def test_mfa_required(self, mock_settings, mock_has_mfa, mock_redirect):
+    def test_mfa_required_all_true__normal_user(self, mock_settings, mock_has_mfa, mock_redirect):
         mock_settings.MFA_REQUIRED = True
-        mock_request = mock.MagicMock()
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user()
 
         mock_has_mfa.return_value = False
 
         obj = TethysMfaRequiredMiddleware(mock_request)
         obj.__call__(mock_request)
 
+        # required for all users
         mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required_all_true__sso_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user(with_sso=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # required for all users
+        mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required_all_true__staff_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user(is_staff=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # required for all users
+        mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__all_false__normal_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = False
+        mock_settings.SSO_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_request = self.mock_request_with_user()
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__all_false__sso_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = False
+        mock_settings.SSO_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_request = self.mock_request_with_user(with_sso=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__all_false__staff_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = False
+        mock_settings.SSO_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_request = self.mock_request_with_user(is_staff=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__mfa_required_false__normal_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = False
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user()
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required for all users user
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__mfa_required_false__sso_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = False
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user(with_sso=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required for all users user
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__mfa_required_false__staff_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = False
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user(is_staff=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required for all users user
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__sso_mfa_required_false__normal_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user()
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # required for non-sso users
+        mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__sso_mfa_required_false__sso_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user(with_sso=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required for SSO user
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__sso_mfa_required_false__staff_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = True
+        mock_request = self.mock_request_with_user(is_staff=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # required for admins/staff user
+        mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__admin_mfa_required_false__normal_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_request = self.mock_request_with_user()
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # required for non admin/staff user
+        mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__admin_mfa_required_false__sso_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_request = self.mock_request_with_user(with_sso=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # required for sso users
+        mock_redirect.assert_called_once_with('mfa_home')
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required__admin_mfa_required_false__admin_user(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_request = self.mock_request_with_user(with_sso=True)
+
+        mock_has_mfa.return_value = False
+
+        obj = TethysMfaRequiredMiddleware(mock_request)
+        obj.__call__(mock_request)
+
+        # not required for admin/staff user
+        mock_redirect.assert_not_called()
+
+    @mock.patch('tethys_portal.middleware.redirect')
+    @mock.patch('tethys_portal.middleware.has_mfa')
+    @mock.patch('tethys_portal.middleware.settings')
+    def test_mfa_required_excluded_paths(self, mock_settings, mock_has_mfa, mock_redirect):
+        mock_settings.MFA_REQUIRED = True
+        mock_settings.SSO_MFA_REQUIRED = True
+        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_has_mfa.return_value = False
+
+        excluded_paths = [
+            '/',
+            '/accounts/login/',
+            '/accounts/logout/',
+            '/oath2/foo/',
+            '/user/bar/',
+            '/captcha/jar/',
+            '/devices/123/',
+            '/mfa/add/'
+        ]
+
+        for path in excluded_paths:
+            mock_request = self.mock_request_with_user(path=path)
+            obj = TethysMfaRequiredMiddleware(mock_request)
+            obj.__call__(mock_request)
+
+            # do not react on these paths
+            mock_redirect.assert_not_called()

--- a/tests/unit_tests/test_tethys_portal/test_middleware.py
+++ b/tests/unit_tests/test_tethys_portal/test_middleware.py
@@ -329,8 +329,7 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         Build a mock request with a mock user.
         """
         mock_request = mock.MagicMock(path=path)
-        mock_request.user = mock.MagicMock()
-        mock_request.user(is_staff=is_staff)
+        mock_request.user = mock.MagicMock(is_staff=is_staff)
         mock_request.user.social_auth.count = mock.MagicMock(return_value=1 if with_sso else 0)
         return mock_request
 
@@ -580,7 +579,7 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
         mock_settings.SSO_MFA_REQUIRED = True
         mock_settings.ADMIN_MFA_REQUIRED = False
         mock_get_response = mock.MagicMock()
-        mock_request = self.mock_request_with_user(with_sso=True)
+        mock_request = self.mock_request_with_user(is_staff=True)
 
         mock_has_mfa.return_value = False
 
@@ -595,7 +594,7 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
     def test_mfa_required_excluded_paths(self, mock_settings, mock_has_mfa, mock_redirect):
         mock_settings.MFA_REQUIRED = True
         mock_settings.SSO_MFA_REQUIRED = True
-        mock_settings.ADMIN_MFA_REQUIRED = False
+        mock_settings.ADMIN_MFA_REQUIRED = True
         mock_has_mfa.return_value = False
         mock_get_response = mock.MagicMock()
 
@@ -603,7 +602,7 @@ class TethysPortalMiddlewareTests(unittest.TestCase):
             '/',
             '/accounts/login/',
             '/accounts/logout/',
-            '/oath2/foo/',
+            '/oauth2/foo/',
             '/user/bar/',
             '/captcha/jar/',
             '/devices/123/',

--- a/tests/unit_tests/test_tethys_portal/test_settings.py
+++ b/tests/unit_tests/test_tethys_portal/test_settings.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from importlib import reload
 from unittest import mock, TestCase
 from tethys_portal import settings
@@ -65,10 +66,22 @@ class TestSettings(TestCase):
         self.assertEqual(settings.MFA_REQUIRED, True)
 
     @mock.patch('tethys_portal.settings.yaml.safe_load',
-                return_value={'settings': {'LOCKOUT_CONFIG': {'AXES_ENABLED': True}}})
-    def test_lockout_config(self, _):
+                return_value={'settings': {'LOCKOUT_CONFIG': {'AXES_COOLOFF_TIME': 1}}})
+    def test_lockout_config__cooloff_int(self, _):
         reload(settings)
-        self.assertEqual(settings.AXES_ENABLED, True)
+        self.assertEqual(settings.AXES_COOLOFF_TIME, 1)
+
+    @mock.patch('tethys_portal.settings.yaml.safe_load',
+                return_value={'settings': {'LOCKOUT_CONFIG': {'AXES_COOLOFF_TIME': 'PT45M'}}})
+    def test_lockout_config__cooloff_iso_str(self, _):
+        reload(settings)
+        self.assertEqual(settings.AXES_COOLOFF_TIME, dt.timedelta(minutes=45))
+
+    @mock.patch('tethys_portal.settings.yaml.safe_load',
+                return_value={'settings': {'LOCKOUT_CONFIG': {'AXES_COOLOFF_TIME': 'foo'}}})
+    def test_lockout_config__cooloff_bad_str(self, _):
+        reload(settings)
+        self.assertEqual(settings.AXES_COOLOFF_TIME, 'foo')
 
     @mock.patch('tethys_portal.settings.yaml.safe_load',
                 return_value={'settings': {'SESSION_CONFIG': {'SESSION_EXPIRES_AT_BROWSER_CLOSE': True}}})

--- a/tethys_portal/middleware.py
+++ b/tethys_portal/middleware.py
@@ -90,13 +90,13 @@ class TethysMfaRequiredMiddleware():
         sso_mfa_required = getattr(settings, 'SSO_MFA_REQUIRED', False)
         admin_mfa_required = getattr(settings, 'ADMIN_MFA_REQUIRED', True)
 
-        # Override MFA_REQUIRED setting for staff users
-        if mfa_required and not admin_mfa_required and request.user.is_staff:
-            mfa_required = False
-
         # Override MFA_REQUIRED setting for users logged in with SSO
         has_social_auth_attr = getattr(request.user, 'social_auth', None) is not None
         if mfa_required and not sso_mfa_required and has_social_auth_attr and request.user.social_auth.count() > 0:
+            mfa_required = False
+
+        # Override MFA_REQUIRED setting for staff users
+        if mfa_required and not admin_mfa_required and request.user.is_staff:
             mfa_required = False
 
         if mfa_required and not has_mfa(request, request.user.username):

--- a/tethys_portal/middleware.py
+++ b/tethys_portal/middleware.py
@@ -86,13 +86,27 @@ class TethysMfaRequiredMiddleware():
         self.get_response = get_response
 
     def __call__(self, request):
-        mfa_required = False
-        if hasattr(settings, 'MFA_REQUIRED'):
-            mfa_required = settings.MFA_REQUIRED is True
+        mfa_required = getattr(settings, 'MFA_REQUIRED', False)
+        sso_mfa_required = getattr(settings, 'SSO_MFA_REQUIRED', False)
+        admin_mfa_required = getattr(settings, 'ADMIN_MFA_REQUIRED', True)
+
+        # Override MFA_REQUIRED setting for staff users
+        if mfa_required and not admin_mfa_required and request.user.is_staff:
+            mfa_required = False
+
+        # Override MFA_REQUIRED setting for users logged in with SSO
+        has_social_auth_attr = getattr(request.user, 'social_auth', None) is not None
+        if mfa_required and not sso_mfa_required and has_social_auth_attr and request.user.social_auth.count() > 0:
+            mfa_required = False
 
         if mfa_required and not has_mfa(request, request.user.username):
-            if '/mfa' not in request.path and request.path != '/' \
-                    and request.path != '/accounts/login/' and request.path != '/accounts/logout/':
+            if '/mfa' not in request.path \
+                    and '/devices' not in request.path \
+                    and '/oauth2' not in request.path \
+                    and '/accounts' not in request.path \
+                    and '/user' not in request.path \
+                    and '/captcha' not in request.path \
+                    and request.path != '/':
                 messages.error(request, 'You must configure Multi Factor Authentication to continue.')
                 return redirect('mfa_home')
 

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -357,9 +357,13 @@ AXES_RESET_ON_SUCCESS = True
 
 LOCKOUT_CONFIG = portal_config_settings.pop('LOCKOUT_CONFIG', {})
 for setting, value in LOCKOUT_CONFIG.items():
-    if setting == 'LOCKOUT_CONFIG':
-        print(setting)
-        print(value)
+    if setting == 'AXES_COOLOFF_TIME' and isinstance(value, str):
+        import isodate
+        try:
+            value = isodate.parse_duration(value)
+        except Exception:
+            pass
+
     setattr(this_module, setting, value)
 
 # Django Guardian Settings

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -320,7 +320,9 @@ for setting, value in OAUTH_CONFIG.items():
 # MFA Settings
 # See: https://github.com/mkalioby/django-mfa2
 # Methods that shouldn't be allowed for the user, U2F, FIDO2, TOTP, Trusted_Devices, Email
-MFA_REQUIRED = False
+MFA_REQUIRED = False                # Require all users to set up MFA
+SSO_MFA_REQUIRED = False            # Require users logged in with SSO to set up MFA when MFA_REQUIRED is True
+ADMIN_MFA_REQUIRED = True           # Require admin users to set up MFA when MFA_REQUIRED is True
 MFA_UNALLOWED_METHODS = ('U2F', 'FIDO2', 'Email', 'Trusted_Devices')
 # A function that should be called by username to login the user in session
 MFA_LOGIN_CALLBACK = 'tethys_portal.utilities.log_user_in'
@@ -355,6 +357,9 @@ AXES_RESET_ON_SUCCESS = True
 
 LOCKOUT_CONFIG = portal_config_settings.pop('LOCKOUT_CONFIG', {})
 for setting, value in LOCKOUT_CONFIG.items():
+    if setting == 'LOCKOUT_CONFIG':
+        print(setting)
+        print(value)
     setattr(this_module, setting, value)
 
 # Django Guardian Settings

--- a/tethys_portal/templates/mfa_email_token_template.html
+++ b/tethys_portal/templates/mfa_email_token_template.html
@@ -1,1 +1,1 @@
-<p>Hello {{ user.username }},</p><p>Here is your one time passcode: <strong>{{ otp }}</strong></p>
+<p>Here is the one time passcode you requested: <strong>{{ otp }}</strong></p>

--- a/tethys_portal/templates/registration/password_reset_email.html
+++ b/tethys_portal/templates/registration/password_reset_email.html
@@ -1,16 +1,13 @@
 {% autoescape off %}
 You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.
 
-Please go to the following page and choose a new password:
+Please use the following link to reset your password:
 {% block reset_link %}
 {% endblock %}
 
 {{ protocol }}://{{ domain }}{% url 'accounts:password_confirm' uidb64=uid token=token %}
 
-
-Your username, in case you've forgotten: {{ user.username }}
-
-Thanks for using our site!
+Thank you for using our site!
 
 The {{ site_name }} team.
 


### PR DESCRIPTION
- Allow users to authenticate with SSO when MFA_REQUIRED is enabled but they don't have MFA enabled yet.
- Allow users to view and edit their User profile when MFA_REQUIRED is enabled but they don't have MFA enabled yet.
- Allow captcha URLs to work when MFA_REQUIRED is enabled but MFA isn't enabled yet.
- Adds two additional settings to allow for customization of MFA_REQUIRED behavior:
    - SSO_MFA_REQUIRED - when True, requires users logged in with SSO to enable MFA when MFA_REQUIRED is True. Defaults to False.
    - ADMIN_MFA_REQUIRED - when True, admin/staff users are required to enable MFA when MFA_REQUIRED is True. Defaults to True.
- Fixes a Typo in the documentation (default value of AXES_ONLY_USER_FAILURES was wrong).
- Removes the username from the email templates to comply with security best practices. This includes the forgotten password and OTP email templates.
- Adds support for ISO 8601 formatted duration strings for the AXES_COOLOFF_TIME setting.