### PR TITLE
Changes to MFA_REQUIRED to Account for Token Authenticated API Calls

### DIFF
--- a/tethys_portal/middleware.py
+++ b/tethys_portal/middleware.py
@@ -9,14 +9,15 @@
 """
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.exceptions import AuthenticationFailed
 from mfa.helpers import has_mfa
 from social_django.middleware import SocialAuthExceptionMiddleware
 from social_core import exceptions as social_exceptions
 from tethys_cli.cli_colors import pretty_output, FG_WHITE
-
 from tethys_apps.utilities import get_active_app, user_can_access_app
-from django.core.exceptions import PermissionDenied
 from tethys_portal.views.error import handler_404
 
 
@@ -89,6 +90,16 @@ class TethysMfaRequiredMiddleware():
         mfa_required = getattr(settings, 'MFA_REQUIRED', False)
         sso_mfa_required = getattr(settings, 'SSO_MFA_REQUIRED', False)
         admin_mfa_required = getattr(settings, 'ADMIN_MFA_REQUIRED', True)
+
+        # Override MFA_REQUIRED setting for API Token authentication
+        if mfa_required and 'Authorization' in request.headers and TokenAuthentication.keyword in request.headers['Authorization']:
+            # Verify Token
+            try:
+                ta = TokenAuthentication()
+                ta.authenticate(request)
+                mfa_required = False
+            except AuthenticationFailed:
+                pass
 
         # Override MFA_REQUIRED setting for users logged in with SSO
         has_social_auth_attr = getattr(request.user, 'social_auth', None) is not None

--- a/tethys_portal/middleware.py
+++ b/tethys_portal/middleware.py
@@ -92,7 +92,8 @@ class TethysMfaRequiredMiddleware():
         admin_mfa_required = getattr(settings, 'ADMIN_MFA_REQUIRED', True)
 
         # Override MFA_REQUIRED setting for API Token authentication
-        if mfa_required and 'Authorization' in request.headers and TokenAuthentication.keyword in request.headers['Authorization']:
+        if mfa_required and 'Authorization' in request.headers \
+                and TokenAuthentication.keyword in request.headers['Authorization']:
             # Verify Token
             try:
                 ta = TokenAuthentication()

--- a/tethys_portal/templates/tethys_portal/user/profile.html
+++ b/tethys_portal/templates/tethys_portal/user/profile.html
@@ -93,7 +93,11 @@
             <li>
               <span class="parameter">Token:</span>
               {% if user.username == context_user.username %}
+                {% if mfa_required and has_mfa %}
                 <span class="value">{{ user_token }}</span>
+                {% else %}
+                <span class="value">Enable 2-Step verification to view token</span>
+                {% endif %}
               {% else %}
                 <span class="label label-info">Private</span>
               {% endif %}

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -104,8 +104,8 @@ def settings(request, username=None):
                'user_token': user_token.key,
                'current_use': current_use,
                'quota': quota,
-                'has_mfa': has_mfa(username=request.user.username, request=request),
-                'mfa_required': getattr(django_settings, 'MFA_REQUIRED', False),
+               'has_mfa': has_mfa(username=request.user.username, request=request),
+               'mfa_required': getattr(django_settings, 'MFA_REQUIRED', False),
                }
 
     return render(request, 'tethys_portal/user/settings.html', context)

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -34,6 +34,7 @@ def profile(request, username=None):
     # The profile should display information about the user that is given in the url.
     # However, the template will hide certain information if the username is not the same
     # as the username of the user that is accessing the page.
+    from django.conf import settings as django_settings
     context_user = User.objects.get(username=username)
     user_token, token_created = Token.objects.get_or_create(user=context_user)
     codename = 'user_workspace_quota'
@@ -47,7 +48,8 @@ def profile(request, username=None):
         'user_token': user_token.key,
         'current_use': current_use,
         'quota': quota,
-        'has_mfa': has_mfa(username=request.user.username, request=request)
+        'has_mfa': has_mfa(username=request.user.username, request=request),
+        'mfa_required': getattr(django_settings, 'MFA_REQUIRED', False)
     }
     return render(request, 'tethys_portal/user/profile.html', context)
 
@@ -58,6 +60,7 @@ def settings(request, username=None):
     """
     Handle the settings view. Access to change settings are not publicly accessible
     """
+    from django.conf import settings as django_settings
     # Get the user object from model
     request_user = request.user
 
@@ -102,6 +105,8 @@ def settings(request, username=None):
                'user_token': user_token.key,
                'current_use': current_use,
                'quota': quota,
+                'has_mfa': has_mfa(username=request.user.username, request=request),
+                'mfa_required': getattr(django_settings, 'MFA_REQUIRED', False),
                }
 
     return render(request, 'tethys_portal/user/settings.html', context)

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -7,6 +7,7 @@
 * License: BSD 2-Clause
 ********************************************************************************
 """
+from django.conf import settings as django_settings
 from django.shortcuts import render, redirect
 from tethys_sdk.permissions import login_required
 from django.contrib.auth.models import User
@@ -34,7 +35,6 @@ def profile(request, username=None):
     # The profile should display information about the user that is given in the url.
     # However, the template will hide certain information if the username is not the same
     # as the username of the user that is accessing the page.
-    from django.conf import settings as django_settings
     context_user = User.objects.get(username=username)
     user_token, token_created = Token.objects.get_or_create(user=context_user)
     codename = 'user_workspace_quota'
@@ -60,7 +60,6 @@ def settings(request, username=None):
     """
     Handle the settings view. Access to change settings are not publicly accessible
     """
-    from django.conf import settings as django_settings
     # Get the user object from model
     request_user = request.user
 


### PR DESCRIPTION
* Don't redirect to the MFA configuration screen if MFA is required and a valid API token is used in the request.
* Hide API token on user profile until MFA is setup when MFA is required.