### PR TITLE
CHANNEL_LAYERS documentation + ASGI processes default 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,10 @@ RUN /bin/bash -c '. ${CONDA_HOME}/bin/activate ${CONDA_ENV_NAME} \
   ; tethys gen portal_config'
 RUN mkdir -p ${TETHYS_PERSIST} ${APPS_ROOT} ${WORKSPACE_ROOT} ${STATIC_ROOT}
 
+# Install channel-redis
+RUN /bin/bash -c '. ${CONDA_HOME}/bin/activate ${CONDA_ENV_NAME} \
+  ; pip install channels_redis'
+
 ############
 # CLEAN UP #
 ############

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ ENV  DEBUG="False" \
      DJANGO_ANALYTICAL="\"{}\"" \
      ADD_BACKENDS="\"[]\"" \
      OAUTH_OPTIONS="\"{}\"" \
-     CHANNEL_LAYER="channels.layers.InMemoryChannelLayer" \
+     CHANNEL_LAYERS_BACKEND="channels.layers.InMemoryChannelLayer" \
+     CHANNEL_LAYERS_CONFIG="\"{}\"" \
      RECAPTCHA_PRIVATE_KEY="" \
      RECAPTCHA_PUBLIC_KEY=""
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV  TETHYS_HOME="/usr/lib/tethys" \
 ENV  BASH_PROFILE=".bashrc" \
      CONDA_HOME="/opt/conda" \
      CONDA_ENV_NAME=tethys \
-     ASGI_PROCESSES=4 \
+     ASGI_PROCESSES=1 \
      CLIENT_MAX_BODY_SIZE="75M"
 
 # Tethys settings arguments
@@ -41,7 +41,7 @@ ENV  DEBUG="False" \
      DJANGO_ANALYTICAL="\"{}\"" \
      ADD_BACKENDS="\"[]\"" \
      OAUTH_OPTIONS="\"{}\"" \
-     CHANNEL_LAYER="" \
+     CHANNEL_LAYER="channels.layers.InMemoryChannelLayer" \
      RECAPTCHA_PRIVATE_KEY="" \
      RECAPTCHA_PUBLIC_KEY=""
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     environment:
       TETHYS_DB_SUPERUSER: "tethys_super"
       TETHYS_DB_SUPERUSER_PASS: "pass"
-      ASGI_PROCESSES: 4
       CLIENT_MAX_BODY_SIZE: "75M"
     links:
       - db

--- a/docker/salt/tethyscore.sls
+++ b/docker/salt/tethyscore.sls
@@ -30,11 +30,8 @@
 {% set DJANGO_ANALYTICAL = salt['environ.get']('DJANGO_ANALYTICAL') %}
 {% set ADD_BACKENDS = salt['environ.get']('ADD_BACKENDS') %}
 {% set OAUTH_OPTIONS = salt['environ.get']('OAUTH_OPTIONS') %}
-{% if salt['environ.get']('CHANNEL_LAYER') %}
-{% set CHANNEL_LAYER = salt['environ.get']('CHANNEL_LAYER') %}
-{% else %}
-{% set CHANNEL_LAYER = "''" %}
-{% endif %}
+{% set CHANNEL_LAYERS_BACKEND = salt['environ.get']('CHANNEL_LAYERS_BACKEND') %}
+{% set CHANNEL_LAYERS_CONFIG = salt['environ.get']('CHANNEL_LAYERS_CONFIG') %}
 {% if salt['environ.get']('RECAPTCHA_PRIVATE_KEY') %}
 {% set RECAPTCHA_PRIVATE_KEY = salt['environ.get']('RECAPTCHA_PRIVATE_KEY') %}
 {% else %}
@@ -89,7 +86,8 @@ Generate_Tethys_Settings_TethysCore:
         --set ANALYTICS_CONFIG {{ DJANGO_ANALYTICAL }}
         --set AUTHENTICATION_BACKENDS {{ ADD_BACKENDS }}
         --set OAUTH_CONFIG {{ OAUTH_OPTIONS }}
-        --set CHANNEL_LAYERS.default.BACKEND {{ CHANNEL_LAYER }}
+        --set CHANNEL_LAYERS.default.BACKEND {{ CHANNEL_LAYERS_BACKEND }}
+        --set CHANNEL_LAYERS.default.CONFIG {{ CHANNEL_LAYERS_CONFIG }}
         --set CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY {{ RECAPTCHA_PRIVATE_KEY }}
         --set CAPTCHA_CONFIG.RECAPTCHA_PUBLIC_KEY {{ RECAPTCHA_PUBLIC_KEY }}
     - unless: /bin/bash -c "[ -f "{{ TETHYS_PERSIST }}/setup_complete" ];"

--- a/docs/installation/production/additional/official_docker.rst
+++ b/docs/installation/production/additional/official_docker.rst
@@ -101,7 +101,6 @@ A more convenient way is to use a docker-compose.yml file to build and run the i
         environment:
           TETHYS_DB_SUPERUSER: "tethys_super"
           TETHYS_DB_SUPERUSER_PASS: "pass"
-          ASGI_PROCESSES: 4
           CLIENT_MAX_BODY_SIZE: "75M"
         links:
           - db
@@ -180,7 +179,7 @@ Tethys uses environment variables to build and initialize the app. These are the
 +---------------------------+------------------------------------------------------------------------------------------+
 | CONDA_ENV_NAME            | Name of conda environment. Defaults to tethys.                                           |
 +---------------------------+------------------------------------------------------------------------------------------+
-| ASGI_PROCESSES            | The maximum number of asgi worker processes. Defaults to 4.                              |
+| ASGI_PROCESSES            | The maximum number of asgi worker processes. Defaults to 1.                              |
 +---------------------------+------------------------------------------------------------------------------------------+
 | CLIENT_MAX_BODY_SIZE      | client_max_body_size parameter for nginx config. Defaults to 75M.                        |
 +---------------------------+------------------------------------------------------------------------------------------+
@@ -313,9 +312,9 @@ You can overwrite the environment variable of the tethys base image in your app 
 
 ::
 
-    ENV ASGI_PROCESSES 1
+    ENV ASGI_PROCESSES 4
 
-This line in your docker file will change the environment variable ASGI_PROCESSES from the default value of 4 to 1.
+This line in your docker file will change the environment variable ASGI_PROCESSES from the default value of 1 to 4.
 
 Here is an example of a dockerfile from a tethys app:
 

--- a/docs/installation/production/additional/official_docker.rst
+++ b/docs/installation/production/additional/official_docker.rst
@@ -224,7 +224,9 @@ Tethys uses environment variables to build and initialize the app. These are the
 |                           | Defaults to "\"{}}\"" (Empty).                                                           |
 |                           | Tethys Portal. See OATH_CONFIGS in :ref:`tethys_configuration`                           |
 +---------------------------+------------------------------------------------------------------------------------------+
-| CHANNEL_LAYER             | the Django Channel Layers Backend. Default to "channels.layers.InMemoryChannelLayer"     |
+| CHANNEL_LAYERS_BACKEND    | the Django Channel Layers backend. Default to "channels.layers.InMemoryChannelLayer"     |
++---------------------------+------------------------------------------------------------------------------------------+
+| CHANNEL_LAYERS_CONFIG     | the Django Channel Layers configuration if a layer other than the default is being used. |
 +---------------------------+------------------------------------------------------------------------------------------+
 | RECAPTCHA_PRIVATE_KEY     | Private key for Google ReCaptcha. Required to enable ReCaptcha on the login screen.      |
 |                           | See RECAPTCHA_PRIVATE_KEY in :ref:`tethys_configuration`                                 |
@@ -348,7 +350,8 @@ Here is an example of a dockerfile from a tethys app:
     # PRODUCTION ENVIRONMENT VARIABLES
     ##################################
     ENV ASGI_PROCESSES 1
-    ENV CHANNEL_LAYER "channels_redis.core.RedisChannelLayer"
+    ENV CHANNEL_LAYERS_BACKEND "channels_redis.core.RedisChannelLayer"
+    ENV CHANNEL_LAYERS_CONFIG "\"{\"hosts\": [[127.0.0.1, 6379]]}\""
 
     #########
     # SETUP #

--- a/docs/installation/production/additional/official_docker.rst
+++ b/docs/installation/production/additional/official_docker.rst
@@ -344,6 +344,12 @@ Here is an example of a dockerfile from a tethys app:
     ENV APP_DB_PASSWORD ${TETHYS_DB_PASSWORD}
     ENV CONDORPY_HOME ${TETHYS_HOME}/tethys
 
+    ##################################
+    # PRODUCTION ENVIRONMENT VARIABLES
+    ##################################
+    ENV ASGI_PROCESSES 1
+    ENV CHANNEL_LAYER "channels_redis.core.RedisChannelLayer"
+
     #########
     # SETUP #
     #########

--- a/docs/installation/production/configuration.rst
+++ b/docs/installation/production/configuration.rst
@@ -39,3 +39,4 @@ These guides describe additional configuration that you can perform to add more 
     configuration/advanced/social_auth
     configuration/advanced/multi_factor_auth
     configuration/advanced/webanalytics
+    configuration/advanced/django_channels_layer

--- a/docs/installation/production/configuration/advanced/django_channels_layer.rst
+++ b/docs/installation/production/configuration/advanced/django_channels_layer.rst
@@ -12,11 +12,11 @@ A ``CHANNEL_LAYER`` provides a backend where ``WebSocket`` messages can be store
 
 Adding a REDIS CHANNEL_LAYER
 ============================
-Development installations make use of the default ``InMemoryChannelLayer``, however this layer is not meant for production (See `Django Channels documentation <https://channels.readthedocs.io/en/latest/topics/channel_layers.html#in-memory-channel-layer>`_). For production purposes, ``Django Channels`` suppports a ``REDIS CHANNEL LAYER``, however other ``CHANNEL_LAYERS`` can be configured. The following documentation demonstrates how to configure a ``REDIS CHANNEL LAYER``.
+Development installations make use of the default ``InMemoryChannelLayer``, however this layer has some limitations in production (See `Django Channels documentation <https://channels.readthedocs.io/en/latest/topics/channel_layers.html#in-memory-channel-layer>`_). To address these limitations, ``Django Channels`` suppports a ``REDIS CHANNEL LAYER``, however other ``CHANNEL_LAYERS`` can be configured. The following documentation demonstrates how to configure a ``REDIS CHANNEL LAYER``.
 
 First, install the ``channels_redis`` Python package in your Tethys conda environment.
 
-..
+::
 
     pip install channels_redis
 
@@ -33,16 +33,64 @@ Second, add or modify the ``CHANNEL_LAYERS`` parameter in the ``portal_config.ym
 
 Finally, start a redis instance. This can easily be done with docker as shown below.
 
-..
+::
 
     docker run -p 6379:6379 -d redis:5
 
-Once the ``CHANNEL_LAYER`` has been configured, the number of ``ASGI_PROCESSES`` can be increased as in the example below:
+Once a production ``CHANNEL_LAYER`` has been configured, the number of ``ASGI_PROCESSES`` can be increased as in the example below:
 
-..
+::
 
     tethys gen asgi_service --asgi-processes <desired_number_of_instances> --conda-prefix <path_to_tethys_conda_environment>
 
-.. note::
+.. warning::
 
-    If using a Docker image, the ``CHANNEL_LAYER`` and ``ASGI_PROCESSES`` parameters can be set on the ``Dockerfile``.
+    ``Bokeh Server`` does not currently support the use of multi intance processes. Therefore, it does not work with more than one ASGI process (``ASGI_PROCESSES`` must be equal to 1) (See `Bokeh Server documentation <https://docs.bokeh.org/en/latest/docs/reference/server/server.html#bokeh.server.server.Server>`_).
+
+
+With Tethys Docker
+------------------
+
+If using Tethys Docker, the ``CHANNEL_LAYER`` and ``ASGI_PROCESSES`` parameters can be set on the ``Dockerfile`` or ``docker-compose``. Below is an example of how to set these variables in a ``Dockerfile``.
+
+::
+
+    ENV ASGI_PROCESSES 1
+    ENV CHANNEL_LAYER "channels_redis.core.RedisChannelLayer"
+
+To configure redis this way, add the following to docker-compose at the same level as the other containters (db, geoserver, etc.):
+
+.. code-block:: yaml
+
+    redis:
+      image: redis:5
+      restart: always
+      networks:
+        - "internal"
+      ports:
+        - "6379:6379"
+
+Finally, add the following code at the beginning of ``tethys_app.sls``
+
+.. code-block:: yaml
+
+    {% set CHANNEL_LAYER = salt['environ.get']('CHANNEL_LAYER') %}
+    {% set ASGI_PROCESSES = salt['environ.get']('ASGI_PROCESSES') %}
+
+
+    Insert_Redis_Channel_Layer:
+      cmd.run:
+        - name: >
+            {{TETHYS_BIN_DIR }}/tethys settings
+            --set CHANNEL_LAYERS.default.BACKEND {{ CHANNEL_LAYER }}
+            --set CHANNEL_LAYERS.default.CONFIG.hosts "[[docker_redis_1,6379],]"
+        - unless: /bin/bash -c "[ -f "{{ TETHYS_PERSIST }}/portal_config.yml" ];"
+
+    Regenerate_ASGI_Service_TethysCore:
+      cmd.run:
+        - name: >
+            {{TETHYS_BIN_DIR }}/tethys gen asgi_service
+            --asgi-processes {{ ASGI_PROCESSES }}
+            --conda-prefix {{ CONDA_HOME }}/envs/{{ CONDA_ENV_NAME }}
+            --overwrite
+        - unless: /bin/bash -c "[ -f "{{ TETHYS_PERSIST }}/portal_config.yml" ];"

--- a/docs/installation/production/configuration/advanced/django_channels_layer.rst
+++ b/docs/installation/production/configuration/advanced/django_channels_layer.rst
@@ -1,0 +1,42 @@
+********************************
+Django Channels Layer (Optional)
+********************************
+
+**Last Updated:** Sep 2020
+
+Production installations that use the ``WebSockets`` and/or ``Bokeh Server`` functionality that comes with Tethys, require the a ``CHANNEL_LAYER``.
+
+Key Concepts
+============
+A ``CHANNEL_LAYER`` provides a backend where ``WebSocket`` messages can be stored and then accessed by  different app instances (ASGI processes).
+
+Adding a REDIS CHANNEL_LAYER
+============================
+Development installations make use of the default ``InMemoryChannelLayer``, however this layer is not meant for production (See `Django Channels documentation <https://channels.readthedocs.io/en/latest/topics/channel_layers.html#in-memory-channel-layer>`_). For production purposes, ``Django Channels`` suppports a ``REDIS CHANNEL LAYER``, however other ``CHANNEL_LAYERS`` can be configured. The following documentation demonstrates how to configure a ``REDIS CHANNEL LAYER``.
+
+First, install the ``channels_redis`` Python package in your Tethys conda environment.
+
+..
+
+    pip install channels_redis
+
+Second, add or modify the ``CHANNEL_LAYERS`` parameter in the ``portal_config.yml`` as follows:
+
+.. code-block:: yaml
+
+    CHANNEL_LAYERS:
+      default:
+        BACKEND: channels_redis.core.RedisChannelLayer
+        CONFIG:
+          hosts:
+          - [127.0.0.1, 6379]
+
+Once the ``CHANNEL_LAYER`` has been configured, the number of ``ASGI_PROCESSES`` can be increased as in the example below:
+
+..
+
+    tethys gen asgi_service --asgi-processes <desired_number_of_instances> --conda-prefix <path_to_tethys_conda_environment>
+
+.. note::
+
+    If using a Docker image, the ``CHANNEL_LAYER``, ``CHANNEL_LAYER_CONFIG``, and ``ASGI_PROCESSES`` parameters can be set on the ``Dockerfile``.

--- a/docs/installation/production/configuration/advanced/django_channels_layer.rst
+++ b/docs/installation/production/configuration/advanced/django_channels_layer.rst
@@ -31,6 +31,12 @@ Second, add or modify the ``CHANNEL_LAYERS`` parameter in the ``portal_config.ym
           hosts:
           - [127.0.0.1, 6379]
 
+Finally, start a redis instance. This can easily be done with docker as shown below.
+
+..
+
+    docker run -p 6379:6379 -d redis:5
+
 Once the ``CHANNEL_LAYER`` has been configured, the number of ``ASGI_PROCESSES`` can be increased as in the example below:
 
 ..
@@ -39,4 +45,4 @@ Once the ``CHANNEL_LAYER`` has been configured, the number of ``ASGI_PROCESSES``
 
 .. note::
 
-    If using a Docker image, the ``CHANNEL_LAYER``, ``CHANNEL_LAYER_CONFIG``, and ``ASGI_PROCESSES`` parameters can be set on the ``Dockerfile``.
+    If using a Docker image, the ``CHANNEL_LAYER`` and ``ASGI_PROCESSES`` parameters can be set on the ``Dockerfile``.

--- a/docs/tutorials/websockets.rst
+++ b/docs/tutorials/websockets.rst
@@ -139,7 +139,7 @@ b. ``Channel layers`` require a backend to store the ``WebSocket messages`` comi
     ``Django Channels`` recommends the use of an external backend store for production environments. The ``channels-redis`` python package plus ``Redis Server`` are the default recommendation. For more information see ``Django Channels`` `channel layers <https://channels.readthedocs.io/en/latest/topics/channel_layers.html>`_ and `deploying <https://channels.readthedocs.io/en/latest/deploying.html>`_ sections.
 
 .. tip::
-    A ``Channel layer`` can be added to the `settings` section of the :file:`portal_config.yml` by manually editing the file or by running ``tethys settings --set CHANNEL_LAYERS.default.BACKEND <<CHANNEL_LAYER>>`` where ``<<CHANNEL_LAYER>>`` is the python dot-formatted path of the channel layer. See :ref:`tethys_configuration` for details.
+    A ``Channel layer`` can be added to the `settings` section of the :file:`portal_config.yml` by manually editing the file or by running ``tethys settings --set CHANNEL_LAYERS.default.BACKEND <<CHANNEL_LAYERS_BACKEND>>`` where ``<<CHANNEL_LAYERS_BACKEND>>`` is the python dot-formatted path of the channel layer. See :ref:`tethys_configuration` for details.
 
 Channel Layer Definitions
 -------------------------

--- a/tests/unit_tests/test_tethys_cli/test__init__.py
+++ b/tests/unit_tests/test_tethys_cli/test__init__.py
@@ -120,7 +120,7 @@ class TethysCommandTests(unittest.TestCase):
     @mock.patch('tethys_cli.gen_commands.generate_command')
     def test_generate_subcommand_nginx_settings_verbose_options(self, mock_gen_command):
         testargs = ['tethys', 'gen', 'nginx', '-d', '/tmp/foo/bar', '--client-max-body-size', '123M',
-                    '--asgi-processes', '4', '--conda-prefix', '/path/to/conda/env', '--tethys-port', '8080',
+                    '--asgi-processes', '1', '--conda-prefix', '/path/to/conda/env', '--tethys-port', '8080',
                     '--overwrite']
 
         with mock.patch.object(sys, 'argv', testargs):
@@ -132,7 +132,7 @@ class TethysCommandTests(unittest.TestCase):
         self.assertEqual('/tmp/foo/bar', call_args[0][0][0].directory)
         self.assertTrue(call_args[0][0][0].overwrite)
         self.assertEqual('nginx', call_args[0][0][0].type)
-        self.assertEqual('4', call_args[0][0][0].asgi_processes)
+        self.assertEqual('1', call_args[0][0][0].asgi_processes)
         self.assertEqual('/path/to/conda/env', call_args[0][0][0].conda_prefix)
         self.assertEqual('8080', call_args[0][0][0].tethys_port)
 

--- a/tethys_cli/gen_commands.py
+++ b/tethys_cli/gen_commands.py
@@ -72,7 +72,7 @@ def add_gen_parser(subparsers):
     gen_parser.add_argument('--client-max-body-size', dest='client_max_body_size',
                             help='Populate the client_max_body_size parameter for nginx config. Defaults to "75M".')
     gen_parser.add_argument('--asgi-processes', dest='asgi_processes',
-                            help='The maximum number of asgi worker processes. Defaults to 4.')
+                            help='The maximum number of asgi worker processes. Defaults to 1.')
     gen_parser.add_argument('--conda-prefix', dest='conda_prefix',
                             help='The path to the Tethys conda environment. Required if $CONDA_PREFIX is not defined.')
     gen_parser.add_argument('--tethys-port', dest='tethys_port',
@@ -80,7 +80,7 @@ def add_gen_parser(subparsers):
                                  'Daphne and nginx configuration files. Defaults to 8000.')
     gen_parser.add_argument('--overwrite', dest='overwrite', action='store_true',
                             help='Overwrite existing file without prompting.')
-    gen_parser.set_defaults(func=generate_command, client_max_body_size='75M', asgi_processes=4, conda_prefix=False,
+    gen_parser.set_defaults(func=generate_command, client_max_body_size='75M', asgi_processes=1, conda_prefix=False,
                             tethys_port=8000, overwrite=False, pin_level='none')
 
 


### PR DESCRIPTION
Added channel layer documentation
- InMemoryChannelLayer should be mainly used in dev
- RedisChannelLayer is the reconmmended one for production

Changed default ASGI processes parameter to 1. No point on having it be 4 when the InMemoryLayer doesn't support more than 1. This and how to set up the a redis layer are the main things explained in the documentation.