### PR TITLE
Fix for Issue 592

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_admin.py
+++ b/tests/unit_tests/test_tethys_apps/test_admin.py
@@ -254,6 +254,17 @@ class TestTethysAppAdmin(unittest.TestCase):
         mock_ua_add_view.assert_called()
         self.assertNotIn(UserQuotasSettingInline, ret.inlines)
 
+        # Repeat to complete full cycle (change -> add -> change -> add)
+        # Add custom inline when change_view is called
+        ret.change_view(mock.MagicMock())
+        mock_ua_change_view.assert_called()
+        self.assertIn(UserQuotasSettingInline, ret.inlines)
+
+        # Remove custom inline when change_view is called
+        ret.add_view(mock.MagicMock())
+        mock_ua_add_view.assert_called()
+        self.assertNotIn(UserQuotasSettingInline, ret.inlines)
+
         # Check registration
         registry = admin.site._registry
         self.assertIn(User, registry)

--- a/tests/unit_tests/test_tethys_apps/test_admin.py
+++ b/tests/unit_tests/test_tethys_apps/test_admin.py
@@ -239,12 +239,22 @@ class TestTethysAppAdmin(unittest.TestCase):
         self.assertFalse(ret.has_add_permission(mock.MagicMock()))
 
     @mock.patch('django.contrib.auth.admin.UserAdmin.change_view')
-    def test_admin_site_register_custom_user(self, mock_user_admin):
+    @mock.patch('django.contrib.auth.admin.UserAdmin.add_view')
+    def test_admin_site_register_custom_user(self, mock_ua_add_view, mock_ua_change_view):
         from django.contrib import admin
         ret = CustomUser(mock.MagicMock(), mock.MagicMock())
+
+        # Add custom inline when change_view is called
         ret.change_view(mock.MagicMock())
-        mock_user_admin.assert_called()
-        self.assertEqual([UserQuotasSettingInline], ret.inlines)
+        mock_ua_change_view.assert_called()
+        self.assertIn(UserQuotasSettingInline, ret.inlines)
+
+        # Remove custom inline when change_view is called
+        ret.add_view(mock.MagicMock())
+        mock_ua_add_view.assert_called()
+        self.assertNotIn(UserQuotasSettingInline, ret.inlines)
+
+        # Check registration
         registry = admin.site._registry
         self.assertIn(User, registry)
         self.assertIsInstance(registry[User], CustomUser)

--- a/tethys_apps/admin.py
+++ b/tethys_apps/admin.py
@@ -140,8 +140,14 @@ class TethysExtensionAdmin(GuardedModelAdmin):
 
 
 class CustomUser(UserAdmin):
+    def add_view(self, *args, **kwargs):
+        if UserQuotasSettingInline in self.inlines:
+            self.inlines.pop(self.inlines.index(UserQuotasSettingInline))
+        return super().add_view(*args, **kwargs)
+
     def change_view(self, *args, **kwargs):
-        self.inlines = [UserQuotasSettingInline]
+        if UserQuotasSettingInline not in self.inlines:
+            self.inlines.append(UserQuotasSettingInline)
         return super().change_view(*args, **kwargs)
 
 

--- a/tethys_quotas/admin.py
+++ b/tethys_quotas/admin.py
@@ -52,7 +52,12 @@ class UserQuotasSettingInline(TethysQuotasSettingInline):
             if not resource_quota.active:
                 return None
 
-            user_id = request.resolver_match.kwargs['object_id']
+            user_id = request.resolver_match.kwargs.get('object_id')
+
+            # new user form case
+            if not user_id:
+                return None
+
             user = User.objects.get(id=user_id)
 
             qs = qs.filter(entity=user)


### PR DESCRIPTION
The issue was caused by how we added the custom Quota's fields to the change/edit User admin form:

```python
class CustomUser(UserAdmin):
    def change_view(self, *args, **kwargs):
        self.inlines = [UserQuotasSettingInline]
        return super().change_view(*args, **kwargs)
```

Changing `self.inlines` for the `change_view` of the `UserAdmin` form permanently changed it for all views including the `add_view`, which would cause the error. I'm guessing this is because `self.inlines` is a class property.

The fix was to remove the `UserQuotasSettingInline` for the `add_view`:

```python
class CustomUser(UserAdmin):
    def add_view(self, *args, **kwargs):
        if UserQuotasSettingInline in self.inlines:
            self.inlines.pop(self.inlines.index(UserQuotasSettingInline))
        return super().add_view(*args, **kwargs)

    def change_view(self, *args, **kwargs):
        if UserQuotasSettingInline not in self.inlines:
            self.inlines.append(UserQuotasSettingInline)
        return super().change_view(*args, **kwargs)
```