### PR TITLE
Jobs Table Bug Fixes

### DIFF
--- a/tethys_gizmos/gizmo_options/jobs_table.py
+++ b/tethys_gizmos/gizmo_options/jobs_table.py
@@ -11,7 +11,6 @@
 from collections import namedtuple
 import logging
 
-from tethys_sdk.jobs import TethysJob
 from tethys_cli.cli_colors import write_warning
 from .base import TethysGizmoOptions
 from .select_input import SelectInput
@@ -203,6 +202,7 @@ class JobsTable(TethysGizmoOptions):
             A list of field values for one row.
 
         """
+        from tethys_compute.models import TethysJob
         row_values = list()
         job_actions = dict()
         for attribute in job_attributes:


### PR DESCRIPTION
* Introducing the TethysJob model import at the module level of the JobsTable causes some issues for our testing. We split our tests into integrated and unittests. Unittests run without needing Tethys started up. However, all of our unittest tests that use a Gizmo of any sort started failing b/c all gizmos are imported in the tethys_sdk.gizmo module.
* I recommend moving TethysJob model import out of module scope in jobs_table.py and into the function scopes where it is used.