### PR TITLE
Simplify/secure CSRF token ajax handling

### DIFF
--- a/tethys_apps/static/tethys_apps/js/app_base.js
+++ b/tethys_apps/static/tethys_apps/js/app_base.js
@@ -299,3 +299,25 @@ var TETHYS_APP_BASE = (function() {
 }()); // End of package wrapper
 // NOTE: that the call operator (open-closed parenthesis) is used to invoke the library wrapper
 // function immediately after being parsed, returning the public interface object.
+
+
+// Global Functions for App Util
+
+/*****************************************************************************
+ *
+ * Cross Site Request Forgery Token Configuration
+ *   copied from (https://docs.djangoproject.com/en/1.7/ref/contrib/csrf/)
+ *
+ *****************************************************************************/
+
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", csrftoken);  // Note csrftoken is defined in app_base.html
+        }
+    }
+});

--- a/tethys_apps/static/tethys_apps/js/app_base.js
+++ b/tethys_apps/static/tethys_apps/js/app_base.js
@@ -35,7 +35,7 @@ var TETHYS_APP_BASE = (function() {
    *                    PRIVATE FUNCTION DECLARATIONS
    *************************************************************************/
    var apply_app_color_theme, app_entry_handler, check_responsive,
-       no_nav_handler, exit_app, toggle_nav;
+       no_nav_handler, exit_app, toggle_nav, csrf_safe_method;
 
 
    /************************************************************************
@@ -196,6 +196,11 @@ var TETHYS_APP_BASE = (function() {
         $(app_content_selector).removeClass('show-app-content');
    };
 
+    csrf_safe_method = function(method) {
+        // these HTTP methods do not require CSRF protection
+        return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+    }
+
   /************************************************************************
    *                        DEFINE PUBLIC INTERFACE
    *************************************************************************/
@@ -247,6 +252,20 @@ var TETHYS_APP_BASE = (function() {
         }, 100);
     };
 
+    /*****************************************************************************
+     *
+     * Cross Site Request Forgery Token Configuration
+     *   copied from (https://docs.djangoproject.com/en/1.7/ref/contrib/csrf/)
+     *
+     *****************************************************************************/
+
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!csrf_safe_method(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader("X-CSRFToken", document.querySelector('[name=csrfmiddlewaretoken]').value);
+            }
+        }
+    });
 
   // Initialization: jQuery function that gets called when
   // the DOM tree finishes loading
@@ -302,22 +321,3 @@ var TETHYS_APP_BASE = (function() {
 
 
 // Global Functions for App Util
-
-/*****************************************************************************
- *
- * Cross Site Request Forgery Token Configuration
- *   copied from (https://docs.djangoproject.com/en/1.7/ref/contrib/csrf/)
- *
- *****************************************************************************/
-
-function csrfSafeMethod(method) {
-    // these HTTP methods do not require CSRF protection
-    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-}
-$.ajaxSetup({
-    beforeSend: function(xhr, settings) {
-        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-            xhr.setRequestHeader("X-CSRFToken", csrftoken);  // Note csrftoken is defined in app_base.html
-        }
-    }
-});

--- a/tethys_apps/static/tethys_apps/js/app_base.js
+++ b/tethys_apps/static/tethys_apps/js/app_base.js
@@ -199,7 +199,7 @@ var TETHYS_APP_BASE = (function() {
     csrf_safe_method = function(method) {
         // these HTTP methods do not require CSRF protection
         return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-    }
+    };
 
   /************************************************************************
    *                        DEFINE PUBLIC INTERFACE
@@ -259,13 +259,17 @@ var TETHYS_APP_BASE = (function() {
      *
      *****************************************************************************/
 
-    $.ajaxSetup({
+    var csrftoken = document.querySelector('[name=csrfmiddlewaretoken]');
+    if(csrftoken){
+          $.ajaxSetup({
         beforeSend: function(xhr, settings) {
             if (!csrf_safe_method(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader("X-CSRFToken", document.querySelector('[name=csrfmiddlewaretoken]').value);
+                xhr.setRequestHeader("X-CSRFToken", csrftoken.value);
             }
         }
-    });
+      });
+    };
+
 
   // Initialization: jQuery function that gets called when
   // the DOM tree finishes loading

--- a/tethys_apps/static/tethys_apps/js/feedback.js
+++ b/tethys_apps/static/tethys_apps/js/feedback.js
@@ -20,29 +20,6 @@ $(document).ready(function(){
   var local_date_time = getDateandTime();
   var username = document.getElementById('page-attributes').getAttribute('data-username');
 
-  function csrfSafeMethod(method) {
-    // these HTTP methods do not require CSRF protection
-    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-  }
-
-  // using jQuery
-  function getCookie(name) {
-    var cookieValue = null;
-    if (document.cookie && document.cookie != '') {
-      var cookies = document.cookie.split(';');
-      for (var i = 0; i < cookies.length; i++) {
-        var cookie = jQuery.trim(cookies[i]);
-        // Does this cookie string begin with the name we want?
-        if (cookie.substring(0, name.length + 1) == (name + '=')) {
-          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-          break;
-        }
-      }
-    }
-    return cookieValue;
-  }
-
-  var csrftoken = getCookie('csrftoken');
   var betamodalform = "<form action='/apps/send-beta-feedback/' method='post' enctype='multipart/form-data' id='uploadBetaFeedback' name='uploadBetaFeedback'>"+
                         "<div class='betaForm'>"+
                           "<div>"+

--- a/tethys_apps/templates/tethys_apps/app_base.html
+++ b/tethys_apps/templates/tethys_apps/app_base.html
@@ -266,6 +266,10 @@
     {% endcomment %}
 
     {% block scripts %}
+      {% csrf_token %}
+      <script>
+        const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+      </script>
       <script src="{% static 'tethys_apps/vendor/cookies.js' %}" type="text/javascript"></script>
       {% block app_base_js %}
         <script src="{% static 'tethys_apps/js/app_base.js' %}" type="text/javascript"></script>

--- a/tethys_apps/templates/tethys_apps/app_base.html
+++ b/tethys_apps/templates/tethys_apps/app_base.html
@@ -254,6 +254,8 @@
       {% gizmo_dependencies css %}
     {% endblock %}
 
+    {% csrf_token %}
+
     {% comment "scripts explanation" %}
       Use this block for adding scripts. Call with block.super to include the default
       scripts.
@@ -266,10 +268,6 @@
     {% endcomment %}
 
     {% block scripts %}
-      {% csrf_token %}
-      <script>
-        const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
-      </script>
       <script src="{% static 'tethys_apps/vendor/cookies.js' %}" type="text/javascript"></script>
       {% block app_base_js %}
         <script src="{% static 'tethys_apps/js/app_base.js' %}" type="text/javascript"></script>

--- a/tethys_apps/templates/tethys_apps/app_base.html
+++ b/tethys_apps/templates/tethys_apps/app_base.html
@@ -254,7 +254,9 @@
       {% gizmo_dependencies css %}
     {% endblock %}
 
-    {% csrf_token %}
+    {% block csrf_token %}
+      {% csrf_token %}
+    {% endblock %}
 
     {% comment "scripts explanation" %}
       Use this block for adding scripts. Call with block.super to include the default

--- a/tethys_gizmos/static/tethys_gizmos/js/jobs_table.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/jobs_table.js
@@ -1,42 +1,5 @@
 /*****************************************************************************
  *
- * Cross Site Request Forgery Token Configuration
- *   copied from (https://docs.djangoproject.com/en/1.7/ref/contrib/csrf/)
- *
- *****************************************************************************/
-
-function getCookie(name) {
-    var cookieValue = null;
-    if (document.cookie && document.cookie != '') {
-        var cookies = document.cookie.split(';');
-        for (var i = 0; i < cookies.length; i++) {
-            var cookie = jQuery.trim(cookies[i]);
-            // Does this cookie string begin with the name we want?
-            if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
-}
-
-var csrftoken = getCookie('csrftoken');
-
-function csrfSafeMethod(method) {
-    // these HTTP methods do not require CSRF protection
-    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-}
-$.ajaxSetup({
-    beforeSend: function(xhr, settings) {
-        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-            xhr.setRequestHeader("X-CSRFToken", csrftoken);
-        }
-    }
-});
-
-/*****************************************************************************
- *
  * Update job status with a timeout while job is still running.
  *
  *****************************************************************************/


### PR DESCRIPTION
This moves the retrieving of the CSRF token from an AJAX call to having be embedded in the page in a script tag. It also moves code from multiple places into the app_base.js file, so it's only in one place.