### PR TITLE
Restrict Open User Profiles

### DIFF
--- a/tests/unit_tests/test_tethys_portal/test_views/test_user.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_user.py
@@ -19,6 +19,7 @@ class TethysPortalUserTests(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @override_settings(OPEN_USER_PROFILES=True)
     @override_settings(MFA_REQUIRED=False)
     @mock.patch('tethys_quotas.utilities.log')
     @mock.patch('tethys_portal.views.user.has_mfa')
@@ -56,6 +57,21 @@ class TethysPortalUserTests(unittest.TestCase):
 
         mock_render.assert_called_with(mock_request, 'tethys_portal/user/profile.html', expected_context)
 
+    @override_settings(OPEN_USER_PROFILES=False)
+    @mock.patch('tethys_portal.views.user.messages')
+    @mock.patch('tethys_portal.views.user.redirect')
+    def test_profile_open_user_profiles_false(self, mock_redirect, mock_messages):
+        mock_request = mock.MagicMock()
+        mock_request.user.username = 'bar'
+
+        username = 'foo'
+
+        profile(mock_request, username)
+
+        mock_messages.warning.assert_called()
+        mock_redirect.assert_called_with('user:profile', username='bar')
+
+    @override_settings(OPEN_USER_PROFILES=True)
     @override_settings(MFA_REQUIRED=False)
     @mock.patch('tethys_quotas.utilities.log')
     @mock.patch('tethys_portal.views.user.has_mfa')
@@ -97,6 +113,7 @@ class TethysPortalUserTests(unittest.TestCase):
 
         mock_token_get_create.assert_called_with(user=mock_context_user)
 
+    @override_settings(OPEN_USER_PROFILES=True)
     @override_settings(MFA_REQUIRED=True)
     @mock.patch('tethys_quotas.utilities.log')
     @mock.patch('tethys_portal.views.user.has_mfa')
@@ -134,6 +151,7 @@ class TethysPortalUserTests(unittest.TestCase):
 
         mock_render.assert_called_with(mock_request, 'tethys_portal/user/profile.html', expected_context)
 
+    @override_settings(OPEN_USER_PROFILES=True)
     @override_settings(MFA_REQUIRED=True)
     @mock.patch('tethys_quotas.utilities.log')
     @mock.patch('tethys_portal.views.user.has_mfa')
@@ -171,6 +189,7 @@ class TethysPortalUserTests(unittest.TestCase):
 
         mock_render.assert_called_with(mock_request, 'tethys_portal/user/profile.html', expected_context)
 
+    @override_settings(OPEN_USER_PROFILES=True)
     @override_settings(MFA_REQUIRED=False)
     @mock.patch('tethys_quotas.utilities.log')
     @mock.patch('tethys_portal.views.user.has_mfa')

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -279,6 +279,8 @@ STATIC_ROOT = TETHYS_PORTAL_CONFIG.pop('STATIC_ROOT', os.path.join(TETHYS_HOME, 
 
 TETHYS_WORKSPACES_ROOT = TETHYS_PORTAL_CONFIG.pop('TETHYS_WORKSPACES_ROOT', os.path.join(TETHYS_HOME, 'workspaces'))
 
+OPEN_USER_PROFILES = TETHYS_PORTAL_CONFIG.pop('OPEN_USER_PROFILES', False)
+
 # add any additional TETHYS_PORTAL_CONFIG settings
 for setting, value in TETHYS_PORTAL_CONFIG.items():
     setattr(this_module, setting, value)

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -10,6 +10,7 @@
 from django.conf import settings as django_settings
 from django.shortcuts import render, redirect
 from tethys_sdk.permissions import login_required
+from django.conf import settings as tethys_settings
 from django.contrib.auth.models import User
 from django.contrib.auth import logout
 from django.contrib import messages
@@ -32,6 +33,12 @@ def profile(request, username=None):
     """
     Handle the profile view. Profiles could potentially be publicly accessible.
     """
+    if not tethys_settings.OPEN_USER_PROFILES:
+        # Users are not allowed to make changes to other users settings
+        if request.user.username != username:
+            messages.warning(request, "You are not allowed to view other users' profiles.")
+            return redirect('user:profile', username=request.user.username)
+
     # The profile should display information about the user that is given in the url.
     # However, the template will hide certain information if the username is not the same
     # as the username of the user that is accessing the page.


### PR DESCRIPTION
Provide a settings option to turn off having open user profiles. If this settings is `False` then when a user tries to go to the URL of another user they will be redirected to their own profile.

![image](https://user-images.githubusercontent.com/6454472/109171532-7e488f80-7747-11eb-81c5-45becd67a455.png)


This provides additional security because it prevents users from being able to figure out other users usernames.