### PR TITLE
Override EXTRA_DATA to include refresh_token

### DIFF
--- a/tethys_services/backends/arcgis_portal.py
+++ b/tethys_services/backends/arcgis_portal.py
@@ -15,6 +15,10 @@ class ArcGISPortalOAuth2(ArcGISOAuth2):
     ArcGISPortal OAuth2 authentication backend.
     """
     name = 'arcgis_portal'
+    EXTRA_DATA = [
+        ('refresh_token', 'refresh_token'),
+        ('expires_in', 'expires_in'),
+    ]
 
     @property
     def PORTAL_URL(self):


### PR DESCRIPTION
The ArcGIS Rest API for OAuth supports using the refresh_token, so it should be included in EXTRA_DATA so that it can be used to refresh a soon-to-be-stale session. See https://developers.arcgis.com/rest/users-groups-and-items/token.htm