### PR TITLE
Add Support for Time-Enabled Layers in Cesium

### DIFF
--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
@@ -109,13 +109,15 @@ class TestMapView(unittest.TestCase):
         source = 'KML'
         legend_title = 'Park City Watershed'
         options = {'url': '/static/tethys_gizmos/data/model.kml'}
+        times = ["20210322T112511Z", "20210322T122511Z", "20210322T132511Z"]
 
-        result = gizmo_map_view.MVLayer(source=source, legend_title=legend_title, options=options)
+        result = gizmo_map_view.MVLayer(source=source, legend_title=legend_title, options=options, times=times)
 
         # Check Result
         self.assertEqual(source, result['source'])
         self.assertEqual(legend_title, result['legend_title'])
         self.assertEqual(options, result['options'])
+        self.assertEqual(times, result['times'])
 
     @mock.patch('tethys_gizmos.gizmo_options.map_view.log.warning')
     def test_MVLayer_warning(self, mock_log):

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -525,7 +525,7 @@ class MVLayer(SecondaryGizmoOptions):
         legend_extent (list): A list of four ordinates representing the extent that will be used on "zoom to layer": [minx, miny, maxx, maxy].
         legend_extent_projection (str): The EPSG projection of the extent coordinates. Defaults to "EPSG:4326".
         data (dict): Dictionary representation of layer data
-        times (list): only for Cesium. List of start time for geoserver image mosaic layers. (e.g.: ["20210322T112511Z", "20210322T122511Z", "20210322T132511Z"])
+        times (list): List of time steps if layer is time-enabled. Times should be represented as strings in ISO 8601 format (e.g.: ["20210322T112511Z", "20210322T122511Z", "20210322T132511Z"]). Currently only supported in CesiumMapView.
     Example
 
     ::

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -525,7 +525,7 @@ class MVLayer(SecondaryGizmoOptions):
         legend_extent (list): A list of four ordinates representing the extent that will be used on "zoom to layer": [minx, miny, maxx, maxy].
         legend_extent_projection (str): The EPSG projection of the extent coordinates. Defaults to "EPSG:4326".
         data (dict): Dictionary representation of layer data
-
+        times (list): only for Cesium. List of start time for geoserver image mosaic layers. (e.g.: ["20210322T112511Z", "20210322T122511Z", "20210322T132511Z"])
     Example
 
     ::
@@ -682,7 +682,7 @@ class MVLayer(SecondaryGizmoOptions):
     def __init__(self, source, options, legend_title, layer_options=None, editable=True,
                  legend_classes=None, legend_extent=None,
                  legend_extent_projection='EPSG:4326',
-                 feature_selection=False, geometry_attribute=None, data=None):
+                 feature_selection=False, geometry_attribute=None, data=None, times=None):
         """
         Constructor
         """
@@ -699,6 +699,7 @@ class MVLayer(SecondaryGizmoOptions):
         self.feature_selection = feature_selection
         self.geometry_attribute = geometry_attribute
         self.data = data or dict()
+        self.times = times
 
         if feature_selection and not geometry_attribute:
             log.warning("geometry_attribute not defined -using default value 'the_geom'")

--- a/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
@@ -235,25 +235,6 @@ var CESIUM_MAP_VIEW = (function() {
                     img_layer['feature_selection'] = curr_layer.feature_selection;
                     img_layer['geometry_attribute'] = curr_layer.geometry_attribute;
                 }
-                else if (curr_layer.source.toLowerCase() == 'geojson') {
-                    let gjson = curr_layer.options;
-                    let dataSourcePromise = Cesium.GeoJsonDataSource.load(gjson).then(function(source_result) {
-                        source_result['tethys_data'] = curr_layer.data;
-                        source_result['legend_title'] = curr_layer.legend_title;
-                        source_result['legend_classes'] = curr_layer.legend_classes;
-                        source_result['legend_extent'] = curr_layer.legend_extent;
-                        source_result['legend_extent_projection'] = curr_layer.legend_extent_projection;
-                        source_result['feature_selection'] = curr_layer.feature_selection;
-                        source_result['geometry_attribute'] = curr_layer.geometry_attribute;
-
-                        if ('layer_options' in curr_layer && curr_layer.layer_options &&
-                            'visible' in curr_layer.layer_options) {
-                            source_result.show = curr_layer.layer_options.visible;
-                        }
-                        return source_result;
-                    });
-                    m_viewer.dataSources.add(dataSourcePromise);
-                }
             } else {
                 var layer_options = cesium_options(curr_layer);
                 for (var layer_option in layer_options) {

--- a/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
@@ -39,7 +39,8 @@ var CESIUM_MAP_VIEW = (function() {
 
     // Utility Methods
     var is_defined, is_empty_or_undefined, in_array, string_to_object, string_to_function, string_w_arg_to_function,
-        build_options, build_options_string, need_to_run, cesium_options, json_parser, clear_data;
+        build_options, build_options_string, need_to_run, cesium_options, json_parser, clear_data,
+        cesium_time_callback;
 
 
  	/************************************************************************
@@ -76,7 +77,6 @@ var CESIUM_MAP_VIEW = (function() {
         // Get view settings from data attribute
         var $map_element = $('#' + m_map_target);
         m_clock = $map_element.data('clock');
-
         if (!is_empty_or_undefined(m_clock))
         {
             // Parse out the Cesium objects
@@ -195,12 +195,37 @@ var CESIUM_MAP_VIEW = (function() {
                     if (curr_layer.options.params.VIEWPARAMS) {
                         parameters.VIEWPARAMS = curr_layer.options.params.VIEWPARAMS;
                     }
+                    if (curr_layer.options.times) {
+                        // times should be in this format "["20210322T112511Z", "20210322T122511Z", "20210323T032511Z"]"
+                        var times = JSON.parse(curr_layer.options.times);
+                        const provider_interval = new Cesium.TimeIntervalCollection.fromIso8601DateArray({
+                            iso8601Dates: JSON.parse(curr_layer.options.times),
+                            dataCallback: cesium_time_callback,
+                        });
 
-                    var tile_wms = new Cesium.WebMapServiceImageryProvider({
-                        url: curr_layer.options.url,
-                        layers: curr_layer.options.params.LAYERS,
-                        parameters: parameters
-                    });
+                        var clock = m_viewer.clock;
+                        var start = Cesium.JulianDate.fromIso8601(times[0])
+                        var stop = Cesium.JulianDate.fromIso8601(times[times.length - 1])
+                        clock.startTime = start;
+                        clock.stopTime = stop;
+                        clock.currentTime = start;
+                        clock.multiplier = 600;
+                        var tile_wms = new Cesium.WebMapServiceImageryProvider({
+                            url: curr_layer.options.url,
+                            layers: curr_layer.options.params.LAYERS,
+                            parameters: parameters,
+                            times: provider_interval,
+                            clock: m_viewer.clock,
+                        });
+                    }
+                    else {
+                        var tile_wms = new Cesium.WebMapServiceImageryProvider({
+                            url: curr_layer.options.url,
+                            layers: curr_layer.options.params.LAYERS,
+                            parameters: parameters,
+                        });
+                        console.log(tile_wms)
+                    }
                     var img_layer = m_viewer.imageryLayers.addImageryProvider(tile_wms);
                     img_layer['tethys_data'] = curr_layer.data;
                     img_layer['legend_title'] = curr_layer.legend_title;
@@ -781,6 +806,12 @@ var CESIUM_MAP_VIEW = (function() {
                 return false;
         }
         return true;
+    }
+
+    cesium_time_callback = function (interval) {
+        return {
+            time: Cesium.JulianDate.toIso8601(interval.start)
+        };
     }
 
 	/************************************************************************

--- a/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
@@ -195,11 +195,11 @@ var CESIUM_MAP_VIEW = (function() {
                     if (curr_layer.options.params.VIEWPARAMS) {
                         parameters.VIEWPARAMS = curr_layer.options.params.VIEWPARAMS;
                     }
-                    if (curr_layer.options.times) {
+                    if (curr_layer.times) {
                         // times should be in this format "["20210322T112511Z", "20210322T122511Z", "20210323T032511Z"]"
-                        var times = JSON.parse(curr_layer.options.times);
+                        var times = JSON.parse(curr_layer.times);
                         const provider_interval = new Cesium.TimeIntervalCollection.fromIso8601DateArray({
-                            iso8601Dates: JSON.parse(curr_layer.options.times),
+                            iso8601Dates: JSON.parse(curr_layer.times),
                             dataCallback: cesium_time_callback,
                         });
 

--- a/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
@@ -806,7 +806,7 @@ var CESIUM_MAP_VIEW = (function() {
         return true;
     }
 
-    cesium_time_callback = function (interval) {
+    cesium_time_callback = function(interval) {
         return {
             time: Cesium.JulianDate.toIso8601(interval.start)
         };


### PR DESCRIPTION
Add support for specifying a list of time steps in the MVLayer to be used to implement animations for time-enabled layers.
Implemented support in the CesiumMapView for now. Not supported in the main MapView as of yet.