### PR TITLE
Add clarifications and fix typos for onelogin SSO instructions

### DIFF
--- a/docs/installation/production/configuration/advanced/social_auth.rst
+++ b/docs/installation/production/configuration/advanced/social_auth.rst
@@ -643,13 +643,13 @@ OneLogin
         .. code-block::
 
             http://<SERVER_DOMAIN_NAME>/login/
-            http://localhost:8000/login/
+            http://localhost:8000/accounts/login/
 
     c. On the SSO tab, set the Token Endpoint Authentication Method to ``POST``.
 
 3. Select the **SSO** tab if you are not on it already and note the ``Client ID`` and ``Client Secret`` for Step 5.
 
-4. Point to **Settings > Account Settings** and note the ``Subdomain`` for step 5.
+4. Point to **Settings > Account Settings** and note the ``Subdomain`` for step 5 (e.g.: https://example.onelogin.com).
 
 5. Add the appropriate settings to the  :file:`portal_config.yml` file using the ``tethys settings`` command:
 

--- a/docs/installation/production/configuration/advanced/social_auth.rst
+++ b/docs/installation/production/configuration/advanced/social_auth.rst
@@ -642,7 +642,7 @@ OneLogin
 
         .. code-block::
 
-            http://<SERVER_DOMAIN_NAME>/login/
+            http://<SERVER_DOMAIN_NAME>/accounts/login/
             http://localhost:8000/accounts/login/
 
     c. On the SSO tab, set the Token Endpoint Authentication Method to ``POST``.


### PR DESCRIPTION
The documentation for OneLogin contained a typo and needed clarification:
* The login URL for Tethys is `http://<SERVER_DOMAIN_NAME>/accounts/login/`, not `http://<SERVER_DOMAIN_NAME>/login/`
* The 'SUBDOMAIN' parameter is the full protocol and domain, not just the subdomain prefix (`"https://example.onelogin.com"` NOT just `"example"`).