### PR TITLE
Pin Channels to 2.*

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
 - social-auth-app-django
 - dask=1.2.*
 - tethys_dask_scheduler>=1.0.2
-- channels
+- channels=2.*
 - daphne=2.5.*
 - service_identity
 - condorpy


### PR DESCRIPTION
BYU is experiencing issues where installing Dev builds installs Channels 3.*, which breaks Tethys. This PR pins the channels dependency to 2.* for now.