### PR TITLE
Fix for Issue #698

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
 
 # database dependencies
 - postgresql
-- psycopg2
+- psycopg2<2.9  # remove pin after upgrading to django 3.
 - sqlalchemy
 - geoalchemy2
 


### PR DESCRIPTION
Pin psycopg2 to < 2.9 b/c 2.9 doesn't work with Django 2.2. See #698 