### PR TITLE
Remove left over "import mock" statements from tests.

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_models/test_SpatialDatasetServiceSetting.py
+++ b/tests/unit_tests/test_tethys_apps/test_models/test_SpatialDatasetServiceSetting.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from tethys_sdk.testing import TethysTestCase
 from tethys_apps.models import TethysApp
 from tethys_apps.exceptions import TethysAppSettingNotAssigned

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_date_picker.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_date_picker.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import unittest
 import tethys_gizmos.gizmo_options.date_picker as gizmo_date_picker
 


### PR DESCRIPTION
Two tests were still using `import mock` instead of `from unittest import mock`. They only recently started failing, so we must have been getting the mock package installed through some other package. This PR changes both import appropriately.