### PR TITLE
Fix Plotly Gizmo Test

### DIFF
--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_plotly_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_plotly_view.py
@@ -23,10 +23,10 @@ class TestPlotlyView(unittest.TestCase):
 
         result = gizmo_plotly_view.PlotlyView(plot_input)
         # Check Result
-        self.assertIn(', '.join(str(e) for e in trace0.x), result['plotly_div'])
-        self.assertIn(', '.join(str(e) for e in trace0.y), result['plotly_div'])
-        self.assertIn(', '.join(str(e) for e in trace1.x), result['plotly_div'])
-        self.assertIn(', '.join(str(e) for e in trace1.y), result['plotly_div'])
+        self.assertIn(','.join(str(e) for e in trace0.x), result['plotly_div'])
+        self.assertIn(','.join(str(e) for e in trace0.y), result['plotly_div'])
+        self.assertIn(','.join(str(e) for e in trace1.x), result['plotly_div'])
+        self.assertIn(','.join(str(e) for e in trace1.y), result['plotly_div'])
 
         self.assertIn('.js', gizmo_plotly_view.PlotlyView.get_vendor_js()[0])
         self.assertNotIn('.css', gizmo_plotly_view.PlotlyView.get_vendor_js()[0])


### PR DESCRIPTION
The test of the Plotly Gizmo was failing because the new version of Plotly changed how the HTML was rendered slightly (spaces were removed in series arrays when they are serialized).