### PR TITLE
Updates ol CDN URL and fixes 1 compatibility issue

### DIFF
--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -313,7 +313,7 @@ class MapView(TethysGizmoOptions):
     """  # noqa: E501
     gizmo_name = "map_view"
     ol_version = '5.3.0'
-    cdn = 'https://cdn.jsdelivr.net/npm/openlayers@{version}/dist/ol{debug}.{ext}'
+    cdn = 'https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v{version}/{folder}/ol{debug}.{ext}'
     alternate_cdn = 'https://cdnjs.cloudflare.com/ajax/libs/openlayers/{version}/ol{debug}.{ext}'
     local_url = 'tethys_gizmos/vendor/openlayers/{version}/ol.{ext}'
 
@@ -355,6 +355,7 @@ class MapView(TethysGizmoOptions):
         openlayers_library = cls.static_url().format(
             version=cls.ol_version,
             debug=cls.debug(),
+            folder='build',
             ext='js'
         )
 
@@ -378,6 +379,7 @@ class MapView(TethysGizmoOptions):
         openlayers_css = cls.static_url().format(
             version=cls.ol_version,
             debug=cls.debug(),
+            folder='css',
             ext='css'
         )
 

--- a/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
@@ -6,6 +6,14 @@
  * LICENSE: BSD 2-Clause
  *****************************************************************************/
 
+ // Backward/forward compatability for OpenLayers
+if (typeof ol.inherits === 'undefined') {
+    ol.inherits = function (child, parent) {
+        child.prototype = Object.create(parent.prototype);
+        child.prototype.constructor = child;
+    }
+}
+
 // Extend Object prototype
 Object.byString = function(o, s) {
     s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties


### PR DESCRIPTION
There are very likely other compatibility issues that would need to be addressed if we truly wanted Tethys Core robust enough to allow for ANY version of OpenLayers. But I only quickly came upon and addressed the one issue with "ol.inherits".