### PR TITLE
Fixes tests for bokeh handler decorators

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_base/test_bokeh_handler.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_bokeh_handler.py
@@ -10,45 +10,54 @@ from tethys_apps.base.bokeh_handler import with_request, with_workspaces
 
 
 @with_request
-def bokeh_to_http_request_handler(doc: Document):
-    return doc.request
+def with_request_decorated(doc: Document):
+    return doc
 
 
 @with_workspaces
-def add_workspaces_to_document_handler(doc: Document):
-    return doc.user_workspace, doc.app_workspace
-
-
-class MockSessionContext(object):
-    def __init__(self, doc):
-        mock_bokeh_request = dict(user=mock.MagicMock(spec=User), scheme='http')
-
-        self._document = doc
-        self.status = None
-        self.counter = 0
-        self.request = mock_bokeh_request
+def with_workspaces_decorated(doc: Document):
+    return doc
 
 
 class TestBokehHandler(unittest.TestCase):
-    def test_bokeh_to_http_request(self):
-        app = baa.Application()
-        doc = app.create_document()
-        session_context = MockSessionContext(doc)
-        doc._session_context = session_context
 
-        ret = bokeh_to_http_request_handler(doc)
-        self.assertIsInstance(ret, HttpRequest)
+    def setUp(self) -> None:
+        self.app = baa.Application()
+        self.doc = self.app.create_document()
+        self.doc._session_context = self.make_session_context(self.doc)
+
+    def make_session_context(self, doc):
+        mock_session_context = mock.MagicMock(
+            return_value=mock.MagicMock(
+                _document=doc,
+                status=None,
+                counter=0,
+                request=dict(
+                    user=mock.MagicMock(spec=User),
+                    scheme='http'
+                )
+            )
+        )
+        return mock_session_context
+
+    def test_with_request_decorator(self):
+        ret_doc = with_request_decorated(self.doc)
+
+        self.assertIsNotNone(getattr(ret_doc, 'request', None))
+        self.assertIsNotNone(getattr(ret_doc.request, 'user', None))
+        self.assertIsInstance(ret_doc.request, HttpRequest)
 
     @mock.patch('tethys_quotas.utilities.log')
     @mock.patch('tethys_apps.base.workspace.log')
     @mock.patch('tethys_apps.utilities.get_active_app')
     @mock.patch('tethys_apps.base.workspace._get_user_workspace')
-    def test_add_workspaces_to_document(self, _, __, ___, ____):
-        app = baa.Application()
-        doc = app.create_document()
-        session_context = MockSessionContext(doc)
-        doc._session_context = session_context
+    @mock.patch('tethys_apps.base.workspace._get_app_workspace')
+    def test_with_workspaces_decorator(self, mock_gaw, mock_guw, _, __, ___):
+        mock_guw.return_value = 'user-workspace'
+        mock_gaw.return_value = 'app-workspace'
 
-        ret = add_workspaces_to_document_handler(doc)
-        self.assertIn('_get_user_workspace', ret[0].__repr__())
-        self.assertIn('app_workspace', ret[1].__repr__())
+        ret_doc = with_workspaces_decorated(self.doc)
+        self.assertIsNotNone(getattr(ret_doc, 'user_workspace', None))
+        self.assertIsNotNone(getattr(ret_doc, 'app_workspace', None))
+        self.assertEqual('user-workspace', ret_doc.user_workspace)
+        self.assertEqual('app-workspace', ret_doc.app_workspace)


### PR DESCRIPTION
- Noticed unrelated tests were failing on Pull Requests
- The tests for the `with_request` and `with_workspaces` Bokeh handler function decorators were failing
- They broke with Bokeh 2.4.0, which expects the `session_context` attribute of `Documents` to be callable.
- Verified Bokeh support and decorators still worked using the solution to the Bokeh tutorial.