### PR TITLE
Improvements to Dockerfile

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -78,6 +78,10 @@ salt-call --local state.apply
 if [[ $test = false ]]; then
   if [[ $skip_perm = false ]]; then
     echo_status "Fixing permissions"
+    find ${STATIC_ROOT} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+    find ${WORKSPACE_ROOT} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+    find ${TETHYS_PERSIST} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+    find ${TETHYSAPP_DIR} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
     find ${TETHYS_HOME} ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
   fi
 

--- a/docker/salt/post_app.sls
+++ b/docker/salt/post_app.sls
@@ -65,3 +65,8 @@ Link_ASGI_Supervisor_Post_App:
     - name: /etc/supervisor/conf.d/asgi_supervisord.conf
     - target: {{ TETHYS_PERSIST }}/asgi_supervisord.conf
     - force: True
+
+Tethys_Persist_Permissions:
+  cmd.run:
+    - name: "chown -R www: {{ TETHYS_PERSIST }} && chmod -R g+rw {{ TETHYS_PERSIST }}"
+    - shell: /bin/bash


### PR DESCRIPTION
- Adds build arg to specify the Python version the image is built with
- Changes supervisord config to use the same user as NGINX instead of running as root
- Adds salt step to change permissions and add group write permission to all files in TETHYS_PERSIST dir
- Adds post-salt change permissions to static, workspaces, tethys_persist, and tethysapp_dir directories
- The permission changes were done so that files uploaded / created by apps at runtime will be created with the NGINX user permissions instead of root.
- It also makes it more convenient for files that are shared between containers through a common mounted host directory.