### PR TITLE
Add API to initialize Cesium

### DIFF
--- a/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/cesium_map_view.js
@@ -874,9 +874,10 @@ var CESIUM_MAP_VIEW = (function() {
 	 */
 
 	public_interface = {
-        getMap: function() {
-            return m_viewer;
-        },
+		getMap: function() {
+		    return m_viewer;
+		},
+		reInitializeMap: cesium_initialize_all,
 	};
 
 	/************************************************************************


### PR DESCRIPTION
When Cesium is loaded via ajax then it needs to be re-initialized. This adds a `reInitializeMap` to the public interface (mirroring the call on the `tethys_map_view`).