### PR TITLE
Updates to Services and App Settings CLI

### DIFF
--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   CONDA_BUILD_PIN_LEVEL: minor
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
 
@@ -51,11 +50,10 @@ jobs:
           tethys test -c -u -v 2
       # Generate Coverage Report
       - name: Genearte Coverage Report
+        uses: coverallsapp/github-action@master
         if: matrix.platform == 'ubuntu-latest'
-        run: |
-            . ~/miniconda/etc/profile.d/conda.sh
-            conda activate tethys
-            coveralls
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   docker-build:
     name: Docker Build

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -31,9 +31,8 @@ jobs:
       # Install Tethys
       - name: Install Tethys
         run: |
-          cd ..
-          bash ./tethys/scripts/install_tethys.sh -h
-          bash ./tethys/scripts/install_tethys.sh --partial-tethys-install meds -n tethys -s $PWD/tethys
+          bash ./scripts/install_tethys.sh -h
+          bash ./scripts/install_tethys.sh --partial-tethys-install meds -n tethys -s $PWD/tethys
       # Setup Tethys and Conda
       - name: Setup Tethys and Conda
         run: |
@@ -49,7 +48,7 @@ jobs:
           conda activate tethys
           tethys test -c -u -v 2
       # Generate Coverage Report
-      - name: Genearte Coverage Report
+      - name: Generate Coverage Report
         uses: coverallsapp/github-action@master
         if: matrix.platform == 'ubuntu-latest'
         with:

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -31,8 +31,9 @@ jobs:
       # Install Tethys
       - name: Install Tethys
         run: |
-          bash ./scripts/install_tethys.sh -h
-          bash ./scripts/install_tethys.sh --partial-tethys-install meds -n tethys -s $PWD/tethys
+          cd ..
+          bash ./tethys/scripts/install_tethys.sh -h
+          bash ./tethys/scripts/install_tethys.sh --partial-tethys-install meds -n tethys -s $PWD/tethys
       # Setup Tethys and Conda
       - name: Setup Tethys and Conda
         run: |
@@ -48,11 +49,12 @@ jobs:
           conda activate tethys
           tethys test -c -u -v 2
       # Generate Coverage Report
-      - name: Generate Coverage Report
+      - name: Genearte Coverage Report
         uses: coverallsapp/github-action@master
         if: matrix.platform == 'ubuntu-latest'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./tethys/.coverage/lcov.info
 
   docker-build:
     name: Docker Build

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Find lcov.info
         run: |
           ls -al .
-          ls -al ./tethys
-          ls -al ./tethys/tests
+          ls -al .coverage
+          ls -al tests
           find . -type f -name lcov.info
       # Generate Coverage Report
       - name: Generate Coverage Report

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -5,7 +5,8 @@ name: Tethys-CI
 on:
   push:
     branches:
-      - '*'
+      - 'master'
+      - 'release*'
   pull_request:
     branches:
       - '*'
@@ -49,14 +50,14 @@ jobs:
           tethys test -c -u -v 2
       # Generate Coverage Report
       - name: Genearte Coverage Report
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-latest'
         run: |
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate tethys
             coveralls
 
   docker-build:
-    name: Docker Build (${{ matrix.platform }})
+    name: Docker Build
     needs: tests
     if:
       contains('
@@ -91,7 +92,7 @@ jobs:
           echo "Uploading is skipped for pull requests."
 
   conda-build:
-    name: Conda Build (${{ matrix.platform }})
+    name: Conda Build
     needs: tests
     if:
       contains('

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CONDA_BUILD_PIN_LEVEL: minor
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
 

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   CONDA_BUILD_PIN_LEVEL: minor
-  github-token: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
 
@@ -49,6 +49,13 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh
           conda activate tethys
           tethys test -c -u -v 2
+      # DEBUG
+      - name: Find lcov.info
+        run: |
+          ls -al .
+          ls -al ./tethys
+          ls -al ./tethys/tests
+          find . -type f -name lcov.info
       # Generate Coverage Report
       - name: Generate Coverage Report
         if: matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -49,13 +49,6 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh
           conda activate tethys
           tethys test -c -u -v 2
-      # DEBUG
-      - name: Find lcov.info
-        run: |
-          ls -al .
-          ls -al .coverage
-          ls -al tests
-          find . -type f -name lcov.info
       # Generate Coverage Report
       - name: Generate Coverage Report
         if: matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -60,11 +60,6 @@ jobs:
   docker-build:
     name: Docker Build
     needs: tests
-    if:
-      contains('
-        refs/heads/master
-        refs/heads/release
-      ', github.ref)
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -95,11 +90,6 @@ jobs:
   conda-build:
     name: Conda Build
     needs: tests
-    if:
-      contains('
-      refs/heads/master
-      refs/heads/release
-      ', github.ref)
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CONDA_BUILD_PIN_LEVEL: minor
+  github-token: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
 
@@ -49,12 +50,12 @@ jobs:
           conda activate tethys
           tethys test -c -u -v 2
       # Generate Coverage Report
-      - name: Genearte Coverage Report
-        uses: coverallsapp/github-action@master
+      - name: Generate Coverage Report
         if: matrix.platform == 'ubuntu-latest'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./tethys/.coverage/lcov.info
+        run: |
+          . ~/miniconda/etc/profile.d/conda.sh
+          conda activate tethys
+          coveralls --service=github
 
   docker-build:
     name: Docker Build

--- a/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
+++ b/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 from django.core.exceptions import ObjectDoesNotExist
 import tethys_cli.app_settings_commands as cli_app_settings_command
+from tethys_sdk.testing import TethysTestCase
 
 
 class TestCliAppSettingsCommand(unittest.TestCase):
@@ -308,3 +309,228 @@ class TestCliAppSettingsCommand(unittest.TestCase):
         self.assertEqual('ds_dataset', cli_app_settings_command.get_setting_type(DatasetServiceSetting()))
         self.assertEqual('wps', cli_app_settings_command.get_setting_type(WebProcessingServiceSetting()))
         self.assertEqual('custom_setting', cli_app_settings_command.get_setting_type(CustomSetting()))
+
+
+class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
+    def set_up(self):
+        pass
+
+    def tear_down(self):
+        pass
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_str(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # String Custom Setting
+        mock_args_str = mock.MagicMock(
+            app='test_app',
+            setting='default_name',
+            value='foo'
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_str)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_int(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Integer Custom Setting
+        mock_args_int = mock.MagicMock(
+            app='test_app',
+            setting='max_count',
+            value='1'
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_int)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_float(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Float Custom Setting
+        mock_args_float = mock.MagicMock(
+            app='test_app',
+            setting='change_factor',
+            value='1.5'
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_float)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_bool(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='test_app',
+            setting='enable_feature',
+            value='True'
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_bad_value_int(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Integer Custom Setting
+        mock_args_int = mock.MagicMock(
+            app='test_app',
+            setting='max_count',
+            value='1.5'  # Not int
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_int)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_bad_value_float(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Float Custom Setting
+        mock_args_float = mock.MagicMock(
+            app='test_app',
+            setting='change_factor',
+            value='1'  # Not float
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_float)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_bad_value_bool(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='test_app',
+            setting='enable_feature',
+            value='foo'  # Not valid bool string
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_non_existant_setting(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='test_app',
+            setting='foo',  # Setting doesn't exist for test_app
+            value='bar'
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_set_non_existant_app(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='foo',  # App foo doesn't exist
+            setting='enable_feature',
+            value='bar'
+        )
+
+        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_reset_str(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # String Custom Setting
+        mock_args_str = mock.MagicMock(
+            app='test_app',
+            setting='default_name',
+        )
+
+        cli_app_settings_command.app_settings_reset_command(mock_args_str)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_reset_int(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Integer Custom Setting
+        mock_args_int = mock.MagicMock(
+            app='test_app',
+            setting='max_count',
+        )
+
+        cli_app_settings_command.app_settings_reset_command(mock_args_int)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_reset_float(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Float Custom Setting
+        mock_args_float = mock.MagicMock(
+            app='test_app',
+            setting='change_factor',
+        )
+
+        cli_app_settings_command.app_settings_reset_command(mock_args_float)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit')
+    def test_app_settings_reset_bool(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='test_app',
+            setting='enable_feature',
+        )
+
+        cli_app_settings_command.app_settings_reset_command(mock_args_bool)
+        mock_write_error.assert_not_called()
+        mock_write_success.assert_called()
+        mock_exit.called_with(0)

--- a/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
+++ b/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
@@ -320,7 +320,7 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_str(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # String Custom Setting
@@ -330,14 +330,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='foo'
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_str)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_str)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_int(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Integer Custom Setting
@@ -347,14 +347,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='1'
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_int)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_int)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_float(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Float Custom Setting
@@ -364,14 +364,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='1.5'
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_float)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_float)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_bool(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Boolean Custom Setting
@@ -381,14 +381,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='True'
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_bool)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_bad_value_int(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Integer Custom Setting
@@ -398,31 +398,31 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='1.5'  # Not int
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_int)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_int)
         mock_write_error.assert_called()
         mock_write_success.assert_not_called()
         mock_exit.assert_called_with(1)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_bad_value_float(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Float Custom Setting
         mock_args_float = mock.MagicMock(
             app='test_app',
             setting='change_factor',
-            value='1'  # Not float
+            value='foo'  # Not float
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_float)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_float)
         mock_write_error.assert_called()
         mock_write_success.assert_not_called()
         mock_exit.assert_called_with(1)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_bad_value_bool(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Boolean Custom Setting
@@ -432,14 +432,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='foo'  # Not valid bool string
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_bool)
         mock_write_error.assert_called()
         mock_write_success.assert_not_called()
         mock_exit.assert_called_with(1)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_non_existant_setting(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Boolean Custom Setting
@@ -449,14 +449,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='bar'
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_bool)
         mock_write_error.assert_called()
         mock_write_success.assert_not_called()
         mock_exit.assert_called_with(1)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_set_non_existant_app(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Boolean Custom Setting
@@ -466,14 +466,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             value='bar'
         )
 
-        cli_app_settings_command.app_settings_set_command(mock_args_bool)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_set_command, mock_args_bool)
         mock_write_error.assert_called()
         mock_write_success.assert_not_called()
         mock_exit.assert_called_with(1)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_reset_str(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # String Custom Setting
@@ -482,14 +482,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             setting='default_name',
         )
 
-        cli_app_settings_command.app_settings_reset_command(mock_args_str)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_reset_command, mock_args_str)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_reset_int(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Integer Custom Setting
@@ -498,14 +498,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             setting='max_count',
         )
 
-        cli_app_settings_command.app_settings_reset_command(mock_args_int)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_reset_command, mock_args_int)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_reset_float(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Float Custom Setting
@@ -514,14 +514,14 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             setting='change_factor',
         )
 
-        cli_app_settings_command.app_settings_reset_command(mock_args_float)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_reset_command, mock_args_float)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
 
     @mock.patch('tethys_cli.app_settings_commands.write_success')
     @mock.patch('tethys_cli.app_settings_commands.write_error')
-    @mock.patch('tethys_cli.app_settings_commands.exit')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
     def test_app_settings_reset_bool(self, mock_exit, mock_write_error, mock_write_success):
         """Test against the installed test app."""
         # Boolean Custom Setting
@@ -530,7 +530,39 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
             setting='enable_feature',
         )
 
-        cli_app_settings_command.app_settings_reset_command(mock_args_bool)
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_reset_command, mock_args_bool)
         mock_write_error.assert_not_called()
         mock_write_success.assert_called()
         mock_exit.called_with(0)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
+    def test_app_settings_reset_non_existant_setting(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='test_app',
+            setting='foo',  # Setting doesn't exist for test_app
+        )
+
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_reset_command, mock_args_bool)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)
+
+    @mock.patch('tethys_cli.app_settings_commands.write_success')
+    @mock.patch('tethys_cli.app_settings_commands.write_error')
+    @mock.patch('tethys_cli.app_settings_commands.exit', side_effect=SystemExit)
+    def test_app_settings_reset_non_existant_app(self, mock_exit, mock_write_error, mock_write_success):
+        """Test against the installed test app."""
+        # Boolean Custom Setting
+        mock_args_bool = mock.MagicMock(
+            app='foo',  # App foo doesn't exist
+            setting='enable_feature',
+        )
+
+        self.assertRaises(SystemExit, cli_app_settings_command.app_settings_reset_command, mock_args_bool)
+        mock_write_error.assert_called()
+        mock_write_success.assert_not_called()
+        mock_exit.assert_called_with(1)

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -207,6 +207,31 @@ def get_app_settings(app):
         write_error('Something went wrong. Please try again.')
 
 
+def get_custom_setting(app_package, setting_name):
+    """
+    Get a CustomSetting for a specified TethysApp.
+
+    Args:
+        app_package (str): The name/package of the TethysApp.
+        setting_name (str): The name of the CustomSetting.
+
+    Returns:
+        CustomSetting: The Custom Setting or None if the TethysApp or CustomSetting cannot be found.
+    """
+    from tethys_apps.models import TethysApp, CustomSetting
+    try:
+        app = TethysApp.objects.get(package=app_package)
+    except TethysApp.DoesNotExist:
+        return None
+
+    try:
+        setting = CustomSetting.objects.get(tethys_app=app, name=setting_name)
+    except CustomSetting.DoesNotExist:
+        return None
+
+    return setting
+
+
 def create_ps_database_setting(app_package, name, description='', required=False, initializer='', initialized=False,
                                spatial=False, dynamic=False):
     from tethys_cli.cli_colors import pretty_output, FG_RED, FG_GREEN

--- a/tethys_cli/app_settings_commands.py
+++ b/tethys_cli/app_settings_commands.py
@@ -1,4 +1,5 @@
-from tethys_apps.utilities import get_app_settings
+from django.core.exceptions import ValidationError
+from tethys_apps.utilities import get_app_settings, get_custom_setting
 from tethys_cli.cli_colors import pretty_output, BOLD
 from tethys_cli.cli_helpers import load_apps
 
@@ -12,6 +13,21 @@ def add_app_settings_parser(subparsers):
     app_settings_list_parser = app_settings_subparsers.add_parser('list', help='List all settings for a specified app')
     app_settings_list_parser.add_argument('app', help='The app ("<app_package>") to list the Settings for.')
     app_settings_list_parser.set_defaults(func=app_settings_list_command)
+
+    # tethys app_settings set
+    app_settings_set_parser = app_settings_subparsers.add_parser('set', help='Set the value of a custom setting '
+                                                                             'for a specified app.')
+    app_settings_set_parser.add_argument('app', help='The app ("<app_package>") with the setting to be set.')
+    app_settings_set_parser.add_argument('setting', help='The name of the setting to be set.')
+    app_settings_set_parser.add_argument('value', help='The value to set.')
+    app_settings_set_parser.set_defaults(func=app_settings_set_command)
+
+    # tethys app_settings set
+    app_settings_reset_parser = app_settings_subparsers.add_parser('reset', help='Reset the value of a custom setting '
+                                                                                 'to its default value.')
+    app_settings_reset_parser.add_argument('app', help='The app ("<app_package>") with the setting to be reset.')
+    app_settings_reset_parser.add_argument('setting', help='The name of the setting to be reset.')
+    app_settings_reset_parser.set_defaults(func=app_settings_reset_command)
 
     # tethys app_settings create
     app_settings_create_cmd = app_settings_subparsers.add_parser('create', help='Create a Setting for an app.')
@@ -99,6 +115,39 @@ def app_settings_list_command(args):
 
             with pretty_output() as p:
                 p.write(f'{setting.pk: <10}{setting.name: <40}{get_setting_type(setting): <15}{service_name: <20}')
+
+
+def app_settings_set_command(args):
+    load_apps()
+    setting = get_custom_setting(args.app, args.setting)
+
+    if not setting:
+        print(f'No such Custom Setting "{args.setting}" for app "{args.app}".')
+        return
+
+    try:
+        setting.value = args.value
+        setting.clean()
+        setting.save()
+    except ValidationError as e:
+        print(f'Value was not set: {",".join(e.messages)} "{args.value}" was given.')
+
+    print(f'Success! Custom Setting "{args.setting}" for app "{args.app}" was set to "{args.value}".')
+
+
+def app_settings_reset_command(args):
+    load_apps()
+    setting = get_custom_setting(args.app, args.setting)
+
+    if not setting:
+        print(f'No such Custom Setting "{args.setting}" for app "{args.app}".')
+        return
+
+    setting.value = setting.default
+    setting.save()
+
+    print(f'Success! Custom Setting "{args.setting}" for app "{args.app}" '
+          f'was reset to the default value of "{setting.value}".')
 
 
 def get_setting_type(setting):

--- a/tethys_cli/app_settings_commands.py
+++ b/tethys_cli/app_settings_commands.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from tethys_apps.utilities import get_app_settings, get_custom_setting
-from tethys_cli.cli_colors import pretty_output, BOLD
+from tethys_cli.cli_colors import pretty_output, BOLD, write_error, write_success
 from tethys_cli.cli_helpers import load_apps
 
 
@@ -122,17 +122,19 @@ def app_settings_set_command(args):
     setting = get_custom_setting(args.app, args.setting)
 
     if not setting:
-        print(f'No such Custom Setting "{args.setting}" for app "{args.app}".')
-        return
+        write_error(f'No such Custom Setting "{args.setting}" for app "{args.app}".')
+        exit(1)
 
     try:
         setting.value = args.value
         setting.clean()
         setting.save()
     except ValidationError as e:
-        print(f'Value was not set: {",".join(e.messages)} "{args.value}" was given.')
+        write_error(f'Value was not set: {",".join(e.messages)} "{args.value}" was given.')
+        exit(1)
 
-    print(f'Success! Custom Setting "{args.setting}" for app "{args.app}" was set to "{args.value}".')
+    write_success(f'Success! Custom Setting "{args.setting}" for app "{args.app}" was set to "{args.value}".')
+    exit(0)
 
 
 def app_settings_reset_command(args):
@@ -140,14 +142,15 @@ def app_settings_reset_command(args):
     setting = get_custom_setting(args.app, args.setting)
 
     if not setting:
-        print(f'No such Custom Setting "{args.setting}" for app "{args.app}".')
-        return
+        write_error(f'No such Custom Setting "{args.setting}" for app "{args.app}".')
+        exit(1)
 
     setting.value = setting.default
     setting.save()
 
-    print(f'Success! Custom Setting "{args.setting}" for app "{args.app}" '
-          f'was reset to the default value of "{setting.value}".')
+    write_success(f'Success! Custom Setting "{args.setting}" for app "{args.app}" '
+                  f'was reset to the default value of "{setting.value}".')
+    exit(0)
 
 
 def get_setting_type(setting):


### PR DESCRIPTION
- Adds type option to `tethys services create spatial` command to allow specifying GeoServer or THREDDS engine.
- Add support for setting custom settings via the `tethys app_settings` command.
- Also fix a couple issues with CI not running coveralls or the builds during PRs