### PR TITLE
Patch docker cli to use log4j-patched versions of geoserver and thredds

### DIFF
--- a/tests/unit_tests/test_tethys_cli/test_docker_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_docker_commands.py
@@ -222,7 +222,7 @@ class TestDockerCommands(unittest.TestCase):
         mock_port_bindings_prop.return_value = mock_port_bindings
         expected_options = dict(
             name='tethys_geoserver',
-            image='ciwater/geoserver:2.8.2-clustered',
+            image='tethysplatform/geoserver:latest',
             environment=dict(
                 ENABLED_NODES='1',
                 REST_NODES='1',
@@ -443,7 +443,7 @@ class TestDockerCommands(unittest.TestCase):
         mock_port_bindings_prop.return_value = mock_port_bindings
         expected_options = dict(
             name='tethys_thredds',
-            image='unidata/thredds-docker:4.6.13',
+            image='unidata/thredds-docker:4.6.20-SNAPSHOT',
             environment=dict(
                 TDM_PW='CHANGEME!',
                 TDS_HOST='http://localhost',

--- a/tethys_cli/docker_commands.py
+++ b/tethys_cli/docker_commands.py
@@ -254,8 +254,8 @@ class GeoServerContainerMetadata(ContainerMetadata):
     input = 'geoserver'
     name = 'tethys_geoserver'
     display_name = 'GeoServer'
-    image_name = 'ciwater/geoserver'
-    tag = '2.8.2-clustered'
+    image_name = 'tethysplatform/geoserver'
+    tag = 'latest'
     host_port = 8181
     container_port = 8080  # only for backwards compatibility with non-clustered containers
 
@@ -305,7 +305,7 @@ class GeoServerContainerMetadata(ContainerMetadata):
 
     @property
     def is_cluster(self):
-        return 'cluster' in self.installed_image
+        return 'cluster' in self.installed_image or 'tethysplatform/geoserver' in self.installed_image
 
     def default_container_options(self):
         options = super().default_container_options()
@@ -495,7 +495,7 @@ class ThreddsContainerMetadata(ContainerMetadata):
     name = 'tethys_thredds'
     display_name = 'THREDDS'
     image_name = 'unidata/thredds-docker'
-    tag = '4.6.13'
+    tag = '4.6.20-SNAPSHOT'
     host_port = 8383
     container_port = 8080
 


### PR DESCRIPTION
Updates the Docker command to use new versions of the THREDDS and GeoServer container images that have been patched for log4j vulnerabilities.