### PR TITLE
Add links to presentations and attribution to Docker and Azure Production docs

### DIFF
--- a/docs/installation/production/cloud.rst
+++ b/docs/installation/production/cloud.rst
@@ -10,3 +10,13 @@ Cloud Virtual Machine Images
     :maxdepth: 2
 
     cloud/azure
+
+Additional Resources
+--------------------
+
+* `Tethys Platform Microsoft Azure Deployment Presentation <https://docs.google.com/presentation/d/1Fp2fp11ukukOjDMdarwvFCxGVUG4NtJ0QiVRuvGLowI/edit?usp=sharing>`_
+
+Attribution
+-----------
+
+Funding for the update of this guide was provided by National Aeronautics and Space Administration (NASA) through SERVIR 80NSSC20K0157. SERVIR is a joint program led by the US Agency for International Development (USAID) and NASA.

--- a/docs/installation/production/docker.rst
+++ b/docs/installation/production/docker.rst
@@ -23,3 +23,12 @@ Docker is self-described as "an open platform for developing, shipping, and runn
     docker/docker_compose
     docker/tethys_docker_reference
 
+Additional Resources
+--------------------
+
+* `Tethys Platform Docker Deployment Presentation <https://docs.google.com/presentation/d/1X4lnIz1EFeBbFTFzYEw1Uun7va6F3XFVw0WY5IbG9KY/edit?usp=sharing>`_
+
+Attribution
+-----------
+
+Funding for the update of this guide was provided by National Aeronautics and Space Administration (NASA) through SERVIR 80NSSC20K0157. SERVIR is a joint program led by the US Agency for International Development (USAID) and NASA.


### PR DESCRIPTION
The development of the new Docker and Azure production deployment documentation was sponsored by SERVIR. This PR adds appropriate attribution to those pages of the docs.

It also adds links to supplementary presentations that can be used as primer material when training on these topics.