### PR TITLE
Fixes Bad Import in App Scaffold

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
@@ -197,8 +197,8 @@ class TestController(unittest.TestCase):
         mock_list.return_value = [
                 {'name': 'name', 'url': 'url'},
             ]
-        tethys_controller.register_controllers('root', 'controllers', 'index')
-        mock_warning.assert_called_once()
+        with self.assertRaises(RuntimeError):
+            tethys_controller.register_controllers('root', 'controllers', 'index')
 
     @mock.patch('tethys_apps.base.controller.get_all_submodules')
     @mock.patch('tethys_apps.base.controller.url_map_maker')

--- a/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
@@ -208,4 +208,14 @@ class TestController(unittest.TestCase):
     def test_register_controllers_with_import_error(self, mock_importlib, mock_warning, _, __, ___):
         mock_importlib.import_module.side_effect = ImportError
         tethys_controller.register_controllers('root', 'controllers')
+        self.assertEqual(3, mock_warning.call_count)
+
+    @mock.patch('tethys_apps.base.controller.get_all_submodules')
+    @mock.patch('tethys_apps.base.controller.url_map_maker')
+    @mock.patch('tethys_apps.base.controller._listify', return_value=['non_existent_module'])
+    @mock.patch('tethys_apps.base.controller.write_warning')
+    @mock.patch('tethys_apps.base.controller.importlib')
+    def test_register_controllers_with_module_not_found_error(self, mock_importlib, mock_warning, _, __, ___):
+        mock_importlib.import_module.side_effect = ModuleNotFoundError
+        tethys_controller.register_controllers('root', 'controllers')
         mock_warning.assert_called_once()

--- a/tethys_apps/base/controller.py
+++ b/tethys_apps/base/controller.py
@@ -621,7 +621,7 @@ def register_controllers(root_url: str, modules: Union[str, list, tuple], index:
                     f'"{module_name}" but the module "{module}" could not be imported. '
                     f'Any controllers in that module will not be registered.'
                 )
-           
+
             if not isinstance(e, ModuleNotFoundError):
                 write_warning(
                     f'Warning: Found controller module "{module}", but it could not be imported '
@@ -629,7 +629,7 @@ def register_controllers(root_url: str, modules: Union[str, list, tuple], index:
                 )
                 tb = traceback.format_exc()
                 write_warning(tb)
-            
+
         else:
             all_modules.extend(get_all_submodules(module))
 

--- a/tethys_apps/base/controller.py
+++ b/tethys_apps/base/controller.py
@@ -8,6 +8,7 @@
 import importlib
 import inspect
 from collections import OrderedDict
+import traceback
 
 from channels.consumer import AsyncConsumer
 from django.views.generic import View
@@ -612,7 +613,7 @@ def register_controllers(root_url: str, modules: Union[str, list, tuple], index:
     for module in modules:
         try:
             module = importlib.import_module(module)
-        except ImportError:
+        except ImportError as e:
             module_name = module.split(".")[-1]
             if module_name not in DEFAULT_CONTROLLER_MODULES:
                 write_warning(
@@ -620,6 +621,15 @@ def register_controllers(root_url: str, modules: Union[str, list, tuple], index:
                     f'"{module_name}" but the module "{module}" could not be imported. '
                     f'Any controllers in that module will not be registered.'
                 )
+           
+            if not isinstance(e, ModuleNotFoundError):
+                write_warning(
+                    f'Warning: Found controller module "{module}", but it could not be imported '
+                    f'because of the following error: {e}'
+                )
+                tb = traceback.format_exc()
+                write_warning(tb)
+            
         else:
             all_modules.extend(get_all_submodules(module))
 

--- a/tethys_apps/base/controller.py
+++ b/tethys_apps/base/controller.py
@@ -662,8 +662,8 @@ def register_controllers(root_url: str, modules: Union[str, list, tuple], index:
             index_kwargs = names[index]
             index_kwargs['url'] = root_url
         except KeyError:
-            write_warning(
-                f'Warning: The app with root_url "{root_url}" specifies an index of "{index}", '
+            raise RuntimeError(
+                f'The app with root_url "{root_url}" specifies an index of "{index}", '
                 f'but there are no controllers registered with that name.'
             )
 

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/controllers.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/controllers.py_tmpl
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from tethys_sdk.base import controller
+from tethys_sdk.routing import controller
 from tethys_sdk.gizmos import Button
 
 @controller

--- a/tethys_cli/scaffold_templates/extension_templates/default/tethysext/+project+/__init__.py
+++ b/tethys_cli/scaffold_templates/extension_templates/default/tethysext/+project+/__init__.py
@@ -1,0 +1,1 @@
+# Included for native namespace package support


### PR DESCRIPTION
This PR addresses issue #789 as follows:

* Fixes the import for the controller decorator in the app scaffold template
* Prints a warning and traceback for import errors that are not ModuleNotFoundErrors encountered while registering controllers:

![image](https://user-images.githubusercontent.com/5123221/164051022-6018b328-580a-49ce-aeeb-c346a934bc22.png)
