### PR TITLE
unpinned openssl; fixed db command's help format

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -77,7 +77,7 @@ dependencies:
   - flake8
   - git
   - setuptools_scm
-  - openssl<3.0.0  # Pin until openssl issue is resolved by conda
+  - openssl
 
   # Conda to allow Python API access to Conda Install
   - conda

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -9,6 +9,7 @@
 """
 from pathlib import Path
 import shutil
+import argparse
 
 from django.conf import settings
 from django.db.utils import IntegrityError
@@ -20,7 +21,8 @@ from tethys_apps.utilities import get_tethys_home_dir
 
 def add_db_parser(subparsers):
     # DB COMMANDS
-    db_parser = subparsers.add_parser('db', help='Tethys Database Server utility commands.')
+    db_parser = subparsers.add_parser('db', help='Tethys Database Server utility commands.',
+                                      formatter_class=argparse.RawTextHelpFormatter)
 
     # Setup db commands
     db_parser.add_argument('command',


### PR DESCRIPTION
I unpinned and tested running "tethys db migrate" from scratch. No errors. Tested with latest openssl version on conda-forge (3.0.2).

Fixes #761