### PR TITLE
Tethys Map Layout Fixes

### DIFF
--- a/docs/tethys_sdk/layouts/map_layout.rst
+++ b/docs/tethys_sdk/layouts/map_layout.rst
@@ -4,7 +4,7 @@
 Map Layout
 **********
 
-**Last Updated:** April 2022
+**Last Updated:** May 2022
 
 The ``MapLayout`` provides a drop-in full-screen map view for Tethys Apps. Displaying a map with a few layers can be accomplished in tens of lines of code and implementing more advanced functionality can be accomplished in hundreds. It includes a layer tree with visibility controls and actions such as "Zoom to Layer". The view can also includes many optional features such as displaying legends for layers, feature selection, map annotation / drawing tools, location lookup via geocoding, and a click-and-plot feature.
 
@@ -573,7 +573,7 @@ In this example, the plot data is hard-coded for simplicity:
 
 .. code-block:: python
 
-    def get_plot_for_layer_feature(self, layer_name, feature_id):
+    def get_plot_for_layer_feature(self, request, layer_name, feature_id, *args, **kwargs):
         """
         Retrieves plot data for given feature on given layer.
 

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
@@ -129,7 +129,93 @@ class TestMapView(unittest.TestCase):
         gizmo_map_view.MVLayer(source=source, legend_title=legend_title, options=options,
                                feature_selection=feature_selection)
 
-        mock_log.assert_called_with("geometry_attribute not defined -using default value 'the_geom'")
+        mock_log.assert_called_with("geometry_attribute not defined for layer 'Park City Watershed' "
+                                    "-using default value 'the_geom'")
+    
+    def test_MVLayer_geojson_source_geometry_attribute(self):
+        source = 'GeoJSON'
+        legend_title = 'GeoJSON Layer'
+        geojson = {
+            'type': 'FeatureCollection',
+            'crs': {
+                'type': 'name',
+                'properties': {
+                    'name': 'EPSG:3857'
+                }
+            },
+            'features': [
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [0, 0]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'LineString',
+                        'coordinates': [[4e6, -2e6], [8e6, 2e6]]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Polygon',
+                        'coordinates': [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
+                    }
+                }
+            ]
+        }
+
+        ret = gizmo_map_view.MVLayer(source=source, legend_title=legend_title, options=geojson)
+
+        self.assertEqual('geometry', ret.geometry_attribute)
+
+    @mock.patch('tethys_gizmos.gizmo_options.map_view.log.warning')
+    def test_MVLayer_geojson_source_geometry_attribute_feature_selection(self, mock_warning):
+        source = 'GeoJSON'
+        legend_title = 'GeoJSON Layer'
+        feature_selection = True
+        geojson = {
+            'type': 'FeatureCollection',
+            'crs': {
+                'type': 'name',
+                'properties': {
+                    'name': 'EPSG:3857'
+                }
+            },
+            'features': [
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [0, 0]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'LineString',
+                        'coordinates': [[4e6, -2e6], [8e6, 2e6]]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'Polygon',
+                        'coordinates': [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
+                    }
+                }
+            ]
+        }
+
+        ret = gizmo_map_view.MVLayer(source=source, legend_title=legend_title, options=geojson,
+                                     feature_selection=feature_selection)
+
+        self.assertEqual('geometry', ret.geometry_attribute)
+
+        mock_warning.assert_not_called()
 
     def test_MVLegendClass(self):
         # Point

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
@@ -131,6 +131,7 @@ class TestMapView(unittest.TestCase):
 
         mock_log.assert_called_with("geometry_attribute not defined for layer 'Park City Watershed' "
                                     "-using default value 'the_geom'")
+
     def test_MVLayer_geojson_source_geometry_attribute(self):
         source = 'GeoJSON'
         legend_title = 'GeoJSON Layer'

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
@@ -131,7 +131,6 @@ class TestMapView(unittest.TestCase):
 
         mock_log.assert_called_with("geometry_attribute not defined for layer 'Park City Watershed' "
                                     "-using default value 'the_geom'")
-    
     def test_MVLayer_geojson_source_geometry_attribute(self):
         source = 'GeoJSON'
         legend_title = 'GeoJSON Layer'

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -706,9 +706,12 @@ class MVLayer(SecondaryGizmoOptions):
         self.geometry_attribute = geometry_attribute
         self.data = data or dict()
         self.times = times
+        
+        if source == 'GeoJSON':
+            geometry_attribute = 'geometry'
 
         if feature_selection and not geometry_attribute:
-            log.warning("geometry_attribute not defined -using default value 'the_geom'")
+            log.warning(f"geometry_attribute not defined for layer '{legend_title}' -using default value 'the_geom'")
 
 
 class MVLegendClass(SecondaryGizmoOptions):

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -708,9 +708,9 @@ class MVLayer(SecondaryGizmoOptions):
         self.times = times
         
         if source == 'GeoJSON':
-            geometry_attribute = 'geometry'
+            self.geometry_attribute = 'geometry'
 
-        if feature_selection and not geometry_attribute:
+        if self.feature_selection and not self.geometry_attribute:
             log.warning(f"geometry_attribute not defined for layer '{legend_title}' -using default value 'the_geom'")
 
 

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -706,7 +706,6 @@ class MVLayer(SecondaryGizmoOptions):
         self.geometry_attribute = geometry_attribute
         self.data = data or dict()
         self.times = times
-        
         if source == 'GeoJSON':
             self.geometry_attribute = 'geometry'
 

--- a/tethys_layouts/mixins/map_layout.py
+++ b/tethys_layouts/mixins/map_layout.py
@@ -352,6 +352,7 @@ class MapLayoutMixin:
 
         # Bind geometry features to layer via layer name
         for feature in geojson['features']:
+            feature.setdefault('properties', {})
             feature['properties']['layer_name'] = layer_name
 
         mv_layer = cls._build_mv_layer(

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.css
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.css
@@ -22,9 +22,8 @@
 
 /* Map Tabs */
 .map-tabs .tab-content {
-    max-height: 700px;
     overflow-y: auto;
-    height: 700px;
+    max-height: 100%;
 }
 
 /* Layer Selector */

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -259,17 +259,18 @@ var MAP_LAYOUT = (function() {
 
     get_feature_id_from_feature = function(feature) {
         let feature_id = feature.getId();
-        let fid = '-1';
 
         if (feature_id) {
-            // Derive fid from ID assigned by GeoServer (<layer_name>.<fid>)
-            // e.g.: 0958cc07-c194-4af9-81c5-118a77d335ac_stream_links.fid--72787a80_169a16811e6_-7aa6
-            fid = feature_id.split('.')[1];
+            if (feature_id.includes('.fid')) {
+                // Derive fid from ID assigned by GeoServer (<layer_name>.<fid>)
+                // e.g.: 0958cc07-c194-4af9-81c5-118a77d335ac_stream_links.fid--72787a80_169a16811e6_-7aa6
+                feature_id = feature_id.split('.')[1];
+            }
         } else {
-            fid = feature.get('id');
+            feature_id = feature.get('id');
         }
 
-        return fid;
+        return feature_id;
     };
 
     // Plotting

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -164,7 +164,7 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         """
         return cls.initial_map_extent
 
-    def get_plot_for_layer_feature(self, layer_name, feature_id):
+    def get_plot_for_layer_feature(self, request, layer_name, feature_id, *args, **kwargs):
         """
         Retrieves plot data for given feature on given layer.
 
@@ -560,7 +560,7 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         feature_id = request.POST.get('feature_id', '')
 
         # Initialize MapManager
-        title, data, layout = self.get_plot_for_layer_feature(layer_name, feature_id)
+        title, data, layout = self.get_plot_for_layer_feature(request, layer_name, feature_id, *args, **kwargs)
 
         return JsonResponse({'title': title, 'data': data, 'layout': layout})
 

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -296,6 +296,13 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         # Add layers to the Map
         log.debug('Composing layers...')
         layer_groups = self.compose_layers(request=request, map_view=map_view, *args, **kwargs)
+        
+        # Add layers to map view if not already added
+        for layer_group in layer_groups:
+            for layer in layer_group['layers']:
+                if layer not in map_view.layers:
+                    map_view.layers.append(layer)
+
         log.debug(f'Number of Layers: {len(map_view.layers)}')
 
         # Check if we need to create a blank custom layer group

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -296,7 +296,6 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         # Add layers to the Map
         log.debug('Composing layers...')
         layer_groups = self.compose_layers(request=request, map_view=map_view, *args, **kwargs)
-        
         # Add layers to map view if not already added
         for layer_group in layer_groups:
             for layer in layer_group['layers']:


### PR DESCRIPTION
This PR contains several fixes for bugs discovered during preparation for the AWRA Tethys Platform presentation.

- Set geometry attribute on GeoJSON MVLayers automatically. To silence warning that happens when using Map Layout.
- Make get_feature_id_from_feature smarter in map_layout.js Don't assume GeoServer layer.
- Fix scroll issue on map layout on smaller screens
- Pass the request and args and kwargs to MapLayout.get_plot_for_layer_feature() Allows it to recieve the app_workspace when class is decorated.
- Add tests for MVLayer changes
