### PR TITLE
Add get_workspace utility functions that enforce quotas

### DIFF
--- a/docs/tethys_cli.rst
+++ b/docs/tethys_cli.rst
@@ -1,3 +1,5 @@
+.. _tethys_cli:
+
 **********************
 Command Line Interface
 **********************

--- a/docs/tethys_sdk/app_class.rst
+++ b/docs/tethys_sdk/app_class.rst
@@ -90,6 +90,12 @@ Class Methods
 .. automethod:: tethys_apps.base.TethysAppBase.get_scheduler
    :noindex:
 
+.. automethod:: tethys_apps.base.TethysAppBase.get_app_workspace
+   :noindex:
+
+.. automethod:: tethys_apps.base.TethysAppBase.get_user_workspace
+   :noindex:
+
 .. automethod:: tethys_apps.base.TethysAppBase.list_persistent_store_connections
 
 .. automethod:: tethys_apps.base.TethysAppBase.list_persistent_store_databases

--- a/docs/tethys_sdk/workspaces.rst
+++ b/docs/tethys_sdk/workspaces.rst
@@ -4,34 +4,97 @@
 Workspaces API
 **************
 
-**Last Updated:** August 6, 2014
+**Last Updated:** September 2022
 
 The Workspaces API makes it easy for you to create directories for storing files that your app operates on. This can be a tricky task for a web application, because of the multi-user, simultaneous-connection environment of the web. The Workspaces API provides a simple mechanism for creating and managing a global workspace for your app and individual workspaces for each user of your app to prevent unwanted overwrites and file lock conflicts.
 
-Get a Workspace
-===============
+Getting Workspaces
+==================
 
-The Workspaces API adds two decorators, that can be used to retrieve the global app workspace and the user workspaces, respectively. To use the Workspace API methods, import the appropriate method from `tethys_sdk.workspaces`. Explanations of the decorators and example usage follows.
+There are three methods for obtaining the workspaces that are supported in Tethys Platform. In order of recommended use, the workspace methods are:
+
+* Controller Decorator
+* Workspaces Decorators
+* App Class Methods
+* Workspace Functions
+
+Controller Decorator
+--------------------
+
+The recommended method for obtaining workspaces in controllers is to use the ``app_workspace`` and ``user_workspace`` arguments of the ``controller`` decorator:
+
+.. code-block:: python
+
+    from tethys_sdk.routing import controller
+
+    @controller(app_workspace=True)
+    def my_controller(request, app_workspace):
+       ...
+
+    @controller(user_workspace=True)
+    def my_controller(request, user_workspace):
+       ...
+
+    @controller(app_workspace=True, user_workspace=True)
+    def my_controller(request, app_workspace, user_workspace):
+       ...
+
+To learn more about the ``controller`` decorator, see: :ref:`controller-decorator`
+
+Workspace Decorators
+--------------------
+
+The Workspaces API includes two decorators, that can be used to retrieve the app workspace and the user workspaces, respectively. To use these decorators, import them from ``tethys_sdk.workspaces``. Explanations of the decorators and example usage follows.
 
 .. _app_workspace:
 
 @app_workspace
------------------
+++++++++++++++
 
 .. automethod:: tethys_apps.base.workspace.app_workspace
 
 .. _user_workspace:
 
 @user_workspace
-------------------
++++++++++++++++
 
 .. automethod:: tethys_apps.base.workspace.user_workspace
+
+App Class Methods
+-----------------
+
+In cases where it is not possible to use one of the decorators, the :term:`app class` provides methods for getting the workspaces:
+
+.. code-block:: python
+
+    from .app import MyFirstApp as app
+
+    @controller
+    def my_controller(request):
+        app_workspace = app.get_app_workspace()
+        user_workspace = app.get_user_workspace(request.user)
+        ...
+
+For more details see :ref:`app_base_class_api`
+
+Workspace Functions
+-------------------
+
+In the rare cases where you need to use a workspace where it is not convenient or not possible to use one of the decorators OR the :term:`app class` methods, the Workspaces API provides function versions of the getters. Import them from ``tethys_sdk.workspaces``:
+
+.. _get_app_workspace_func:
+
+.. automethod:: tethys_apps.base.workspace.get_app_workspace
+
+.. _get_user_workspace_func:
+
+.. automethod:: tethys_apps.base.workspace.get_user_workspace
 
 
 Working with Workspaces
 =======================
 
-The two methods described above return a ``TethysWorkspace`` object that contains the path to the workspace and several convenience methods for working with the workspace. An explanation of the ``TethysWorkspace`` object and examples of it's usage is provided below.
+All of the methods described above return a ``TethysWorkspace`` object that contains the path to the workspace and several convenience methods for working with the workspace directory. An explanation of the ``TethysWorkspace`` object and examples of it's usage are provided below.
 
 TethysWorkspace Objects
 -----------------------
@@ -42,7 +105,7 @@ TethysWorkspace Objects
 Centralize Workspaces
 =====================
 
-The Workspaces API includes a command, ``collectworkspaces``, for moving all workspaces to a central location and symbolically linking them back to the app project directories. This is especially useful for production where the administrator may want to locate workspace content on a mounted drive to optimize storage. A brief explanation of how to use this command will follow. Refer to the :doc:`../tethys_cli` documentation for details about the ``collectworkspaces`` command.
+The Workspaces API provides a :ref:`tethys_cli` command, ``collectworkspaces``, for moving all workspaces to a central location and symbolically linking them back to the app project directories. This command is intended for use in production installations where the administrator may want to locate workspace content on a mounted drive to optimize storage and make it easier to backup app data. A brief explanation of how to use this command will follow. Refer to the :ref:`tethys_cli` documentation for details about the ``collectworkspaces`` command.
 
 Setting
 -------

--- a/tests/unit_tests/test_tethys_apps/test_base/test_app_base.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_app_base.py
@@ -685,6 +685,19 @@ class TestTethysAppBase(unittest.TestCase):
         mock_jm.return_value = 'test_job_manager'
         self.assertEqual('test_job_manager', self.app.get_job_manager())
 
+    @mock.patch('tethys_apps.base.app_base.get_user_workspace')
+    def test_get_user_workspace(self, mock_guw):
+        mock_user = mock.MagicMock()
+        ret = TethysAppChild.get_user_workspace(mock_user)
+        mock_guw.assert_called_with(TethysAppChild, mock_user)
+        self.assertEqual(ret, mock_guw())
+
+    @mock.patch('tethys_apps.base.app_base.get_app_workspace')
+    def test_get_app_workspace(self, mock_gaw):
+        ret = TethysAppChild.get_app_workspace()
+        mock_gaw.assert_called_with(TethysAppChild)
+        self.assertEqual(ret, mock_gaw())
+
     @mock.patch('tethys_apps.models.TethysApp')
     def test_get_custom_setting(self, mock_ta):
         setting_name = 'fake_setting'

--- a/tests/unit_tests/test_tethys_apps/test_base/test_workspace.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_workspace.py
@@ -7,7 +7,23 @@ from ... import UserFactory
 from django.http import HttpRequest
 from django.contrib.auth.models import User
 import tethys_apps.base.app_base as tethys_app_base
-from tethys_apps.base.workspace import user_workspace, app_workspace, _get_app_workspace, _get_user_workspace
+from tethys_apps.base.workspace import (
+    _get_user_workspace, get_user_workspace, user_workspace, _get_app_workspace, get_app_workspace, app_workspace
+)
+
+
+class TethysAppChild(tethys_app_base.TethysAppBase):
+    """
+    Tethys app class for Test App.
+    """
+
+    name = 'Test App'
+    index = 'home'
+    icon = 'test_app/images/icon.gif'
+    package = 'test_app'
+    root_url = 'test-app'
+    color = '#2c3e50'
+    description = 'Place a brief description of your app here.'
 
 
 @user_workspace
@@ -121,100 +137,217 @@ class TestUrlMap(unittest.TestCase):
         self.assertEqual(self.test_root, workspace.path)
 
     @mock.patch('tethys_apps.base.workspace.TethysWorkspace')
-    def test_get_user_workspace(self, mock_tws):
-        user = self.user
-        _get_user_workspace(self.app, user)
-
-        # Check result
+    def test__get_user_workspace_user(self, mock_tws):
+        ret = _get_user_workspace(self.app, self.user)
+        expected_path = os.path.join('workspaces', 'user_workspaces', self.user.username)
         rts_call_args = mock_tws.call_args_list
-        self.assertIn('workspaces', rts_call_args[0][0][0])
-        self.assertIn('user_workspaces', rts_call_args[0][0][0])
-        self.assertIn(user.username, rts_call_args[0][0][0])
+        self.assertEqual(ret, mock_tws())
+        self.assertIn(expected_path, rts_call_args[0][0][0])
 
     @mock.patch('tethys_apps.base.workspace.TethysWorkspace')
-    def test_get_user_workspace_http(self, mock_tws):
+    def test__get_user_workspace_http(self, mock_tws):
         from django.http import HttpRequest
         request = HttpRequest()
         request.user = self.user
-
-        _get_user_workspace(self.app, request)
-
-        # Check result
+        ret = _get_user_workspace(self.app, request)
+        expected_path = os.path.join('workspaces', 'user_workspaces', self.user.username)
         rts_call_args = mock_tws.call_args_list
-        self.assertIn('workspaces', rts_call_args[0][0][0])
-        self.assertIn('user_workspaces', rts_call_args[0][0][0])
-        self.assertIn(self.user.username, rts_call_args[0][0][0])
+        self.assertEqual(ret, mock_tws())
+        self.assertIn(expected_path, rts_call_args[0][0][0])
 
     @mock.patch('tethys_apps.base.workspace.TethysWorkspace')
-    def test_get_user_workspace_none(self, mock_tws):
-        _get_user_workspace(self.app, None)
-
-        # Check result
+    def test__get_user_workspace_none(self, mock_tws):
+        ret = _get_user_workspace(self.app, None)
+        expected_path = os.path.join('workspaces', 'user_workspaces', 'anonymous_user')
         rts_call_args = mock_tws.call_args_list
-        self.assertIn('workspaces', rts_call_args[0][0][0])
-        self.assertIn('user_workspaces', rts_call_args[0][0][0])
-        self.assertIn('anonymous_user', rts_call_args[0][0][0])
+        self.assertEqual(ret, mock_tws())
+        self.assertIn(expected_path, rts_call_args[0][0][0])
 
-    def test_get_user_workspace_error(self):
+    def test__get_user_workspace_error(self):
         with self.assertRaises(ValueError) as context:
-            _get_user_workspace(self.app, 'test')
+            _get_user_workspace(self.app, 'not_user_or_request')
+
         self.assertEqual(
-            "Invalid type for argument 'user': must be either an User or HttpRequest object.", str(context.exception))
+            str(context.exception),
+            "Invalid type for argument 'user': must be either an User or HttpRequest object."
+        )
+
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.base.workspace._get_user_workspace')
+    def test_get_user_workspace_aor_app_instance(self, mock_guw, mock_pq):
+        mock_workspace = mock.MagicMock()
+        mock_guw.return_value = mock_workspace
+        ret = get_user_workspace(self.app, self.user)
+        self.assertEqual(ret, mock_workspace)
+        mock_pq.assert_called_with(self.user, 'user_workspace_quota')
+        mock_guw.assert_called_with(self.app, self.user)
+
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.base.workspace._get_user_workspace')
+    def test_get_user_workspace_aor_app_class(self, mock_guw, mock_pq):
+        mock_workspace = mock.MagicMock()
+        mock_guw.return_value = mock_workspace
+        ret = get_user_workspace(TethysAppChild, self.user)
+        self.assertEqual(ret, mock_workspace)
+        mock_pq.assert_called_with(self.user, 'user_workspace_quota')
+        mock_guw.assert_called_with(TethysAppChild, self.user)
+
+    @mock.patch('tethys_apps.utilities.get_active_app')
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.base.workspace._get_user_workspace')
+    def test_get_user_workspace_aor_request(self, mock_guw, mock_pq, mock_gaa):
+        from django.http import HttpRequest
+        request = HttpRequest()
+        request.user = self.user
+        mock_workspace = mock.MagicMock()
+        mock_guw.return_value = mock_workspace
+        mock_app = mock.MagicMock()
+        mock_gaa.return_value = mock_app
+        ret = get_user_workspace(request, self.user)
+        self.assertEqual(ret, mock_workspace)
+        mock_gaa.assert_called_with(request, get_class=True)
+        mock_pq.assert_called_with(self.user, 'user_workspace_quota')
+        mock_guw.assert_called_with(mock_app, self.user)
+
+    def test_get_user_workspace_aor_error(self):
+        with self.assertRaises(ValueError) as context:
+            get_user_workspace('not_app_or_request', self.user)
+
+        self.assertEqual(
+            str(context.exception),
+            'Argument "app_class_or_request" must be of type TethysAppBase or HttpRequest: "<class \'str\'>" given.'
+        )
+
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.base.workspace._get_user_workspace')
+    def test_get_user_workspace_uor_user(self, mock_guw, mock_pq):
+        mock_workspace = mock.MagicMock()
+        mock_guw.return_value = mock_workspace
+        ret = get_user_workspace(self.app, self.user)
+        self.assertEqual(ret, mock_workspace)
+        mock_pq.assert_called_with(self.user, 'user_workspace_quota')
+        mock_guw.assert_called_with(self.app, self.user)
+
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.base.workspace._get_user_workspace')
+    def test_get_user_workspace_uor_request(self, mock_guw, mock_pq):
+        from django.http import HttpRequest
+        request = HttpRequest()
+        request.user = self.user
+        mock_workspace = mock.MagicMock()
+        mock_guw.return_value = mock_workspace
+        ret = get_user_workspace(self.app, request)
+        self.assertEqual(ret, mock_workspace)
+        mock_pq.assert_called_with(self.user, 'user_workspace_quota')
+        mock_guw.assert_called_with(self.app, self.user)
+
+    def test_get_user_workspace_uor_error(self):
+        with self.assertRaises(ValueError) as context:
+            get_user_workspace(self.app, 'not_user_or_request')
+
+        self.assertEqual(
+            str(context.exception),
+            'Argument "user_or_request" must be of type HttpRequest or User: "<class \'str\'>" given.'
+        )
+
+    @mock.patch('tethys_apps.base.workspace.get_user_workspace')
+    def test_user_workspace_decorator_user(self, mock_guw):
+        from django.http import HttpRequest
+        request = HttpRequest()
+        request.user = self.user
+        mock_workspace = mock.MagicMock()
+        mock_guw.return_value = mock_workspace
+        ret = user_dec_controller(request)
+        self.assertEqual(ret, mock_workspace)
+        mock_guw.assert_called_with(request, self.user)
+
+    def test_user_workspace_decorator_HttpRequest_not_given(self):
+        not_a_request = mock.MagicMock()
+        with self.assertRaises(ValueError) as context:
+            user_dec_controller(not_a_request)
+
+        self.assertEqual(
+            str(context.exception),
+            'No request given. The user_workspace decorator only works on controllers.'
+        )
 
     @mock.patch('tethys_apps.base.workspace.TethysWorkspace')
-    def test_get_app_workspace(self, mock_tws):
-        _get_app_workspace(self.app)
-
-        # Check result
+    def test__get_app_workspace(self, mock_tws):
+        ret = _get_app_workspace(self.app)
+        self.assertEqual(ret, mock_tws())
+        expected_path = os.path.join('workspaces', 'app_workspace')
         rts_call_args = mock_tws.call_args_list
-        self.assertIn('workspaces', rts_call_args[0][0][0])
-        self.assertIn('app_workspace', rts_call_args[0][0][0])
-        self.assertNotIn('user_workspaces', rts_call_args[0][0][0])
+        self.assertIn(expected_path, rts_call_args[0][0][0])
 
-    @mock.patch('tethys_apps.base.workspace.log')
-    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
-    @mock.patch('tethys_apps.utilities.get_active_app')
-    @mock.patch('tethys_apps.base.workspace._get_user_workspace')
-    def test_user_workspace_user(self, mock_guw, _, mock_pq, mock_log):
-        user_workspace = mock.MagicMock()
-        mock_guw.return_value = user_workspace
-        mock_request = mock.MagicMock(spec=HttpRequest, user=mock.MagicMock(spec=User))
-
-        ret = user_dec_controller(mock_request)
-        self.assertEqual(user_workspace, ret)
-        self.assertEqual(0, len(mock_log.warning.call_args_list))
-        mock_pq.assert_called_once()
-
-    def test_user_workspace_no_HttpRequest(self):
-        mock_request = mock.MagicMock()
-
-        ret = None
-        with self.assertRaises(ValueError) as context:
-            ret = user_dec_controller(mock_request)
-        self.assertTrue(
-            'No request given. The user_workspace decorator only works on controllers.' in str(context.exception))
-        self.assertEqual(None, ret)
-
-    @mock.patch('tethys_apps.base.workspace.log')
     @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
     @mock.patch('tethys_apps.utilities.get_active_app')
     @mock.patch('tethys_apps.base.workspace._get_app_workspace')
-    def test_app_workspace_app(self, mock_gaw, _, mock_pq, mock_log):
-        app_workspace = mock.MagicMock()
-        mock_gaw.return_value = app_workspace
-        mock_request = mock.MagicMock(spec=HttpRequest, user=mock.MagicMock(spec=User))
+    def test_get_app_workspace_app_instance(self, mock_gaw, mock_gaa, mock_pq):
+        mock_workspace = mock.MagicMock()
+        mock_gaw.return_value = mock_workspace
+        ret = get_app_workspace(self.app)
+        self.assertEqual(ret, mock_workspace)
+        mock_gaa.assert_not_called()
+        mock_pq.assert_called_with(self.app, 'app_workspace_quota')
+        mock_gaw.assert_called_with(self.app)
 
-        ret = app_dec_controller(mock_request)
-        self.assertEqual(app_workspace, ret)
-        self.assertEqual(0, len(mock_log.warning.call_args_list))
-        mock_pq.assert_called_once()
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.utilities.get_active_app')
+    @mock.patch('tethys_apps.base.workspace._get_app_workspace')
+    def test_get_app_workspace_app_class(self, mock_gaw, mock_gaa, mock_pq):
+        mock_workspace = mock.MagicMock()
+        mock_gaw.return_value = mock_workspace
+        ret = get_app_workspace(TethysAppChild)
+        self.assertEqual(ret, mock_workspace)
+        mock_gaa.assert_not_called()
+        mock_pq.assert_called_with(TethysAppChild, 'app_workspace_quota')
+        mock_gaw.assert_called_with(TethysAppChild)
+    
+    @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
+    @mock.patch('tethys_apps.utilities.get_active_app')
+    @mock.patch('tethys_apps.base.workspace._get_app_workspace')
+    def test_get_app_workspace_http(self, mock_gaw, mock_gaa, mock_pq):
+        from django.http import HttpRequest
+        request = HttpRequest()
+        mock_workspace = mock.MagicMock()
+        mock_gaw.return_value = mock_workspace
+        mock_app = mock.MagicMock()
+        mock_gaa.return_value = mock_app
+        ret = get_app_workspace(request)
+        self.assertEqual(ret, mock_workspace)
+        mock_gaa.assert_called_with(request, get_class=True)
+        mock_pq.assert_called_with(mock_app, 'app_workspace_quota')
+        mock_gaw.assert_called_with(mock_app)
 
-    def test_app_workspace_no_HttpRequest(self):
-        mock_request = mock.MagicMock()
-
-        ret = None
+    def test_get_app_workspace_error(self):
         with self.assertRaises(ValueError) as context:
-            ret = app_dec_controller(mock_request)
-        self.assertTrue(
-            'No request given. The app_workspace decorator only works on controllers.' in str(context.exception))
-        self.assertEqual(None, ret)
+            get_app_workspace('not_app_or_request')
+
+        self.assertEqual(
+            str(context.exception),
+            'Argument "app_or_request" must be of type HttpRequest or TethysAppBase: "<class \'str\'>" given.'
+        )
+
+    @mock.patch('tethys_apps.utilities.get_active_app')
+    @mock.patch('tethys_apps.base.workspace.get_app_workspace')
+    def test_app_workspace_decorator(self, mock_gaw, mock_gaa):
+        from django.http import HttpRequest
+        request = HttpRequest()
+        mock_workspace = mock.MagicMock()
+        mock_gaw.return_value = mock_workspace
+        mock_app = mock.MagicMock()
+        mock_gaa.return_value = mock_app
+        ret = app_dec_controller(request)
+        self.assertEqual(ret, mock_workspace)
+        mock_gaw.assert_called_with(request)
+
+    def test_app_workspace_decorator_HttpRequest_not_given(self):
+        not_a_request = mock.MagicMock()
+
+        with self.assertRaises(ValueError) as context:
+            app_dec_controller(not_a_request)
+
+        self.assertEqual(
+            str(context.exception),
+            'No request given. The app_workspace decorator only works on controllers.'
+        )

--- a/tests/unit_tests/test_tethys_apps/test_base/test_workspace.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_workspace.py
@@ -5,7 +5,6 @@ import shutil
 from unittest import mock
 from ... import UserFactory
 from django.http import HttpRequest
-from django.contrib.auth.models import User
 import tethys_apps.base.app_base as tethys_app_base
 from tethys_apps.base.workspace import (
     _get_user_workspace, get_user_workspace, user_workspace, _get_app_workspace, get_app_workspace, app_workspace
@@ -146,7 +145,6 @@ class TestUrlMap(unittest.TestCase):
 
     @mock.patch('tethys_apps.base.workspace.TethysWorkspace')
     def test__get_user_workspace_http(self, mock_tws):
-        from django.http import HttpRequest
         request = HttpRequest()
         request.user = self.user
         ret = _get_user_workspace(self.app, request)
@@ -196,7 +194,6 @@ class TestUrlMap(unittest.TestCase):
     @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
     @mock.patch('tethys_apps.base.workspace._get_user_workspace')
     def test_get_user_workspace_aor_request(self, mock_guw, mock_pq, mock_gaa):
-        from django.http import HttpRequest
         request = HttpRequest()
         request.user = self.user
         mock_workspace = mock.MagicMock()
@@ -231,7 +228,6 @@ class TestUrlMap(unittest.TestCase):
     @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
     @mock.patch('tethys_apps.base.workspace._get_user_workspace')
     def test_get_user_workspace_uor_request(self, mock_guw, mock_pq):
-        from django.http import HttpRequest
         request = HttpRequest()
         request.user = self.user
         mock_workspace = mock.MagicMock()
@@ -252,7 +248,6 @@ class TestUrlMap(unittest.TestCase):
 
     @mock.patch('tethys_apps.base.workspace.get_user_workspace')
     def test_user_workspace_decorator_user(self, mock_guw):
-        from django.http import HttpRequest
         request = HttpRequest()
         request.user = self.user
         mock_workspace = mock.MagicMock()
@@ -302,12 +297,11 @@ class TestUrlMap(unittest.TestCase):
         mock_gaa.assert_not_called()
         mock_pq.assert_called_with(TethysAppChild, 'app_workspace_quota')
         mock_gaw.assert_called_with(TethysAppChild)
-    
+
     @mock.patch('tethys_apps.base.workspace.passes_quota', return_value=True)
     @mock.patch('tethys_apps.utilities.get_active_app')
     @mock.patch('tethys_apps.base.workspace._get_app_workspace')
     def test_get_app_workspace_http(self, mock_gaw, mock_gaa, mock_pq):
-        from django.http import HttpRequest
         request = HttpRequest()
         mock_workspace = mock.MagicMock()
         mock_gaw.return_value = mock_workspace
@@ -331,7 +325,6 @@ class TestUrlMap(unittest.TestCase):
     @mock.patch('tethys_apps.utilities.get_active_app')
     @mock.patch('tethys_apps.base.workspace.get_app_workspace')
     def test_app_workspace_decorator(self, mock_gaw, mock_gaa):
-        from django.http import HttpRequest
         request = HttpRequest()
         mock_workspace = mock.MagicMock()
         mock_gaw.return_value = mock_workspace

--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -19,6 +19,7 @@ from .testing.environment import is_testing_environment, get_test_db_name, TESTI
 from .permissions import Permission as TethysPermission, PermissionGroup
 from .handoff import HandoffManager
 from .mixins import TethysBaseMixin
+from .workspace import get_app_workspace, get_user_workspace
 from ..exceptions import TethysAppSettingDoesNotExist, TethysAppSettingNotAssigned
 
 from bokeh.server.django.consumers import WSConsumer
@@ -905,6 +906,36 @@ class TethysAppBase(TethysBase):
         app = cls()
         job_manager = JobManager(app)
         return job_manager
+
+    @classmethod
+    def get_user_workspace(cls, user_or_request):
+        """
+        Get the dedicated user workspace for this app. If an HttpRequest is given, the workspace of the logged-in user will be returned (i.e. request.user).
+
+        Args:
+            request_or_user (User or HttpRequest): Either an HttpRequest with active user session or Django User object.
+        
+        Raises:
+            ValueError: if user_or_request is not of type HttpRequest or User.
+            AssertionError: if quota for the user workspace has been exceeded.
+
+        Returns:
+            TethysWorkspace: workspace object bound to the user's workspace directory.
+        """  # noqa: E501
+        return get_user_workspace(cls, user_or_request)
+
+    @classmethod
+    def get_app_workspace(cls):
+        """
+        Get the app workspace for the given Tethys App class.
+
+        Raises:
+            AssertionError: if quota for the app workspace has been exceeded.
+
+        Returns:
+            TethysWorkspace: workspace object bound to the app workspace.
+        """
+        return get_app_workspace(cls)
 
     @classmethod
     def get_scheduler(cls, name):

--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -914,13 +914,24 @@ class TethysAppBase(TethysBase):
 
         Args:
             request_or_user (User or HttpRequest): Either an HttpRequest with active user session or Django User object.
-        
+
         Raises:
             ValueError: if user_or_request is not of type HttpRequest or User.
             AssertionError: if quota for the user workspace has been exceeded.
 
         Returns:
             TethysWorkspace: workspace object bound to the user's workspace directory.
+
+        **Example:**
+
+        ::
+
+            from .app import MyFirstApp as app
+
+            @controller
+            def my_controller(request):
+                user_workspace = app.get_user_workspace(request.user)
+                ...
         """  # noqa: E501
         return get_user_workspace(cls, user_or_request)
 
@@ -934,6 +945,17 @@ class TethysAppBase(TethysBase):
 
         Returns:
             TethysWorkspace: workspace object bound to the app workspace.
+
+        **Example:**
+
+        ::
+
+            from .app import MyFirstApp as app
+
+            @controller
+            def my_controller(request):
+                app_workspace = app.get_app_workspace()
+                ...
         """
         return get_app_workspace(cls)
 
@@ -952,7 +974,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             scheduler = app.get_scheduler('primary_condor')
             job_manager = app.get_job_manager()
@@ -991,7 +1013,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             max_count = app.get_custom_setting('max_count')
 
@@ -1018,7 +1040,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             max_count = app.set_custom_setting('max_count', 5)
 
@@ -1071,7 +1093,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             ckan_engine = app.get_dataset_service('primary_ckan', as_engine=True)
 
@@ -1109,7 +1131,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             geoserver_engine = app.get_spatial_dataset_service('primary_geoserver', as_engine=True)
 
@@ -1150,7 +1172,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             wps_engine = app.get_web_processing_service('primary_52n')
 
@@ -1183,7 +1205,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             conn_engine = app.get_persistent_store_connection('primary')
             conn_url = app.get_persistent_store_connection('primary', as_url=True)
@@ -1222,7 +1244,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             db_engine = app.get_persistent_store_database('example_db')
             db_url = app.get_persistent_store_database('example_db', as_url=True)
@@ -1269,7 +1291,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             result = app.create_persistent_store('example_db', 'primary')
 
@@ -1352,7 +1374,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             result = app.drop_persistent_store('example_db')
 
@@ -1396,7 +1418,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             ps_databases = app.list_persistent_store_databases()
 
@@ -1425,7 +1447,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             ps_connections = app.list_persistent_store_connections()
 
@@ -1452,7 +1474,7 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from my_first_app.app import MyFirstApp as app
+            from .app import MyFirstApp as app
 
             result = app.persistent_store_exists('example_db')
 

--- a/tethys_apps/base/bokeh_handler.py
+++ b/tethys_apps/base/bokeh_handler.py
@@ -18,7 +18,7 @@ from django.http.request import HttpRequest
 from django.shortcuts import render
 
 # Tethys Imports
-from tethys_sdk.workspaces import user_workspace, app_workspace
+from tethys_sdk.workspaces import get_user_workspace, get_app_workspace
 
 
 def with_request(handler):
@@ -38,20 +38,10 @@ def with_workspaces(handler):
     @with_request
     @wraps(handler)
     def wrapper(doc: Document):
-        doc.user_workspace = get_user_workspace(doc.request)
+        doc.user_workspace = get_user_workspace(doc.request, doc.request.user)
         doc.app_workspace = get_app_workspace(doc.request)
         return handler(doc)
     return wrapper
-
-
-@user_workspace
-def get_user_workspace(request, user_workspace):
-    return user_workspace
-
-
-@app_workspace
-def get_app_workspace(request, app_workspace):
-    return app_workspace
 
 
 def _get_bokeh_controller(template=None, app_package=None):

--- a/tethys_apps/base/workspace.py
+++ b/tethys_apps/base/workspace.py
@@ -211,29 +211,6 @@ def _get_user_workspace(app_class, user_or_request):
 
     Returns:
       tethys_apps.base.TethysWorkspace: An object representing the workspace.
-
-    **Example:**
-
-    ::
-
-        import os
-        from my_first_app.app import MyFirstApp as app
-
-        def a_controller(request):
-            \"""
-            Example controller that uses get_user_workspace() method.
-            \"""
-            # Retrieve the workspace
-            user_workspace = app.get_user_workspace(request.user)
-            new_file_path = os.path.join(user_workspace.path, 'new_file.txt')
-
-            with open(new_file_path, 'w') as a_file:
-                a_file.write('...')
-
-            context = {}
-
-            return render(request, 'my_first_app/template.html', context)
-
     """
     username = ''
 
@@ -259,13 +236,23 @@ def get_user_workspace(app_class_or_request, user_or_request) -> TethysWorkspace
     Args:
         app_class_or_request (TethysAppBase or HttpRequest): The Tethys app class that is defined in app.py or HttpRequest to app endpoint.
         user_or_request (User or HttpRequest): Either an HttpRequest with active user session or Django User object.
-    
+
     Raises:
         ValueError: if app_class_or_request or user_or_request are not correct types.
         AssertionError: if quota for the user workspace has been exceeded.
 
     Returns:
-        TethysWorkspace: workspace object bound to the user's workspace directory.    
+        TethysWorkspace: workspace object bound to the user's workspace directory.
+
+    ::
+
+        import os
+        from tethys_sdk.workspaces import get_user_workspace
+        from .app import MyFirstApp as app
+
+        def some_function(user):
+            user_workspace = get_user_workspace(app, user)
+            ...
     """  # noqa: E501
     from tethys_apps.base.app_base import TethysAppBase
     from tethys_apps.utilities import get_active_app
@@ -273,7 +260,7 @@ def get_user_workspace(app_class_or_request, user_or_request) -> TethysWorkspace
 
     # Get app
     if isinstance(app_class_or_request, TethysAppBase) or \
-        (isinstance(app_class_or_request, type) and issubclass(app_class_or_request, TethysAppBase)):
+       (isinstance(app_class_or_request, type) and issubclass(app_class_or_request, TethysAppBase)):
         app = app_class_or_request
     elif isinstance(app_class_or_request, HttpRequest):
         app = get_active_app(app_class_or_request, get_class=True)
@@ -351,29 +338,6 @@ def _get_app_workspace(app_class):
 
     Returns:
       tethys_apps.base.TethysWorkspace: An object representing the workspace.
-
-    **Example:**
-
-    ::
-
-        import os
-        from my_first_app.app import MyFirstApp as app
-
-        def a_controller(request):
-            \"""
-            Example controller that uses get_app_workspace() method.
-            \"""
-            # Retrieve the workspace
-            app_workspace = app.get_app_workspace()
-            new_file_path = os.path.join(app_workspace.path, 'new_file.txt')
-
-            with open(new_file_path, 'w') as a_file:
-                a_file.write('...')
-
-            context = {}
-
-            return render(request, 'my_first_app/template.html', context)
-
     """
     project_directory = os.path.dirname(sys.modules[app_class.__module__].__file__)
     workspace_directory = os.path.join(project_directory, 'workspaces', 'app_workspace')
@@ -393,6 +357,18 @@ def get_app_workspace(app_or_request) -> TethysWorkspace:
 
     Returns:
         TethysWorkspace: workspace object bound to the app workspace.
+
+    **Example:**
+
+    ::
+
+        import os
+        from tethys_sdk.workspaces import get_app_workspace
+        from .app import MyFirstApp as app
+
+        def some_function():
+            app_workspace = get_app_workspace(app)
+            ...
     """
     from tethys_apps.base.app_base import TethysAppBase
     from tethys_apps.utilities import get_active_app
@@ -401,7 +377,7 @@ def get_app_workspace(app_or_request) -> TethysWorkspace:
     if isinstance(app_or_request, HttpRequest):
         app = get_active_app(app_or_request, get_class=True)
     elif isinstance(app_or_request, TethysAppBase) or \
-        (isinstance(app_or_request, type) and issubclass(app_or_request, TethysAppBase)):
+            (isinstance(app_or_request, type) and issubclass(app_or_request, TethysAppBase)):
         app = app_or_request
     else:
         raise ValueError(f'Argument "app_or_request" must be of type HttpRequest or TethysAppBase: '

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -102,7 +102,7 @@ def get_directories_in_tethys(directory_names, with_app_name=False):
     return match_dirs
 
 
-def get_active_app(request=None, url=None, get_class=None):
+def get_active_app(request=None, url=None, get_class=False):
     """
     Get the active TethysApp object based on the request or URL.
     """

--- a/tethys_quotas/decorators.py
+++ b/tethys_quotas/decorators.py
@@ -8,7 +8,6 @@
 """
 import logging
 from django.utils.functional import wraps
-from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
 from tethys_apps.utilities import get_active_app
 from tethys_quotas.models.resource_quota import ResourceQuota

--- a/tethys_sdk/workspaces.py
+++ b/tethys_sdk/workspaces.py
@@ -9,4 +9,5 @@
 """
 # flake8: noqa
 # DO NOT ERASE
-from tethys_apps.base.workspace import TethysWorkspace, user_workspace, app_workspace
+from tethys_apps.base.workspace import TethysWorkspace, user_workspace, app_workspace, get_app_workspace, \
+    get_user_workspace


### PR DESCRIPTION
Adds `get_app_workspace` and `get_user_workspace` functions that can be used when the decorator cannot be used. 

- These functions will enforce Workspace Quotas when enabled.
- They raise an Assertion Error when the Quota is not met.