### PR TITLE
Unpin pyjwt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,7 @@ dependencies:
   - condorpy
   - siphon
   - python-jose
-  - pyjwt<2.0.0
+  - pyjwt
 
   # datetime dependencies
   - arrow


### PR DESCRIPTION
I'm not sure why pyjwt was pinned, but it's preventing other packages (e.g. `python-social-core`) from updating to the latest version.