### PR TITLE
Refinements to the Click-n-plot capability of MapLayout

### DIFF
--- a/docs/tethys_sdk/layouts/map_layout.rst
+++ b/docs/tethys_sdk/layouts/map_layout.rst
@@ -573,13 +573,15 @@ In this example, the plot data is hard-coded for simplicity:
 
 .. code-block:: python
 
-    def get_plot_for_layer_feature(self, request, layer_name, feature_id, *args, **kwargs):
+    def get_plot_for_layer_feature(self, request, layer_name, feature_id, layer_data, feature_props, *args, **kwargs):
         """
         Retrieves plot data for given feature on given layer.
 
         Args:
             layer_name (str): Name/id of layer.
             feature_id (str): ID of feature.
+            layer_data (dict): The MVLayer.data dictionary.
+            feature_props (dict): The properties of the selected feature.
 
         Returns:
             str, list<dict>, dict: plot title, data series, and layout options, respectively.

--- a/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
+++ b/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
@@ -239,7 +239,7 @@ class TestMapLayout(TestCase):
         mock_request = mock.MagicMock()
         inst = MapLayout()
         plot_title, data, layout = inst.get_plot_for_layer_feature(
-            mock_request, "Foo", "12345"
+            mock_request, "Foo", "12345", {}, {}
         )
         self.assertEqual(plot_title, "Undefined")
         self.assertListEqual(
@@ -741,12 +741,16 @@ class TestMapLayout(TestCase):
         self.assertIn(geojson, ret2)
 
     def test_get_plot_data(self):
+        layer_data = {"layer_id": "24680"}
+        feature_props = {"id": "67890", "name": "foo"}
         request = self.factory.post(
             "/some/endpoint",
             data={
                 "method": "get-plot-data",
                 "layer_name": "Foo",
                 "feature_id": "12345",
+                "layer_data": json.dumps(layer_data),
+                "feature_props": json.dumps(feature_props),
             },
         )
 

--- a/tethys_layouts/mixins/map_layout.py
+++ b/tethys_layouts/mixins/map_layout.py
@@ -333,10 +333,8 @@ class MapLayoutMixin:
             data=data,
             feature_selection=selectable,
             times=times,
+            geometry_attribute=geometry_attribute,
         )
-
-        if geometry_attribute:
-            mv_layer.geometry_attribute = geometry_attribute
 
         return mv_layer
 

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -357,6 +357,7 @@ var MAP_LAYOUT = (function() {
                     'role="button"' +
                     'data-feature-id="' + fid +'"' +
                     'data-layer-id="' + layer_id + '"' +
+                    'data-layer-data="' + JSON.stringify(layer.tethys_data) + '"'
                 '>Plot</a>' +
             '</div>';
 
@@ -402,9 +403,10 @@ var MAP_LAYOUT = (function() {
         $('.btn-plot').on('click', function(e) {
             let layer_name = $(e.target).data('layer-id');
             let feature_id = $(e.target).data('feature-id');
+            let layer_data = $(e.target).data('layer-data');
 
             // Load the plot
-            load_plot(e.target, layer_name, feature_id);
+            load_plot(e.target, layer_name, feature_id, layer_data);
             hide_properties_pop_up();
         });
     };
@@ -423,7 +425,7 @@ var MAP_LAYOUT = (function() {
         });
     };
 
-    load_plot = function(plot_button, layer_name, feature_id) {
+    load_plot = function(plot_button, layer_name, feature_id, layer_data) {
         // Disable plot button
         $(plot_button).attr('disabled', 'disabled');
 
@@ -434,7 +436,8 @@ var MAP_LAYOUT = (function() {
             data: {
                 'method': 'get-plot-data',
                 'layer_name': layer_name,
-                'feature_id': feature_id
+                'feature_id': feature_id,
+                'layer_data': layer_data,
             },
         }).done(function(data){
             // Update plot

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -354,10 +354,10 @@ var MAP_LAYOUT = (function() {
             '<div class="plot-btn-wrapper">' +
                 '<a class="btn btn-primary btn-popup btn-plot" ' +
                     'href="javascript:void(0);" ' +
-                    'role="button"' +
-                    'data-feature-id="' + fid +'"' +
-                    'data-layer-id="' + layer_id + '"' +
-                    'data-layer-data="' + JSON.stringify(layer.tethys_data) + '"'
+                    'role="button" ' +
+                    'data-feature-id="' + fid +'" ' +
+                    'data-layer-id="' + layer_id + '" ' +
+                    'data-layer-data=' + JSON.stringify(layer.tethys_data) +
                 '>Plot</a>' +
             '</div>';
 

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -357,7 +357,8 @@ var MAP_LAYOUT = (function() {
                     'role="button" ' +
                     'data-feature-id="' + fid +'" ' +
                     'data-layer-id="' + layer_id + '" ' +
-                    'data-layer-data="' + JSON.stringify(layer.tethys_data) + '"' +
+                    'data-layer-data="' + encodeURIComponent(JSON.stringify(layer.tethys_data)) + '"' +
+                    'data-feature-props="' + encodeURIComponent(JSON.stringify(feature.getProperties())) + '"' +
                 '>Plot</a>' +
             '</div>';
 
@@ -404,9 +405,10 @@ var MAP_LAYOUT = (function() {
             let layer_name = $(e.target).data('layer-id');
             let feature_id = $(e.target).data('feature-id');
             let layer_data = $(e.target).data('layer-data');
+            let feature_props = $(e.target).data('feature-props');
 
             // Load the plot
-            load_plot(e.target, layer_name, feature_id, layer_data);
+            load_plot(e.target, layer_name, feature_id, layer_data, feature_props);
             hide_properties_pop_up();
         });
     };
@@ -425,7 +427,7 @@ var MAP_LAYOUT = (function() {
         });
     };
 
-    load_plot = function(plot_button, layer_name, feature_id, layer_data) {
+    load_plot = function(plot_button, layer_name, feature_id, layer_data, feature_props) {
         // Disable plot button
         $(plot_button).attr('disabled', 'disabled');
 
@@ -438,6 +440,7 @@ var MAP_LAYOUT = (function() {
                 'layer_name': layer_name,
                 'feature_id': feature_id,
                 'layer_data': layer_data,
+                'feature_props': feature_props,
             },
         }).done(function(data){
             // Update plot

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -404,8 +404,8 @@ var MAP_LAYOUT = (function() {
         $('.btn-plot').on('click', function(e) {
             let layer_name = $(e.target).data('layer-id');
             let feature_id = $(e.target).data('feature-id');
-            let layer_data = JSON.parse(decodeURIComponent($(e.target).data('layer-data')));
-            let feature_props = JSON.parse(decodeURIComponent($(e.target).data('feature-props')));
+            let layer_data = decodeURIComponent($(e.target).data('layer-data'));
+            let feature_props = decodeURIComponent($(e.target).data('feature-props'));
 
             // Load the plot
             load_plot(e.target, layer_name, feature_id, layer_data, feature_props);

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -404,8 +404,8 @@ var MAP_LAYOUT = (function() {
         $('.btn-plot').on('click', function(e) {
             let layer_name = $(e.target).data('layer-id');
             let feature_id = $(e.target).data('feature-id');
-            let layer_data = $(e.target).data('layer-data');
-            let feature_props = $(e.target).data('feature-props');
+            let layer_data = JSON.parse(decodeURIComponent($(e.target).data('layer-data')));
+            let feature_props = JSON.parse(decodeURIComponent($(e.target).data('feature-props')));
 
             // Load the plot
             load_plot(e.target, layer_name, feature_id, layer_data, feature_props);

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -357,7 +357,7 @@ var MAP_LAYOUT = (function() {
                     'role="button" ' +
                     'data-feature-id="' + fid +'" ' +
                     'data-layer-id="' + layer_id + '" ' +
-                    'data-layer-data=' + JSON.stringify(layer.tethys_data) +
+                    'data-layer-data="' + JSON.stringify(layer.tethys_data) + '"' +
                 '>Plot</a>' +
             '</div>';
 

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -173,7 +173,7 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         return cls.initial_map_extent
 
     def get_plot_for_layer_feature(
-        self, request, layer_name, feature_id, layer_data, *args, **kwargs
+        self, request, layer_name, feature_id, layer_data, feature_props, *args, **kwargs
     ):
         """
         Retrieves plot data for given feature on given layer.
@@ -590,10 +590,11 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         layer_name = request.POST.get("layer_name", "")
         feature_id = request.POST.get("feature_id", "")
         layer_data = json.loads(request.POST.get("layer_data", "{}"))
+        feature_props = json.loads(request.POST.get("feature_props", "{}"))
 
         # Initialize MapManager
         title, data, layout = self.get_plot_for_layer_feature(
-            request, layer_name, feature_id, layer_data, *args, **kwargs
+            request, layer_name, feature_id, layer_data, feature_props, *args, **kwargs
         )
 
         return JsonResponse({"title": title, "data": data, "layout": layout})

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -156,6 +156,8 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         Args:
             request(HttpRequest): A Django request object.
             map_view(MapView): The MapView gizmo to add layers to.
+            layer_data (dict): The MVLayer.data dictionary.
+            feature_props (dict): The properties of the selected feature.
 
         Returns:
             list<LayerGroupDicts>: The MapView, extent, and list of LayerGroup dictionaries.
@@ -173,7 +175,14 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         return cls.initial_map_extent
 
     def get_plot_for_layer_feature(
-        self, request, layer_name, feature_id, layer_data, feature_props, *args, **kwargs
+        self,
+        request,
+        layer_name,
+        feature_id,
+        layer_data,
+        feature_props,
+        *args,
+        **kwargs,
     ):
         """
         Retrieves plot data for given feature on given layer.

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -173,7 +173,7 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         return cls.initial_map_extent
 
     def get_plot_for_layer_feature(
-        self, request, layer_name, feature_id, *args, **kwargs
+        self, request, layer_name, feature_id, layer_data, *args, **kwargs
     ):
         """
         Retrieves plot data for given feature on given layer.
@@ -589,10 +589,11 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         # Get request parameters
         layer_name = request.POST.get("layer_name", "")
         feature_id = request.POST.get("feature_id", "")
+        layer_data = json.loads(request.POST.get("layer_data", "{}"))
 
         # Initialize MapManager
         title, data, layout = self.get_plot_for_layer_feature(
-            request, layer_name, feature_id, *args, **kwargs
+            request, layer_name, feature_id, layer_data, *args, **kwargs
         )
 
         return JsonResponse({"title": title, "data": data, "layout": layout})


### PR DESCRIPTION
Include the `layer.tethys_data` and `feature.properties` objects in the AJAX request that is sent to generate the plot data.

TODO:

- [x] Lint
- [x] Update docs
- [x] Tests