### PR TITLE
Fixed dynamic settings sync bug

### DIFF
--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -1654,8 +1654,8 @@ class TethysAppBase(TethysBase):
         # persistent store settings
         db_app.sync_settings(
             self.persistent_store_settings(),
-            db_app.persistent_store_connection_settings
-            | db_app.persistent_store_database_settings,
+            list(db_app.persistent_store_connection_settings)
+            + list(db_app.persistent_store_database_settings),
         )
         # scheduler settings
         db_app.sync_settings(self.scheduler_settings(), db_app.scheduler_settings)

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -98,6 +98,10 @@ class TethysApp(models.Model, TethysBaseMixin):
             self.add_settings(setting_list)
             setting_names = [setting.name for setting in setting_list]
             for setting in existing_settings:
+                # Do not remove dynamically craeted settings
+                if getattr(setting, "dynamic", False) and setting.dynamic:
+                    continue
+
                 if setting.name not in setting_names:
                     setting.delete()
 

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -175,8 +175,11 @@ class MapLayout(TethysLayout, MapLayoutMixin):
         Retrieves plot data for given feature on given layer.
 
         Args:
+            request(HttpRequest): A Django request object.
             layer_name(str): Name/id of layer.
             feature_id(str): Feature ID of feature.
+            layer_data(dict): Data attached to the layer with the data argument.
+            feature_props(dict): Feature type properties.
 
         Returns:
             str, list<dict>, dict: plot title, data series, and layout options, respectively.


### PR DESCRIPTION
Fixes a bug with app setting syncing introduced with #890.

- Persistent store database settings that were created dynamically using the `app.create_persistent_store()` method were removed every time Tethys reloaded.
- This is because dynamically created settings are not listed in the app.py and were thus being treated as obsolete settings.
- This PR makes it so that settings with a `dynamic` attribute that is `True` will be ignored when removing obsolete settings.