### PR TITLE
Fix Cookies JS Path

### DIFF
--- a/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
+++ b/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
@@ -41,7 +41,6 @@ class ComposeLayersMapLayout(MapLayout):
             layer_title="WMS THREDDS Layer",
             layer_variable="grace",
             visible=True,
-            show_legend=False,
         )
 
         wms_geoserver_layer = self.build_wms_layer(
@@ -75,6 +74,7 @@ class ComposeLayersMapLayout(MapLayout):
             layer_variable="reference",
             visible=False,
             extent=[-63.69, 12.81, -129.17, 49.38],
+            show_legend=False,
         )
 
         arc_gis_layer = self.build_arc_gis_layer(

--- a/tethys_portal/dependencies.py
+++ b/tethys_portal/dependencies.py
@@ -79,7 +79,7 @@ class StaticDependency:
 
     def _get_url(self, url_type_or_path, version=None, debug=None, use_cdn=None):
         version = version or self.version
-        debug = debug if debug is None else settings.DEBUG
+        debug = debug if debug is not None else settings.DEBUG
         use_cdn = use_cdn or self.use_cdn
 
         path = {

--- a/tethys_portal/dependencies.py
+++ b/tethys_portal/dependencies.py
@@ -79,7 +79,7 @@ class StaticDependency:
 
     def _get_url(self, url_type_or_path, version=None, debug=None, use_cdn=None):
         version = version or self.version
-        debug = debug or settings.DEBUG
+        debug = debug if debug is None else settings.DEBUG
         use_cdn = use_cdn or self.use_cdn
 
         path = {
@@ -216,7 +216,8 @@ vendor_static_dependencies = {
     "doc_cookies": JsDelivrStaticDependency(
         npm_name="doc-cookies",
         version="1.1.0",
-        js_path="cookies.min.js",
+        js_path="cookies_min.js",
+        debug_path_converter=lambda path: path.replace("_min", ""),
     ),
     "graphlib": JsDelivrStaticDependency(
         npm_name="graphlib",


### PR DESCRIPTION
Fix the "min" path for cookies.js so it will work with CND and local.

The published path for the minified version of the `cookies.js` file in the npm package is `cookies_min.js`. JSDelivr generated it's own version and called it `cookies.min.js`. Since Tethys used the `cookies.min.js` path, the minified version would work when using CDN, but it would fail when trying to server the files locally (because the npm package didn't contain the `cookies.min.js` version of the file.

This fix changes the minified path to use `cookies_min.js` which is available in both the npm package and on JSDelivr.