### PR TITLE
Fix error message showing in green box while deleting a job

### DIFF
--- a/tethys_gizmos/views/gizmos/jobs_table.py
+++ b/tethys_gizmos/views/gizmos/jobs_table.py
@@ -41,7 +41,7 @@ def delete(request, job_id):
         success = True
         message = ""
     except Exception as e:
-        success = True
+        success = False
         message = str(e)
         log.error(f"The following error occurred when deleting job {job_id}: {message}")
     return JsonResponse({"success": success, "message": message})


### PR DESCRIPTION
Before this change, an exception while deleting a job would show the error message in a green success box and remove the job row from the browser display, although a browser refresh would show that job again. After this change, it will show the error in a red box and still display the job.