### PR TITLE
New Documentation Theme

### DIFF
--- a/docs/_static/css/tethys.css
+++ b/docs/_static/css/tethys.css
@@ -1,7 +1,9 @@
+/* Header color */
 .bg-gray-dark {
     background-color: #1662a9;
 }
 
+/* Spacing between sections */
 section>section {
     padding-bottom: 0;
     padding-top: 0;
@@ -9,11 +11,22 @@ section>section {
     margin-top: 3rem;
 }
 
+/* Hide header buttons if screen gets too narrow */
+@media (max-width: 975px) {
+    header a {
+        display: none!important;
+    }
+}
+
+/* Make the sidebar nav not so wide */
+[data-sidebar-target=sidebar].isShown {
+    width: auto!important;
+}
+
 /* Read the docs version picker */
 .rst-versions.rst-badge {
-    top: 16px!important;
+    bottom: 16px!important;
     height: auto!important;
-    bottom: auto!important;
 }
 
 .rst-versions .rst-current-version {

--- a/docs/_static/css/tethys.css
+++ b/docs/_static/css/tethys.css
@@ -26,6 +26,8 @@ section>section {
 /* Read the docs version picker */
 .rst-versions.rst-badge {
     bottom: 16px!important;
+    left: 16px!important;
+    right: auto!important;
     height: auto!important;
 }
 

--- a/docs/_static/css/tethys.css
+++ b/docs/_static/css/tethys.css
@@ -1,30 +1,12 @@
-.mdl-layout__header {
-    background: #1662a9!important;
+.bg-gray-dark {
+    background-color: #1662a9;
 }
 
-.mdl-layout__drawer>.mdl-layout-title .title-text {
-    text-align: left!important;
-}
-
-img[alt='_images/tethys_logo_inverse.png'] {
-    float: left;
-    margin: 20px 10px 10px 0px;
-}
-
-#idbutton-show-source {
-    display: none;
-}
-
-form[action="search.html"] {
-    margin-right: 125px;
-}
-
-.brand {
-    background-image: url(http://www.tethysplatform.org/images/tethys-logo-75.png);
-    background-size: 30px;
-    padding: 2px 0 10px 35px;
-    background-repeat: no-repeat;
-    text-align: center;
+section>section {
+    padding-bottom: 0;
+    padding-top: 0;
+    margin-bottom: 3rem;
+    margin-top: 3rem;
 }
 
 /* Read the docs version picker */

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,7 +236,7 @@ todo_include_todos = True
 # If this is True, todo emits a warning for each TODO entries. The default is False.
 todo_emit_warnings = True
 
-html_title = f"{project} {version} Documentation"
+html_title = f"{project} Documentation"
 html_short_title = "Tethys Docs"
 html_logo = "images/features/tethys-logo-75.png"
 html_favicon = "images/default_favicon.ico"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,7 @@ installed_apps = [
     "tethys_gizmos",
     "tethys_services",
     "tethys_compute",
+    "tethys_layouts",
 ]
 
 settings.configure(
@@ -119,19 +120,7 @@ settings.configure(
 )
 django.setup()
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
-
-# -- General configuration ------------------------------------------------
-
-# If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
+# Sphinx extensions
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
@@ -139,6 +128,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.todo",
     "sphinxarg.ext",
+    "sphinxawesome_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -155,7 +145,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Tethys Platform"
-copyright = "2022, Tethys Platform"
+copyright = "2023, Tethys Platform"
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get("READTHEDOCS") == "True"
@@ -168,10 +158,7 @@ release = get_version(root="..", relative_to=__file__)
 # major/minor
 version = ".".join(release.split(".")[:2])
 
-# A string of reStructuredText that will be included at the end of every source
-# file that is read. This is the right place to add substitutions that should be
-# available in every file.
-
+# Determine branch
 git_directory = Path(__file__).parent.parent
 ret = subprocess.run(
     ["git", "-C", git_directory, "rev-parse", "--abbrev-ref", "HEAD"],
@@ -192,28 +179,12 @@ exclude_patterns = ["_build"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
-# -- Options for HTML output ----------------------------------------------
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-html_favicon = "images/default_favicon.ico"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
-
-html_css_files = [
-    "css/tethys.css",
-]
-
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 smartquotes = False
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "TethysPlatformdoc"
+htmlhelp_basename = f"{project}doc"
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
@@ -265,61 +236,37 @@ todo_include_todos = True
 # If this is True, todo emits a warning for each TODO entries. The default is False.
 todo_emit_warnings = True
 
-html_theme = "sphinx_materialdesign_theme"
+html_title = f"{project} {version} Documentation"
+html_short_title = "Tethys Docs"
+html_logo = "images/features/tethys-logo-75.png"
+html_favicon = "images/default_favicon.ico"
+html_static_path = ["_static"]
+html_css_files = [
+    "css/tethys.css",
+]
 
+html_theme = "sphinxawesome_theme"
 html_theme_options = {
-    # Specify a list of menu in Header.
-    # Tuples forms:
-    #  ('Name', 'external url or path of pages in the document', boolean, 'icon name')
-    #
-    # Third argument:
-    # True indicates an external link.
-    # False indicates path of pages in the document.
-    #
-    # Fourth argument:
-    # Specify the icon name.
-    # For details see link.
-    # https://material.io/icons/
-    "header_links": [
-        ("Home", "index", False, "home"),
-        ("Tutorials", "tutorials", False, "assignment"),
-        ("SDK", "tethys_sdk", False, "build"),
-        ("Template Gizmos", "tethys_sdk/gizmos", False, "widgets"),
-        ("CLI", "tethys_cli", False, "keyboard_arrow_right"),
-        ("Tethys Portal", "tethys_portal", False, "web"),
-        ("Software Suite", "software_suite", False, "developer_board"),
-        ("Migrate Apps", "whats_new/app_migration", False, "open_in_browser"),
-        (
-            "Issues",
-            "https://github.com/tethysplatform/tethys/issues",
-            True,
-            "bug_report",
-        ),
-        ("GitHub", "https://github.com/tethysplatform/tethys", True, "launch"),
-    ],
-    # Customize css colors.
-    # For details see link.
-    # https://getmdl.io/customize/index.html
-    #
-    # Values: amber, blue, brown, cyan deep_orange, deep_purple, green, grey, indigo, light_blue,
-    #         light_green, lime, orange, pink, purple, red, teal, yellow(Default: indigo)
-    "primary_color": "blue",
-    # Values: Same as primary_color. (Default: pink)
-    "accent_color": "light_blue",
-    # Customize layout.
-    # For details see link.
-    # https://getmdl.io/components/index.html#layout-section
-    "fixed_drawer": False,
-    "fixed_header": True,
-    "header_waterfall": True,
-    "header_scroll": False,
-    # Render title in header.
-    # Values: True, False (Default: False)
-    "show_header_title": True,
-    # Render title in drawer.
-    # Values: True, False (Default: True)
-    "show_drawer_title": False,
-    # Render footer.
-    # Values: True, False (Default: True)
-    "show_footer": True,
+    "extra_header_links": {
+        "Tutorials": "tutorials",
+        "SDK": "tethys_sdk",
+        "CLI": "tethys_cli",
+        "Tethys Portal": "tethys_portal",
+        "Migrate Apps": "whats_new/app_migration",
+        "GitHub": "https://github.com/tethysplatform/tethys",
+    },
+    "show_breadcrumbs": False,
+    "show_prev_next": True,
+    "show_scrolltop": True,
 }
+
+html_collapsible_definitions = True
+
+# Link icon for header links instead of pharagraph icons that are the default
+html_permalinks_icon = (
+    '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+    '<path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 '
+    "5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 "
+    '0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z">'
+    "</path></svg>"
+)

--- a/docs/docs_environment.yml
+++ b/docs/docs_environment.yml
@@ -13,11 +13,11 @@ dependencies:
   - pip
   - tethys_dataset_services >=2.0.0
   - django =3.2.*
-  - sphinx =5.*
+  - sphinx
   - sphinx-argparse
   - make
   - setuptools_scm
   - pip:
-      - sphinx_materialdesign_theme
+      - sphinxawesome-theme
       - sphinx-autobuild
       - sphinx_autodoc_typehints

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,8 @@
-.. image:: images/features/tethys_logo_inverse.png
-   :height: 35px
-   :width: 35px
-   :align: left
-
 *************************
 Tethys Platform |version|
 *************************
 
-**Last Updated:** July 2022
+**Last Updated:** January 2023
 
 Tethys is a platform that can be used to develop and host environmental web apps. It includes a suite of free and open source software (FOSS) that has been carefully selected to address the unique development needs of environmental web apps. Tethys web apps are developed using a Python software development kit (SDK) which includes programmatic links to each software component. Tethys Platform is powered by the Django Python web framework giving it a solid web foundation with excellent security and performance. Refer to the :doc:`./features` article for an overview of the features of Tethys Platform.
 

--- a/docs/installation/production/docker/docker_compose.rst
+++ b/docs/installation/production/docker/docker_compose.rst
@@ -363,7 +363,7 @@ c. Add the following contents to each ``.env`` file:
         # Don't change these parameters
         ASGI_PROCESSES=1
         CHANNEL_LAYERS_BACKEND=channels_redis.core.RedisChannelLayer
-        CHANNEL_LAYERS_CONFIG="\"{\"hosts\": [[\"redis\", 6379]]}\""  # Hostname is the name of the service
+        CHANNEL_LAYERS_CONFIG="\"{'hosts':[{'host':\ 'redis',\ 'port':\ 6379}]}\""  # Hostname is the name of the service
 
         # Database parameters
         TETHYS_DB_HOST=db  # Hostname is the name of the service

--- a/docs/installation/production/docker/tethys_docker_reference.rst
+++ b/docs/installation/production/docker/tethys_docker_reference.rst
@@ -219,6 +219,7 @@ The following environment variables can be used to set some of the Tethys Settin
 +---------------------------+------------------------------------------------------------------------------------------+
 | CHANNEL_LAYERS_CONFIG     | The Django Channel Layers configuration if a layer other than the default is being used. |
 |                           | Defaults to "\"{}}\"" (Empty).                                                           |
+|                           | For example: "\"{'hosts':[{'host':\ 'localhost',\ 'port':\ 6379}]}\""                    |
 +---------------------------+------------------------------------------------------------------------------------------+
 | RECAPTCHA_PRIVATE_KEY     | Private key for Google ReCaptcha. Required to enable ReCaptcha on the login screen.      |
 |                           | See RECAPTCHA_PRIVATE_KEY in :ref:`tethys_configuration`                                 |

--- a/docs/installation/production/manual/configuration/advanced/django_channels_layer.rst
+++ b/docs/installation/production/manual/configuration/advanced/django_channels_layer.rst
@@ -60,7 +60,7 @@ If using Tethys Docker, the ``CHANNEL_LAYERS_BACKEND``, ``CHANNEL_LAYERS_CONFIG`
 
     ENV ASGI_PROCESSES 1
     ENV CHANNEL_LAYERS_BACKEND "channels_redis.core.RedisChannelLayer"
-    ENV CHANNEL_LAYERS_CONFIG "\"{\"hosts\": [[127.0.0.1, 6379]]}\""
+    ENV CHANNEL_LAYERS_CONFIG "\"{'hosts':[{'host':\ 'redis',\ 'port':\ 6379}]}\""
 
 Finally, make sure that a ``REDIS Server`` is running. This can easily be done with a ``Docker container`` either by running it directly or adding it to a docker-compose.
 

--- a/docs/installation/resources/example-install.yml
+++ b/docs/installation/resources/example-install.yml
@@ -1,5 +1,7 @@
 # This file should be committed to your app code.
 version: 1.1
+# This should be greater or equal to your tethys-platform in your environment
+tethys_version: ">=4.0.0"
 # This should match the app - package name in your setup.py
 name: my_first_app
 

--- a/docs/tethys_cli/manage.rst
+++ b/docs/tethys_cli/manage.rst
@@ -5,6 +5,7 @@ manage command
 
 Manage various aspects of the underlying Tethys Platform Django project. Provides a full pass-through interface for the ``manage.py`` command.
 
+
 .. argparse::
    :module: tethys_cli
    :func: tethys_command_parser

--- a/docs/tethys_sdk/gizmos/map_view.rst
+++ b/docs/tethys_sdk/gizmos/map_view.rst
@@ -1,324 +1,1025 @@
-.. _map-view:
+.. _map_layout:
 
-********
-Map View
-********
+**********
+Map Layout
+**********
 
-.. autoclass:: tethys_sdk.gizmos.MapView
+**Last Updated:** January 2023
 
-.. _gizmo_mvlayer:
+The ``MapLayout`` provides a drop-in full-screen map view for Tethys Apps. Displaying a map with a few layers can be accomplished in tens of lines of code and implementing more advanced functionality can be accomplished in hundreds. It includes a layer tree with visibility controls and actions such as "Zoom to Layer". The view can also includes many optional features such as displaying legends for layers, feature selection, map annotation / drawing tools, location lookup via geocoding, and a click-and-plot feature.
 
-MVLayer
--------
+.. figure:: ./images/map_layout/map_layout.png
+    :width: 800px
+    :align: left
 
-.. autoclass:: tethys_sdk.gizmos.MVLayer
+    **Figure 1**: Example map view created using Map Layout.
 
-MVLegendClass
--------------
+Setup
+=====
 
-.. autoclass:: tethys_sdk.gizmos.MVLegendClass
+Setting up a new ``MapLayout`` involves the following steps:
 
-MVLegendImageClass
-------------------
+1. Create a new class in :file:`controllers.py` that inherits from ``MapLayout``.
+2. Decorate the new class with the :ref:`controller-decorator` to set up routing. 
+3. Configure the new ``MapLayout`` by setting properties on the new class. Review the :ref:`MapLayout properties <map_layout_properties>` for a full list. For example, set the ``map_title`` property to set the title of the view that appears in the navigation bar. 
 
-.. autoclass:: tethys_sdk.gizmos.MVLegendImageClass
+The following example demonstrates how to create a new ``MapLayout`` view:
 
-MVLegendGeoServerImageClass
----------------------------
+.. code-block:: python
 
-.. autoclass:: tethys_sdk.gizmos.MVLegendGeoServerImageClass
-
-MVDraw
-------
-
-.. autoclass:: tethys_sdk.gizmos.MVDraw
-
-MVView
-------
-
-.. autoclass:: tethys_sdk.gizmos.MVView
+    from django.urls import reverse_lazy
+    from tethys_sdk.layouts import MapLayout
+    from tethys_sdk.routing import controller
 
 
-.. _map_view_gizmo_js:
+    @controller(
+        name="map",
+        url="my_first-app/map"
+    )
+    class MyMapLayout(MapLayout):
+        app = app
+        base_template = 'my_first_app/base.html'
+        back_url = reverse_lazy('my_first_app:home')
+        map_title = 'My Map Layout'
+        map_subtitle = 'Subtitle'
+        basemaps = [
+            'OpenStreetMap',
+            'ESRI',
+            'Stamen',
+            {'Stamen': {'layer': 'toner', 'control_label': 'Black and White'}},
+        ]
+        default_map_extent = [-65.69, 23.81, -129.17, 49.38]  # CONUS bbox
+        max_zoom = 16
+        min_zoom = 2
 
-JavaScript API
+
+Add Layers
+==========
+
+To add layers to the map in a ``MapLayout``, override the :ref:`compose_layers <map_layout_compose_layers>` method. The ``MapLayout`` view uses the :ref:`MapView Gizmo <map-view>` under the covers and it is given to the ``compose_layers()`` method via the ``map_view`` argument. Use the ``map_view`` argument to add new :ref:`MVLayers <gizmo_mvlayer>` to the ``MapView``.
+
+While the ``MapView`` Gizmo will be able to accept any ``MVLayer`` object, the ``MapLayout`` needs layers to have additional metadata attached for them to be recognized by the layers in the Layer Tree, legend, and other features of ``MapLayout``. Several helper methods are provided by ``MapLayout`` to assist with building ``MVLayer`` objects in the correct way: :ref:`build_wms_layer() <map_layout_build_wms_layer>`, :ref:`build_geojson_layer() <map_layout_build_geojson_layer>`, and :ref:`build_arc_gis_layer() <map_layout_build_arc_gis_layer>`.
+
+In addition, the ``compose_layers()`` method needs to return a ``list`` of at least one Layer Group. A Layer Group contains a list of layers and is used by the Layer Tree of ``MapLayout`` to organize layers. In addition, a control type is specified for each Layer Group (``'check' or 'radio'``), and can be used to control whether all the layers in a Layer Group can be viewed simultaneously (``'check'``) or only one at a time (``'radio'``). Create Layer Groups using the :ref:`map_layout_build_layer_group` helper method.
+
+WMS Layer
+---------
+
+.. figure:: ./images/map_layout/map_layout_wms_layer.png
+    :width: 800px
+    :align: left
+
+    **Figure 2**: Example of a WMS layer displayed in a Map Layout.
+
+The following example demonstrates how to add WMS layers to a ``MapLayout`` using the ``build_wms_layer`` method:
+
+.. code-block:: python
+
+    @controller(
+        name="map",
+        url="my_first-app/map"
+    )
+    class MyMapLayout(MapLayout):
+
+        ...
+
+        def compose_layers(self, request, map_view, *args, **kwargs):
+            """
+            Add layers to the MapLayout and create associated layer group objects.
+            """
+            # WMS Layer
+            usa_population = self.build_wms_layer(
+                endpoint='http://localhost:8181/geoserver/wms',
+                server_type='geoserver',
+                layer_name='topp:states',
+                layer_title='USA Population',
+                layer_variable='population',
+                visible=True,  # Set to False if the layer should be hidden initially
+            )
+
+            # Add layer to map
+            map_view.layers.append(usa_population)
+
+            # Add layer to layer group
+            layer_groups = [
+                self.build_layer_group(
+                    id='usa-layer-group',
+                    display_name='United States',
+                    layer_control='radio',  # 'radio' or 'check'
+                    layers=[
+                        usa_population,
+                    ],
+                ),
+            ]
+
+            return layer_groups
+
+
+.. caution::
+
+    The ellipsis (`...`) in code examples indicate code that is not shown for brevity. **DO NOT COPY VERBATIM**.
+
+GeoJSON Layers
 --------------
 
-For advanced features, the JavaScript API can be used to interact with the OpenLayers map object that is generated by the Map View JavaScript library.
+.. figure:: ./images/map_layout/map_layout_geojson_layer.png
+    :width: 800px
+    :align: left
 
-TETHYS_MAP_VIEW.getMap()
-++++++++++++++++++++++++
+    **Figure 3**: Example of a GeoJSON layer displayed in a Map Layout.
 
-This method returns the OpenLayers map object. You can use the `OpenLayers Map API version 5.3.0 <https://openlayers.org/en/v5.3.0/apidoc/module-ol_Map-Map.html>`_ to perform operations on this object such as adding layers and custom controls.
+The following example demonstrates how to add a GeoJSON layer to a ``MapLayout`` using the ``build_geojson_layer`` method:
 
-::
+.. code-block:: python
 
-    $(function() { //wait for page to load
+    @controller(
+        name="map",
+        url="my_first-app/map"
+    )
+    class MyMapLayout(MapLayout):
 
-        var ol_map = TETHYS_MAP_VIEW.getMap();
-        ol_map.addLayer(...);
-        ol_map.setView(...);
+        ...
 
-    });
+        def compose_layers(self, request, map_view, *args, **kwargs):
+            """
+            Add layers to the MapLayout and create associated layer group objects.
+            """
+            # Load GeoJSON From File
+            us_states_path = Path(app_workspace.path) / 'my_first_app' / 'us-states.json'
+            with open(us_states_path) as gj:
+                us_states_geojson = json.loads(gj.read())
 
-.. caution::
+            # GeoJSON Layer
+            us_states_layer = self.build_geojson_layer(
+                geojson=us_states_geojson,
+                layer_name='us-states',
+                layer_title='U.S. States',
+                layer_variable='reference',
+                visible=True,
+            )
 
-    The Map View Gizmo is powered by OpenLayers version 5.3.0 by default. When referring to the OpenLayers documentation, ensure that you are browsing the correct version of documentation (see the URL of the documentation page).
+            # Add layer to map
+            map_view.layers.append(us_states_layer)
 
-TETHYS_MAP_VIEW.updateLegend()
-++++++++++++++++++++++++++++++
+            # Add layer to layer group
+            ...
 
-This method can be used to update the legend after removing/adding layers to the map.
+Vector Layer Styles
++++++++++++++++++++
 
-::
+.. figure:: ./images/map_layout/map_layout_styled_geojson_layer.png
+    :width: 800px
+    :align: left
 
-    $(function() { //wait for page to load
+    **Figure 4**: Example of a GeoJSON layer with custom styles displayed in a Map Layout.
 
-        var ol_map = TETHYS_MAP_VIEW.getMap();
-        ol_map.addLayer(...);
-        TETHYS_MAP_VIEW.updateLegend();
-    
-    });
+Use the ``get_vector_style_map`` method of ``MapLayout`` to define custom styles for GeoJSON layers. The method expects a dictionary to be returned containing keys that coorespond to feature types (e.g.: "Point", "LineString", "Polygon") and values that are the style definition. The style definitions are created using a Python dictionary syntax that mirrors the `OpenLayers Style API <https://openlayers.org/en/latest/examples/geojson.html>`_. The For example:
 
-TETHYS_MAP_VIEW.zoomToExtent(latlongextent)
-+++++++++++++++++++++++++++++++++++++++++++
+.. code-block:: python
 
-This method can be used to set the view of the map to the extent provided. The extent is assumed to be given in the EPSG:4326 coordinate reference system.
+    @controller(
+        name="map",
+        url="my_first-app/map"
+    )
+    class MyMapLayout(MapLayout):
 
-::
-
-    $(function() { //wait for page to load
-
-        var extent = [-109.49945001309617, 37.58047995600726, -109.44540360290348, 37.679502621605735];
-        TETHYS_MAP_VIEW.zoomToExtent(extent);
-    });
-
-TETHYS_MAP_VIEW.clearSelection()
-++++++++++++++++++++++++++++++++
-
-This method applies to the WMS layer feature selection functionality. Use this method to clear the current selection via JavaScript.
-
-::
-
-    TETHYS_MAP_VIEW.clearSelection();
-
-
-TETHYS_MAP_VIEW.overrideSelectionStyler(geometry_type, styler)
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-This method applies to the WMS layer feature selection functionality. This method can be used to override the default styling for the points, lines, and polygons selected feature layers.
-
-* geometry_type (str): The type of the layer that the styler function will apply to. One of: 'points', 'lines', or 'polygons'.
-* styler (func): A function that accepts two arguments, feature and resolution, and returns an array of valid ol.style objects.
-
-::
-
-    function my_styler(feature, resolution) {
-    var image, properties;
-        properties = feature.getProperties();
-
-        // Default icon
-        image = new ol.style.Circle({
-            radius: 5,
-            fill: new ol.style.Fill({
-                color: 'red'
-            })
-        });
-
-        if ('type' in properties) {
-            if (properties.type === 'TANK') {
-                image = new ol.style.RegularShape({
-                    fill: new ol.style.Fill({
-                        color: SELECTED_NODE_COLOR
-                    }),
-                    stroke: new ol.style.Stroke({
-                        color: 'white',
-                        width: 1
-                    }),
-                    points: 4,
-                    radius: 14,
-                    rotation: 0,
-                    angle: Math.PI / 4
-                });
-
+        ...
+        @classmethod
+        def get_vector_style_map(cls):
+            return {
+                'Point': {'ol.style.Style': {
+                    'image': {'ol.style.Circle': {
+                        'radius': 5,
+                        'fill': {'ol.style.Fill': {
+                            'color': 'red',
+                        }},
+                        'stroke': {'ol.style.Stroke': {
+                            'color': 'red',
+                            'width': 2
+                        }}
+                    }}
+                }},
+                'LineString': {'ol.style.Style': {
+                    'stroke': {'ol.style.Stroke': {
+                        'color': 'green',
+                        'width': 3
+                    }}
+                }},
+                'MultiPolygon': {'ol.style.Style': {
+                    'stroke': {'ol.style.Stroke': {
+                        'color': 'orange',
+                        'width': 3
+                    }},
+                    'fill': {'ol.style.Fill': {
+                        'color': 'rgba(255, 140, 0, 0.1)'
+                    }}
+                }},
+                'Polygon': {'ol.style.Style': {
+                    'stroke': {'ol.style.Stroke': {
+                        'color': 'green',
+                        'width': 3
+                    }},
+                    'fill': {'ol.style.Fill': {
+                        'color': 'rgba(0, 255, 0, 0.1)'
+                    }}
+                }},
             }
-            else if (properties.type === 'RESERVOIR') {
-                image = new ol.style.RegularShape({
-                    fill: new ol.style.Fill({
-                        color: SELECTED_NODE_COLOR
-                    }),
-                    stroke: new ol.style.Stroke({
-                        color: 'white',
-                        width: 1
-                    }),
-                    points: 3,
-                    radius: 14,
-                    rotation: 0,
-                    angle: 0
-                });
-            }
-        }
 
-        return [new ol.style.Style({image: image})];
+ArcGIS REST Layer
+-----------------
 
-    }
+.. figure:: ./images/map_layout/map_layout_arcgis_layer.png
+    :width: 800px
+    :align: left
 
-    TETHYS_MAP_VIEW.overrideSelectionStyler('points', my_styler);
+    **Figure 5**: Example of a ArcGIS layer displayed in a Map Layout.
 
+The following example demonstrates how to add an ArcGIS REST layer to a ``MapLayout`` using the ``build_arc_gis_layer`` method:
 
-TETHYS_MAP_VIEW.onSelectionChange(callback)
-+++++++++++++++++++++++++++++++++++++++++++
+.. code-block:: python
 
-This method applies to the WMS layer feature selection functionality. The callback function provided will be called each time the feature selection is changed.
+    @controller(
+        name="map",
+        url="my_first-app/map"
+    )
+    class MyMapLayout(MapLayout):
 
-* callback (func): A function that accepts three arguments, points_layer, lines_layer, polygons_layer. These are handles on the OpenLayers layers that are rendering the selected features. The features are divided into three layers by type.
+        ...
 
-::
+        def compose_layers(self, request, map_view, *args, **kwargs):
+            """
+            Add layers to the MapLayout and create associated layer group objects.
+            """
+            # ArcGIS Layer
+            us_highways_layer = self.build_arc_gis_layer(
+                endpoint='https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer',
+                layer_name='ESRI_StateCityHighway',
+                layer_title='US Highways',
+                layer_variable='highways',
+                visible=False,
+                extent=[-173, 17, -65, 72],
+            )
 
-    function my_callback(points_layer, lines_layer, polygons_layer) {
-       console.log(points_layer);
-    }
+            # Add layer to map
+            map_view.layers.append(us_highways_layer)
 
-    TETHYS_MAP_VIEW.onSelectionChange(my_callback);
+            # Add layer to layer group
+            ...
 
+.. _map_layout_feature_selection:
 
-TETHYS_MAP_VIEW.getSelectInteraction()
-++++++++++++++++++++++++++++++++++++++
+Feature Selection
+=================
 
-This method applies to the WFS/GeoJSON/KML layer feature selection functionality.
+The ``MapLayout`` layout supports two modes of feature selection: Feature Selection for Vector Layers and Feature Selection for WMS Layers. Select features by clicking on the feature and select multiple layers by holding the ``SHIFT`` key while clicking on features.
 
-::
+Vector Layers
+-------------
 
-    $(function() { //wait for page to load
+Vector layers, like GeoJSON layers, support Feature selection.
 
-        var selection_interaction = TETHYS_MAP_VIEW.getSelectInteraction();
+.. figure:: ./images/map_layout/map_layout_vector_feature_selection.png
+    :width: 800px
+    :align: left
 
-        //when selected, print feature to developers console
-        selection_interaction.getFeatures().on('change:length', function(e) {
-          if (e.target.getArray().length > 0) {
-            // this means there is at least 1 feature selected
-            var selected_feature = e.target.item(0); // 1st feature in Collection
-            console.log(selected_feature);
+    **Figure 6**: Vector layer feature selection in Map Layout.
 
-          }
-        });
+Feature Selection for Vector Layers, such as GeoJSON layers, can be enabled on a layer-by-layer basis by setting the ``selectable`` argument to ``True``:
 
-    });
+.. code-block:: python
 
-TETHYS_MAP_VIEW.mapClicked(callback)
-++++++++++++++++++++++++++++++++++++
+    # Load GeoJSON From File
+    us_states_path = Path(app_workspace.path) / 'my_first_app' / 'us-states.json'
+    with open(us_states_path) as gj:
+        us_states_geojson = json.loads(gj.read())
 
-Provide a callback function to call when the map is clicked on. Only works if `map_click_event` parameter is set to `True` when defining the `MapView`. The function must accept two parameters an array of coordinates (lat, lon) and the click event object.
-
-::
-
-     TETHYS_MAP_VIEW.mapClicked(function(coordinates, event) {
-         // Custom code to run whenever the map is clicked.
-     });
-
-TETHYS_MAP_VIEW.clearClickedPoint()
-+++++++++++++++++++++++++++++++++++
-
-Clear the clicked point selected by the user.
-
-::
-
-     TETHYS_MAP_VIEW.clearClickedPoint();
-
-TETHYS_MAP_VIEW.reInitializeMap()
-+++++++++++++++++++++++++++++++++
-
-This method is intended for initializing a map generated from an AJAX request.
-
-.. caution::
-
-    This method assumes there is only one and that there will only ever be one map on the page.
+    # GeoJSON Layer
+    us_states_layer = self.build_geojson_layer(
+        geojson=us_states_geojson,
+        layer_name='us-states',
+        layer_title='U.S. States',
+        layer_variable='reference',
+        visible=True,
+        selectable=True
+    )
 
 .. note::
 
-    In order to use this, you will either need to use a MapView gizmo or import
-    the JavaScript/CSS libraries in the main html template page using the 
-    ``import_gizmo_dependency`` tag in the ``import_gizmos`` block.
+    Clicking inside a polygon feature will not select it. Instead, click on the border of the polygon to select it.
 
-    For example:
-    ::
+JavaScript
+++++++++++
 
-        {% block import_gizmos %}
-            {% import_gizmo_dependency map_view %}
-        {% endblock %}
+Use the ``getSelectInteraction()`` method of the underlying ``MapView`` Gizmo to bind functions to the Vector feature selection event:
 
-Four elements are required:
+.. code-block:: javascript
 
-1) A controller for the AJAX call with a map view gizmo.
-::
+    $(function() { // Wait for page to load
+        let selection_interaction = TETHYS_MAP_VIEW.getSelectInteraction();
 
-    @login_required()
-    def dam_break_map_ajax(request):
-        """
-        Controller for the dam_break_map ajax request.
-        """
-        if request.GET:
-            ...            
-            
-            #get layers
-            map_layer_list = ...
-
-            # Define initial view for Map View
-            view_options = MVView(
-                projection='EPSG:4326',
-                center=[(bbox[0]+bbox[2])/2.0, (bbox[1]+bbox[3])/2.0],
-                zoom=10,
-                maxZoom=18,
-                minZoom=2,
-            )
-
-            # Configure the map
-            map_options = MapView(
-                height='500px',
-                width='100%',
-                layers=map_layer_list,
-                controls=['FullScreen'],
-                view=view_options,
-                basemap=['OpenStreetMap'],
-                legend=True,
-            )
-        
-            context = { 'map_options': map_options }
-            
-            return render(request, 'dam_break_map_ajax/map_ajax.html', context)
-
-2) A url map to the controller in app.py
-::
-
-    ...
-        UrlMap(name='dam_break_map_ajax',
-               url='dam-break/map/dam_break_map_ajax',
-               controller='dam_break.controllers.dam_break_map_ajax'),
-    ...
-
-3) A template for with the tethys gizmo (e.g. map_ajax.html)
-::
-
-    {% load tethys_gizmos %}
-
-    {% gizmo map_options %}
-
-
-4) The AJAX call in the javascript
-::
-
-    $(function() { //wait for page to load
-
-        $.ajax({
-            url: ajax_url,
-            method: 'GET',
-            data: ajax_data,
-            success: function(data) {
-                //add new map to map div
-                $('#main_map_div').html(data);
-
-                TETHYS_MAP_VIEW.reInitializeMap();
+        // Called each time the select interaction's list of features changes
+        selection_interaction.getFeatures().on('change:length', function(e) {
+            // Check if there is at least 1 feature selected
+            if (e.target.getLength() > 0) {
+                // Do something with the feature
+                let selected_feature = e.target.item(0); // 1st feature in Collection
+                console.log(`Selected State: ${selected_feature.get('name')}`);
             }
         });
-
     });
+
+.. tip::
+
+    See the :ref:`layout_custom_template` section for how to define a custom template for a ``MapLayout`` and add custom JavaScript.
+
+WMS Layers
+----------
+
+``MapLayout`` also supports feature selection for WMS layers that are hosted by a GeoServer and are derived from a vector source (e.g. created from a Shapefile or SQLView).
+
+.. figure:: ./images/map_layout/map_layout_wms_feature_selection.png
+    :width: 800px
+    :align: left
+
+    **Figure 7**: WMS layer feature selection in Map Layout.
+
+Enabling feature selection is done on a layer by layer basis by setting the ``selectable`` argument to ``True`` as shown in the example below:
+
+.. code-block:: python
+
+    # WMS Layer
+    usa_population = self.build_wms_layer(
+        endpoint='http://localhost:8181/geoserver/wms',
+        server_type='geoserver',
+        layer_name='topp:states',
+        layer_title='USA Population',
+        layer_variable='population',
+        visible=True,  # Set to False if the layer should be hidden initially
+        selectable=True
+    )
+
+Geometry attribute
+++++++++++++++++++
+
+The ``build_wms_layer`` method takes an additional feature-selection related argument that is sometimes necessary: ``geometry attribute``. Use this argument to specify a different value if the partiuclar layer uses a different naming convention for the feature attribute that stores the geometry. The default value for ``geometry_attribute`` is ``"the_geom"``. For example:
+
+.. code-block:: python
+
+    # WMS Layer
+    usa_population = self.build_wms_layer(
+        endpoint='http://localhost:8181/geoserver/wms',
+        server_type='geoserver',
+        layer_name='topp:states',
+        layer_title='USA Population',
+        layer_variable='population',
+        visible=True,  # Set to False if the layer should be hidden initially
+        selectable=True,
+        geometry_attribute='geometry',  # Defaults to "the_geom"
+    )
+
+Class Properties
+++++++++++++++++
+
+There are two class properties that can be used to modify the behavior of the WMS feature selection: ``feature_selection_multiselect`` and ``feature_selection_sensitivity``.
+
+Set ``feature_selection_multiselect`` to ``True`` to allow selecting multiple features from WMS layers that have feature selection enabled. This is done by holding the ``SHIFT`` key while selecting. The default behavior is to allow only one feature to be selected at a time.
+
+set the ``feature_selection_sensitivty`` to adjust the relative search radius around the clicked point of the selection algorithm. The default value is 4.
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        feature_selection_multiselect = True
+        feature_selection_sensitivty = 8
+
+.. _map_layout_feature_selection_popups:
+
+Property Popups
+---------------
+
+As the name suggestions, properties popups can be enabled to display properties of selected features in a popup dialog.
+
+.. figure:: ./images/map_layout/map_layout_properties_popup.png
+    :width: 800px
+    :align: left
+
+    **Figure 8**: Example of properties popup on a selected feature from a WMS layer.
+
+Enable pop-ups displaying the properties of selected features by setting the ``show_properties_popup`` to ``True``.
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        show_properties_popup = True
+
+.. note::
+    
+    This feature only works for the layer types supported by :ref:`map_layout_feature_selection`.
+
+Exclude properties from being displayed in the properties pop-ups using the ``excluded_properties`` argument of the build methods. The ``id``, ``type``, ``geometry``, ``the_geom``, and ``layer_name`` properties are automatically excluded.
+
+.. code-block:: python
+
+    # WMS Layer
+    usa_population = self.build_wms_layer(
+        endpoint='http://localhost:8181/geoserver/wms',
+        server_type='geoserver',
+        layer_name='topp:states',
+        layer_title='USA Population',
+        layer_variable='population',
+        visible=True,  # Set to False if the layer should be hidden initially
+        selectable=True,
+        geometry_attribute='geometry',  # Defaults to "the_geom"
+        excluded_properties=['STATE_FIPS', 'SUB_REGION'],
+    )
+
+.. note::
+
+    Names of properties displayed in pop-ups have been reformatted by replacing any underscores (``_``) or hyphens (``-``) with spaces and changing the case to title case. For example, a property called ``STATE_FIPS`` would be displayed as ``State Fips``. You must specify the pre-formatted/original version of the property name for the ``excluded_properties`` argument.
+
+.. caution::
+
+    The Feature Selection Property Popup feature and the :ref:`map_layout_map_clicks_popups` feature cannot not be used together. When both are enabled, neither popup is displayed.
+
+.. _map_layout_popup_javascript_api:
+
+JavaScript
+----------
+
+The ``MapLayout`` JavaScript API provides several methods for controlling the properties popup. See: :ref:`map_layout_js_show_properties_popup`, :ref:`map_layout_js_close_properties_popup`, :ref:`map_layout_js_hide_properties_popup`, :ref:`map_layout_js_reset_properties_popup`, :ref:`map_layout_js_properties_table_generator`, :ref:`map_layout_js_custom_properties_generator`, and :ref:`map_layout_js_custom_properties_initializer`.
+
+.. tip::
+
+    See the :ref:`layout_custom_template` section for how to define a custom template for a ``MapLayout`` and add custom JavaScript.
+
+.. _map_layout_map_clicks:
+
+Map Clicks
+==========
+
+The Map Clicks feature of ``MapLayout`` will display a point at the location on the map where the user clicked. 
+
+.. figure:: ./images/map_layout/map_layout_map_click.png
+    :width: 800px
+    :align: left
+
+    **Figure 9**: Map clicks adds a point on the map at the location where the user last clicked on the map.
+
+Enable Map Clicks by setting the ``show_map_clicks`` property of ``MapLayout`` to ``True``:
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        show_map_clicks = True
+
+.. _map_layout_map_clicks_popups:
+
+Map Clicks Popups
+-----------------
+
+The Map Clicks Popups feature displays a popup pointing to the point at the location on the map where the user clicked. The popup is empty by default, but content can be added using JavaScript and the selector ``#properties-popup-content`` (see JavaScript section below). 
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        show_map_clicks = True
+        show_map_click_popup = True
+
+.. caution::
+
+    The Map Clicks Popup feature and the Feature Selection :ref:`map_layout_feature_selection_popups` feature cannot not be used together. When both are enabled, neither popup is displayed.
+
+JavaScript
+----------
+
+Use the ``TETHYS_MAP_VIEW.mapClicked()`` method to respond to Map Click events. Pass a callback function that takes the coordinates of the clicked point as an argument:
+
+.. code-block:: javascript
+
+    $(function() {  // Wait for page to load
+        // Map Click Event Handler
+        TETHYS_MAP_VIEW.mapClicked(function(coords) {
+            let popup_content = document.querySelector("#properties-popup-content");
+            let lat_lon = ol.proj.transform(coords, 'EPSG:3857', 'EPSG:4326');
+            let rounded_lat = Math.round(lat_lon[1] * 1000000) / 1000000;
+            let rounded_lon = Math.round(lat_lon[0] * 1000000) / 1000000;
+            popup_content.innerHTML = `<b>Coordinates:</b><p>${rounded_lat}, ${rounded_lon}</p>`;
+        });
+    });
+
+.. figure:: ./images/map_layout/map_layout_map_click_popup.png
+    :width: 800px
+    :align: left
+
+    **Figure 10**: Example of custom content generated from JavaScript in the Map Click popup.
+
+The ``show_properties_popup``, ``close_properties_popup``, ``hide_properties_popup``, and ``reset_properties_popup`` methods can be used to manipulate the Map Click popup (see: :ref:`Feature Selection > JavaScript <map_layout_popup_javascript_api>`).
+
+.. tip::
+
+    See the :ref:`layout_custom_template` section for how to define a custom template for a ``MapLayout`` and add custom JavaScript.
+
+Click and Plot
+==============
+
+The Click and Plot capability of ``MapLayout`` can be used to plot data associated with individual features of a layer. The plots are powered by `PlotlyJS <https://plotly.com/javascript/>`_ and are displayed on a slide sheet that slides from the bottom of the map window.
+
+.. figure:: ./images/map_layout/map_layout_click_n_plot.png
+    :width: 800px
+    :align: left
+
+    **Figure 11**: The Click and Plot feature can be used to plot data associated with selected features.
+
+Enable the Plot Slide Sheet by setting the ``plot_slide_sheet`` property to ``True``:
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        plot_slide_sheet = True
+
+Then enable the plot capability on one or more layers by setting the ``plottable`` argument to ``True``:
+
+.. code-block:: python
+
+    # WMS Layer
+    usa_population = self.build_wms_layer(
+        endpoint='http://localhost:8181/geoserver/wms',
+        server_type='geoserver',
+        layer_name='topp:states',
+        layer_title='USA Population',
+        layer_variable='population',
+        visible=True,  # Set to False if the layer should be hidden initially
+        selectable=True,
+        plottable=True,
+    )
+
+.. note::
+    
+    This feature only works for the layer types supported by :ref:`map_layout_feature_selection`.
+
+Finally, override the ``get_plot_for_layer_feature`` method of the ``MapLayout`` class. This method is called to retrive the plot data for a particular feature. The name of the layer and the id of the feature are given as arguments to allow for looking up the data dynamically.
+
+The ``get_plot_for_layer_feature`` method should return three things:
+
+* **title*** (str): The title of the plot slide sheet.
+* **data** (list<dict>): A list of dictionaries containing the data series.
+* **layout** (dict): A dictionary with layout options for the plot.
+
+The data series and layout objects should be the Python equivalent of the Plotly JSON objects (see: `JavaScript Figure Reference | Plotly <https://plotly.com/javascript/reference/index/>`_).
+
+In this example, the plot data is hard-coded for simplicity:
+
+.. code-block:: python
+
+    def get_plot_for_layer_feature(self, request, layer_name, feature_id, layer_data, feature_props, *args, **kwargs):
+        """
+        Retrieves plot data for given feature on given layer.
+
+        Args:
+            layer_name (str): Name/id of layer.
+            feature_id (str): ID of feature.
+            layer_data (dict): The MVLayer.data dictionary.
+            feature_props (dict): The properties of the selected feature.
+
+        Returns:
+            str, list<dict>, dict: plot title, data series, and layout options, respectively.
+        """
+        # Define data
+        month = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
+                'August', 'September', 'October', 'November', 'December']
+        high_2000 = [32.5, 37.6, 49.9, 53.0, 69.1, 75.4, 76.5, 76.6, 70.7, 60.6, 45.1, 29.3]
+        low_2000 = [13.8, 22.3, 32.5, 37.2, 49.9, 56.1, 57.7, 58.3, 51.2, 42.8, 31.6, 15.9]
+        
+        layout = {
+            'xaxis': {
+                'title': 'Month'
+            },
+            'yaxis': {
+                'title': 'Temperature (degrees F)'
+            }
+        }
+
+        data = [
+            {
+                'name': 'High 2000',
+                'mode': 'lines',
+                'x': month,
+                'y': high_2000,
+                'line': {
+                    'dash': 'dot',
+                    'width': 4,
+                    'color': 'red'
+                }
+            }, {
+                'name': 'Low 2000',
+                'mode': 'lines',
+                'x': month,
+                'y': low_2000,
+                'line': {
+                    'dash': 'dot',
+                    'width': 4,
+                    'color': 'blue'
+                }
+            }
+        ]
+        return 'Average High and Low Temperatures', data, layout
+
+JavaScript
+----------
+
+The plot slide sheet can be manipulated for more general purposes via the JavaScript API for ``MapLayout``. Ensure that the ``plot_slide_sheet`` property of the ``MapLayout`` class is set to ``True`` to enable this functionality. See: :ref:`map_layout_js_get_plot`, :ref:`map_layout_js_show_plot`, :ref:`map_layout_js_hide_plot`, :ref:`map_layout_js_update_plot`, :ref:`map_layout_js_plot_loader`, and :ref:`map_layout_js_plot_button_generator`.
+
+.. tip::
+
+    See the :ref:`layout_custom_template` section for how to define a custom template for a ``MapLayout`` and add custom JavaScript.
+
+Address Search (Geocoding)
+==========================
+
+The Geocoding feature allows users to search for locations by street address or name. 
+
+.. figure:: ./images/map_layout/map_layout_geocoding.png
+    :width: 800px
+    :align: left
+
+    **Figure 12**: Use the Geocoding capability of Map Layout to perform address and location search.
+
+The geocoding capability is powered by the `OpenCage Geocoding API <https://opencagedata.com/>`_. You will need to `create an account on OpenCage <https://opencagedata.com/users/sign_up>`_ and `obtain an API key <https://opencagedata.com/api>`_. Then set the ``geocode_api_key`` to the value of your OpenCage API key:
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        geocode_api_key = 'mY-@pI-k3y'
+
+
+.. tip::
+
+    Rather than store the API Key in plain text in your source code, you can store it as an app setting and retrieve it using this pattern:
+
+    .. code-block:: python
+
+        class MyMapLayout(MapLayout):
+
+            @property
+            def geocode_api_key(self):
+                return self.app.get_custom_setting('open_cage_api_key')
+
+Once the API key is set, a search box will appear on the ``MapLayout`` page. The search requires a minimum of 3 characters to be entered and no activity for 2 seconds before it attempts to search.
+
+The search extent can be limited by providing setting the ``geocode_extent`` property:
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        geocode_api_key = 'mY-@pI-k3y'
+        geocode_extent = [-127.26563,23.56399,-66.09375,50.51343]
+
+Permissions
+===========
+
+Some of the features of ``MapView`` can be restricted to users with certain permissions. To enable permissions enforcement, first set the ``enforce_permissions`` property to ``True``:
+
+.. code-block:: python
+
+    class MyMapLayout(MapLayout):
+        enforce_permissions = True
+
+
+Define the following permissions in the ``permissions()`` method of your app class (located in the :file:`app.py`):
+
+.. code-block:: python
+
+    from tethys_sdk.permissions import Permission, PermissionGroup
+
+
+    class MyFirstApp(TethysAppBase):
+
+        ...
+
+        def permissions(self)
+            # Define Permissions
+            can_use_map_geocode = Permission(
+                name='use_map_geocode',
+                description='Can use the address search feature.'
+            )
+
+            can_use_map_plot = Permission(
+                name='use_map_plot',
+                description='Can use the click and plot capability.'
+            )
+
+            can_remove_layers = Permission(
+                name='remove_layers',
+                description='Can remove layerss'
+            )
+
+            can_rename_layers = Permission(
+                name='rename_layers',
+                description='Can rename layers.'
+            )
+
+            can_toggle_public_layer = Permission(
+                name='toggle_public_layer',
+                description='Can toggle the public toggle for layers.'
+            )
+
+            can_download = Permission(
+                name='can_download',
+                description='Can download layers.'
+            )
+
+            # Create map admin permission group
+            map_admin_group = PermissionGroup(
+                name='map_admin',
+                permissions=(
+                    can_use_map_geocode, can_use_map_plot, can_remove_layers,
+                    can_rename_layers, can_toggle_public_layer, can_download
+                )
+            )
+
+            return (map_admin_group,)
+
+Finally, use the admin pages to assign individual permissions to users, create additional permissions groups, and assign them to users (see: :ref:`tethys_portal_auth_admin`).
+
+
+Python API Documentation
+========================
+
+.. _map_layout_class:
+
+MapLayout Class
+---------------
+
+.. _map_layout_properties:
+
+Properties
+++++++++++
+
+The following properties can be overridden customize the behavior of the ``MapLayout``. It is recommended that the following properties be overridden every time: ``app``, ``base_template``, ``map_subtitle``, and ``map_title``.
+
+.. autoclass:: tethys_layouts.views.map_layout.MapLayout
+
+.. _map_layout_override_methods:
+
+Override Methods
+++++++++++++++++
+
+Override these methods to customize the behavior of the ``MapLayout`` for your application. For example, override the ``compose_layers`` method to add layers to the ``MapLayout``.
+
+.. _map_layout_compose_layers:
+
+compose_layers
+^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.compose_layers
+
+get_plot_for_layer_feature
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.get_plot_for_layer_feature
+
+get_vector_style_map
+^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.get_vector_style_map
+
+should_disable_basemap
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.should_disable_basemap
+
+on_add_custom_layer
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.on_add_custom_layer
+
+on_remove_tree_item
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.on_remove_tree_item
+
+on_rename_tree_item
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.on_rename_tree_item
+
+.. _map_layout_methods:
+
+Helper Methods and Properties
++++++++++++++++++++++++++++++
+
+These methods and properties simplify common workflows that are used in ``MapLayout`` implementations. Don't override these unless you know what you are doing.
+
+build_map_extent_and_view
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_map_extent_and_view
+
+.. _map_layout_build_wms_layer:
+
+build_wms_layer
+^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_wms_layer
+
+.. _map_layout_build_geojson_layer:
+
+build_geojson_layer
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_geojson_layer
+
+.. _map_layout_build_arc_gis_layer:
+
+build_arc_gis_layer
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_arc_gis_layer
+
+.. _map_layout_build_layer_group:
+
+build_layer_group
+^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_layer_group
+
+build_legend
+^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_legend
+
+generate_custom_color_ramp_divisions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.generate_custom_color_ramp_divisions
+
+build_param_string
+^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.build_param_string
+
+JavaScript API Documentation
+============================
+
+In addition to providing it's own JavaScript API, the ``MapLayout`` uses the ``MapView`` gizmo under the covers which means, many of the ``MapView`` gizmo JavaScript capabilities are applicable.
+
+MapLayout
+---------
+
+Properties Popups
++++++++++++++++++
+
+.. _map_layout_js_show_properties_popup:
+
+show_properties_popup
+^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.show_properties_popup(coordinates)**
+
+    Show the properties popup at the location given.
+
+    **Parameters**
+
+    * **coordinates** (*ol.geom.Point*|*Array*): An ``ol.goem.Point`` or an ``Array`` of length 2 (e.g. ``[-11981657.512845377, 4615036.7485996075]``). Coordinates should be specified in the ``EPSG:3857`` coordinate system.
+
+.. _map_layout_js_close_properties_popup:
+
+close_properties_popup
+^^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.close_properties_popup()** 
+
+    Hides the properties popup and clears the features selected.
+
+.. _map_layout_js_hide_properties_popup:
+
+hide_properties_popup
+^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.hide_properties_popup()**
+
+    Hides the properties popup without clearing selection.
+
+.. _map_layout_js_reset_properties_popup:
+
+reset_properties_popup
+^^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.reset_properties_popup()**
+
+    Empties content of properties popup and then hides it.
+
+.. _map_layout_js_properties_table_generator:
+
+properties_table_generator
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.properties_table_generator(f)**
+
+    Override the default function that is used to generate the properties table that is displayed in the feature selection properties popup.
+
+    **Parameters**
+
+    * **function**: Provide a function that accepts two arguments, ``feature`` and ``layer``, and returns a string containing the HTML markup to insert into the popup.
+
+.. _map_layout_js_custom_properties_generator:
+
+custom_properties_generator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.custom_properties_generator(f)**
+
+    Define a function that is used to generate content to display in the popup after the properties table.
+
+    **Parameters**
+
+    * **f** (function): Provide a function that accepts two arguments, ``feature`` and ``layer``, and returns a string containing the HTML markup to insert in the popup after the properties table.
+
+.. _map_layout_js_custom_properties_initializer:
+
+custom_properties_initializer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.custom_properties_initializer(f)**
+
+    Define a function that performs initialization operations for custom content after the custom content markup is rendered (e.g. initialize a plot).
+
+    **Parameters**
+
+    * **f** (function): Provide a function that accepts no arguments and performs the initialization of custom content in the popup.
+
+Plot Slide Sheet
+++++++++++++++++
+
+.. _map_layout_js_get_plot:
+
+get_plot
+^^^^^^^^
+
+**MAP_LAYOUT.get_plot()**
+
+    Return the selector for the Plotly plot element for use in Plotly functions.
+
+.. _map_layout_js_show_plot:
+
+show_plot
+^^^^^^^^^
+
+**MAP_LAYOUT.show_plot()**
+
+    Open/show the slide sheet containing the plot.
+
+.. _map_layout_js_hide_plot:
+
+hide_plot
+^^^^^^^^^
+
+**MAP_LAYOUT.hide_plot()**
+
+    Close/hide the slide sheet containing the plot.
+
+.. _map_layout_js_update_plot:
+
+update_plot
+^^^^^^^^^^^
+
+**MAP_LAYOUT.update_plot(title, data, layout)**
+
+    Update the Plotly plot and slide sheet with the given title, data, and layout objects. Uses the ``Plotly.react()`` method to do this efficiently.
+
+    **Parameters**
+
+    * **title** (str): Title of the plot slide sheet.
+    * **data** (array<object>): JavaScript array of objects, one for each data series.
+    * **layout** (object): JavaScript object with Layout options for the plot.
+
+.. _map_layout_js_plot_loader:
+
+plot_loader
+^^^^^^^^^^^
+
+**MAP_LAYOUT.plot_loader(f)**
+
+    Override the default plot loading function.
+
+    **Parameters**
+
+    * **f** (function): A JavaScript function to be called whenever plot data needs to be loaded. Must accept three arguments: ``plot_button``, ``layer_name``, and ``feature_id``.
+
+.. _map_layout_js_plot_button_generator:
+
+plot_button_generator
+^^^^^^^^^^^^^^^^^^^^^
+
+**MAP_LAYOUT.plot_button_generator(f)**
+
+    Override the default plot button generator function. Useful for customizing the appearance, title, or behavior of the Plot button.
+
+    **Parameters**
+
+    * **f** (function): A JavaScript function to be called whenever the plot button needs to be generated. Must accept two arguments: ``feature`` and ``layer`` and return a string with HTML markup for the custom button.
+
+MapView Gizmo
+-------------
+
+See: :ref:`MapView Gizmo JavaScript API <map_view_gizmo_js>`

--- a/docs/tethys_sdk/layouts/map_layout.rst
+++ b/docs/tethys_sdk/layouts/map_layout.rst
@@ -788,15 +788,20 @@ should_disable_basemap
 
 .. automethod:: tethys_layouts.views.map_layout.MapLayout.should_disable_basemap
 
-save_custom_layers
-^^^^^^^^^^^^^^^^^^
-
-.. automethod:: tethys_layouts.views.map_layout.MapLayout.save_custom_layers
-
-remove_custom_layer
+on_add_custom_layer
 ^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: tethys_layouts.views.map_layout.MapLayout.remove_custom_layer
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.on_add_custom_layer
+
+on_remove_tree_item
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.on_remove_tree_item
+
+on_rename_tree_item
+^^^^^^^^^^^^^^^^^^^
+
+.. automethod:: tethys_layouts.views.map_layout.MapLayout.on_rename_tree_item
 
 .. _map_layout_methods:
 

--- a/docs/tethys_sdk/layouts/map_layout.rst
+++ b/docs/tethys_sdk/layouts/map_layout.rst
@@ -871,10 +871,10 @@ Properties Popups
 
 .. _map_layout_js_show_properties_popup:
 
-show_properties_popup
-^^^^^^^^^^^^^^^^^^^^^
+show_properties_pop_up
+^^^^^^^^^^^^^^^^^^^^^^
 
-**MAP_LAYOUT.show_properties_popup(coordinates)**
+**MAP_LAYOUT.show_properties_pop_up(coordinates)**
 
     Show the properties popup at the location given.
 
@@ -884,28 +884,28 @@ show_properties_popup
 
 .. _map_layout_js_close_properties_popup:
 
-close_properties_popup
-^^^^^^^^^^^^^^^^^^^^^^
+close_properties_pop_up
+^^^^^^^^^^^^^^^^^^^^^^^
 
-**MAP_LAYOUT.close_properties_popup()** 
+**MAP_LAYOUT.close_properties_pop_up()** 
 
     Hides the properties popup and clears the features selected.
 
 .. _map_layout_js_hide_properties_popup:
 
-hide_properties_popup
-^^^^^^^^^^^^^^^^^^^^^
+hide_properties_pop_up
+^^^^^^^^^^^^^^^^^^^^^^
 
-**MAP_LAYOUT.hide_properties_popup()**
+**MAP_LAYOUT.hide_properties_pop_up()**
 
     Hides the properties popup without clearing selection.
 
 .. _map_layout_js_reset_properties_popup:
 
-reset_properties_popup
-^^^^^^^^^^^^^^^^^^^^^^
+reset_properties_pop_up
+^^^^^^^^^^^^^^^^^^^^^^^
 
-**MAP_LAYOUT.reset_properties_popup()**
+**MAP_LAYOUT.reset_properties_pop_up()**
 
     Empties content of properties popup and then hides it.
 

--- a/docs/tethys_sdk/static_resources.rst
+++ b/docs/tethys_sdk/static_resources.rst
@@ -162,7 +162,7 @@ To use, add the following stylesheet to your HTML template in the ``styles`` blo
         <link href="{% static 'tethys_sdk/css/nav_tabs.css' %}" rel="stylesheet">
     {% endblock %}
 
-Then add Bootstrap tabs to the template in the ``app_navigation`` block as usual (see `Navs and tabs | Bootstrap <https://getbootstrap.com/docs/5.0/components/navs-tabs/#using-data-attributes>`_):
+Then add Bootstrap tabs to the template in the ``app_navigation`` block as usual (see `Navs and tabs | Bootstrap <https://getbootstrap.com/docs/5.2/components/navs-tabs/#using-data-attributes>`_):
 
 .. code-block:: html+django
 

--- a/docs/tethys_sdk/templating.rst
+++ b/docs/tethys_sdk/templating.rst
@@ -390,7 +390,7 @@ app_navigation_items
 app_navigation_items
 --------------------
 
-Override or append to the app navigation list. These should be ``<li>`` elements according to the `Boostrap Vertical Nav <https://getbootstrap.com/docs/5.0/components/navs-tabs/#vertical>`_ structure. In addition, Tethys Platform provides the ``title`` and ``separator`` classes that can be used to split the navigation items into sections.
+Override or append to the app navigation list. These should be ``<li>`` elements according to the `Boostrap Vertical Nav <https://getbootstrap.com/docs/5.2/components/navs-tabs/#vertical>`_ structure. In addition, Tethys Platform provides the ``title`` and ``separator`` classes that can be used to split the navigation items into sections.
 
 Example:
 

--- a/docs/tutorials/google_earth_engine/part_1.rst
+++ b/docs/tutorials/google_earth_engine/part_1.rst
@@ -4,7 +4,7 @@
 Part 1: Dataset Viewer
 **********************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial, you will be introduced to some of the basic functionality of Google Earth Engine. Next, you will learn how to visualize Google Earth Engine layers on a Tethys :ref:`map-view` Gizmo. Finally, you will learn how to use Google Earth Engine to extract time series data at a location and plot it using a :ref:`plotly_view_gizmo` Gizmo.
 

--- a/docs/tutorials/google_earth_engine/part_1/dataset_controls.rst
+++ b/docs/tutorials/google_earth_engine/part_1/dataset_controls.rst
@@ -2,7 +2,7 @@
 Build Dataset Selection Controls
 ********************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will add controls to the app that will eventually be used to select various Google Earth Engine datasets to display. The following topics will be reviewed in this tutorial:
 

--- a/docs/tutorials/google_earth_engine/part_1/dataset_controls_js.rst
+++ b/docs/tutorials/google_earth_engine/part_1/dataset_controls_js.rst
@@ -2,7 +2,7 @@
 Add JavaScript for Dynamic Control Behavior
 *******************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will add dynamic behavior to the dataset controls created in the previous step using JavaScript. The following topics will be reviewed in this tutorial:
 

--- a/docs/tutorials/google_earth_engine/part_1/dataset_controls_js.rst
+++ b/docs/tutorials/google_earth_engine/part_1/dataset_controls_js.rst
@@ -239,8 +239,8 @@ Here is a brief explanation of each method that will be implemented in this step
 
 .. code-block:: javascript
 
-        bind_controls = function() {
-            $('#platform').on('change', function() {
+    bind_controls = function() {
+        $('#platform').on('change', function() {
             let platform = $('#platform').val();
 
             if (platform !== m_platform) {

--- a/docs/tutorials/google_earth_engine/part_1/gee_primer.rst
+++ b/docs/tutorials/google_earth_engine/part_1/gee_primer.rst
@@ -2,7 +2,7 @@
 Part 1 Primer: Google Earth Engine for Tethys Developers
 ********************************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 This tutorial provides links to Google Earth Engine tutorials and resources that can be used to learn what you need to know for this Tethys tutorial. This is by no means exhaustive and we encourage you familiarize yourself with everything Google Earth Engine has to offer by visiting their documentation: `<https://developers.google.com/earth-engine/>`_. You will need an active `Google Earth Engine account <https://signup.earthengine.google.com>`_ to complete this tutorial.
 

--- a/docs/tutorials/google_earth_engine/part_1/map_view.rst
+++ b/docs/tutorials/google_earth_engine/part_1/map_view.rst
@@ -2,7 +2,7 @@
 Add Map View
 ************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will add a map to the Home Page using the Tethys MapView Gizmo. The following topics will be reviewed in this tutorial:
 

--- a/docs/tutorials/google_earth_engine/part_1/new_app_project.rst
+++ b/docs/tutorials/google_earth_engine/part_1/new_app_project.rst
@@ -2,7 +2,7 @@
 New Tethys App Project
 **********************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will create a new Tethys App project using the scaffold. The following topics will be reviewed in this tutorial:
 

--- a/docs/tutorials/google_earth_engine/part_1/new_app_project.rst
+++ b/docs/tutorials/google_earth_engine/part_1/new_app_project.rst
@@ -50,19 +50,23 @@ App dependencies should be managed using the :file:`install.yml` instead of the 
 
     # This file should be committed to your app code.
     version: 1.0
+    # This should be greater or equal to your tethys-platform in your environment
+    tethys_version: ">=4.0.0"
     # This should match the app - package name in your setup.py
     name: earth_engine
 
     requirements:
-      # Putting in a skip true param will skip the entire section. Ignoring the option will assume it be set to False
-      skip: false
-      conda:
+    # Putting in a skip true param will skip the entire section. Ignoring the option will assume it be set to False
+    skip: false
+    conda:
         channels:
-          - conda-forge
+        - conda-forge
         packages:
-          - earthengine-api
-          - oauth2client
-      pip:
+        - earthengine-api
+        - oauth2client
+    pip:
+
+    npm:
 
     post:
 
@@ -85,18 +89,24 @@ Download this :download:`Google Earth Engine App Icon <./resources/earth-engine-
 
 .. code-block:: python
 
+    from tethys_sdk.base import TethysAppBase
+
+
     class EarthEngine(TethysAppBase):
         """
-        Tethys app class for Google Earth Engine Tutorial.
+        Tethys app class for Earth Engine.
         """
 
         name = 'Google Earth Engine Tutorial'
-        index = 'earth_engine:home'
-        icon = 'earth_engine/images/earth-engine-logo.png'
-        package = 'earth_engine'
+        description = ''
+        package = 'earth_engine'  # WARNING: Do not change this value
+        index = 'home'
+        icon = f'{package}/images/earth-engine-logo.png'
         root_url = 'earth-engine'
         color = '#524745'
-        ...
+        tags = ''
+        enable_feedback = False
+        feedback_emails = []
 
 5. View Your New App
 ====================

--- a/docs/tutorials/google_earth_engine/part_1/plot_data.rst
+++ b/docs/tutorials/google_earth_engine/part_1/plot_data.rst
@@ -352,7 +352,7 @@ In this step you'll add a Plot button and the modal for the plot to the controll
       {% gizmo plot_button %}
     {% endblock %}
 
-3. Add a new `Bootstrap Modal <https://getbootstrap.com/docs/3.3/javascript/#modals>`_ for displaying the plot to the ``after_app_content`` block of the :file:`templates/earth_engine/home.html` template:
+3. Add a new `Bootstrap Modal <https://getbootstrap.com/docs/5.2/components/modal/>`_ for displaying the plot to the ``after_app_content`` block of the :file:`templates/earth_engine/home.html` template:
 
 .. code-block:: html+django
 

--- a/docs/tutorials/google_earth_engine/part_1/plot_data.rst
+++ b/docs/tutorials/google_earth_engine/part_1/plot_data.rst
@@ -35,7 +35,7 @@ In this step you'll expand the GEE functions to include a function that can extr
 
 .. code-block:: bash
 
-    conda install -c conda-forge geojson
+    conda install -c conda-forge geojson pandas
 
 2. Add ``geojson`` as a dependency in the :file:`install.yml`:
 
@@ -43,6 +43,8 @@ In this step you'll expand the GEE functions to include a function that can extr
 
     # This file should be committed to your app code.
     version: 1.0
+    # This should be greater or equal to your tethys-platform in your environment
+    tethys_version: ">=4.0.0"
     # This should match the app - package name in your setup.py
     name: earth_engine
 
@@ -53,10 +55,13 @@ In this step you'll expand the GEE functions to include a function that can extr
         channels:
           - conda-forge
         packages:
-          - earthengine-api=0.1.205
+          - earthengine-api
           - oauth2client
           - geojson
+          - pandas
       pip:
+
+      npm:
 
     post:
 
@@ -311,7 +316,7 @@ In this step you'll add a Plot button and the modal for the plot to the controll
         name='load_plot',
         display_text='Plot AOI',
         style='outline-secondary',
-        attributes={'id': 'load_plot'}
+        attributes={'id': 'load_plot'},
     )
 
     context = {
@@ -343,7 +348,7 @@ In this step you'll add a Plot button and the modal for the plot to the controll
       <p class="help">Change variables to select a data product, then press "Load" to add that product to the map.</p>
       {% gizmo load_button %}
       {% gizmo clear_button %}
-      <p class="help">Draw an area of interest or drop a point, the press "Plot AOI" to view a plot of the data.</p>
+      <p class="help mt-2">Draw an area of interest or drop a point, the press "Plot AOI" to view a plot of the data.</p>
       {% gizmo plot_button %}
     {% endblock %}
 
@@ -378,7 +383,7 @@ In this step you'll add a Plot button and the modal for the plot to the controll
 .. code-block:: javascript
 
     $('#load_plot').on('click', function() {
-       $('#plot-modal').modal('show');
+        $('#plot-modal').modal('show');
     });
 
 4. Stub Out the Plot JavaScript Methods
@@ -418,7 +423,11 @@ In this step you'll add a loading image to the modal whenever it is shown, repla
 .. code-block:: css
 
     #plot-loader {
-        margin: 65px 84px;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        justify-content: center;
+        flex-direction: column;
     }
 
     #plot-loader p {
@@ -427,6 +436,11 @@ In this step you'll add a loading image to the modal whenever it is shown, repla
 
     #plot-modal .modal-body {
         min-height: 480px;
+    }
+
+    .modal-dialog {
+        max-width: 70vw;
+        margin: 1.75rem auto;
     }
 
 3. Include the :file:`plot.css` stylesheet in the :file:`home.html` template:
@@ -463,7 +477,7 @@ In this step you'll add a loading image to the modal whenever it is shown, repla
 .. code-block:: javascript
 
     $('#load_plot').on('click', function() {
-       show_plot_modal();
+        show_plot_modal();
     });
 
 6. Verify that the loading GIF appears in the modal when it is opened. Browse to `<http://localhost:8000/apps/earth-engine>`_ in a web browser and login if necessary. Click on the **Plot AOI** button to open the modal. The modal should show the loading GIF and it should be centered in the modal.

--- a/docs/tutorials/google_earth_engine/part_1/plot_data.rst
+++ b/docs/tutorials/google_earth_engine/part_1/plot_data.rst
@@ -2,7 +2,7 @@
 Plot Data at a Location
 ***********************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In the final tutorial you will add the ability for users to drop a point or draw a polygon and generate a time series of the selected dataset at that location. The following topics will be reviewed in this tutorial:
 

--- a/docs/tutorials/google_earth_engine/part_1/vis_gee_layers.rst
+++ b/docs/tutorials/google_earth_engine/part_1/vis_gee_layers.rst
@@ -2,7 +2,7 @@
 Visualize Google Earth Engine Datasets
 **************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will load the GEE dataset the user has selected into the map view. The following topics will be reviewed in this tutorial:
 

--- a/docs/tutorials/google_earth_engine/part_1/vis_gee_layers.rst
+++ b/docs/tutorials/google_earth_engine/part_1/vis_gee_layers.rst
@@ -474,7 +474,8 @@ Users can now visualize GEE layers on the map, but there is no way to clear the 
         name='clear_map',
         display_text='Clear',
         style='outline-secondary',
-        attributes={'id': 'clear_map'}
+        attributes={'id': 'clear_map'},
+        classes='mt-2',
     )
 
     context = {

--- a/docs/tutorials/google_earth_engine/part_2.rst
+++ b/docs/tutorials/google_earth_engine/part_2.rst
@@ -4,7 +4,7 @@
 Part 2: Additional Pages, Clip by Asset, and Rest API
 *****************************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 This tutorial builds on the app developed in the :ref:`google_earth_engine_part_1` Tutorial.
 

--- a/docs/tutorials/google_earth_engine/part_2/about_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/about_page.rst
@@ -65,7 +65,7 @@ The first step to adding a new page to the app is to create a new controller and
 
 In this step you will add a new button to the page header that will link to the new About page. This button will be added in the base template so the About link is available from any page that inherits from it, including the Viewer page. You'll also add it to the Home and About pages because they inherit from different base templates. 
 
-To minimize the amount of code that is duplicated, you will create a new :file:`header_buttons.html` templateand use the Django ``include`` tag to insert it in each page.
+To minimize the amount of code that is duplicated, you will create a new :file:`header_buttons.html` template and use the Django ``include`` tag to insert it in each page.
 
 1. Create a new template :file:`templates/earth_engine/header_buttons.html` with the following contents:
 

--- a/docs/tutorials/google_earth_engine/part_2/about_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/about_page.rst
@@ -2,7 +2,7 @@
 Add About Page and Disclaimer Modal
 ***********************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will add an About page and a disclaimer modal. The requirements for the About page include a fixed width content area, two columns with text on the left and images on the right, and a list of sponsor logos at the bottom. The Disclaimer modal needs to be available from any page in the app and should also include the sponsor logos. The following topics will be reviewed in this tutorial:
 
@@ -35,20 +35,12 @@ If you wish to use the previous solution as a starting point:
 
 The first step to adding a new page to the app is to create a new controller and template for the page.
 
-1. Create new :file:`templates/earth_engine/about.html` template. Include the :file:`public/earth_engine/css/no_nav.css` stylesheet because this template overrides the navigation menu:
+1. Create new :file:`templates/earth_engine/about.html` template:
 
 .. code-block:: html+django
 
-    {% extends "earth_engine/base.html" %}
+    {% extends "tethys_apps/app_header_content.html" %}
     {% load static %}
-
-    {% block styles %}
-      {{ block.super }}
-      <link rel="stylesheet" href="{% static 'earth_engine/css/no_nav.css' %}" />
-    {% endblock %}
-
-    {% block app_navigation_override %}
-    {% endblock %}
 
     {% block app_content %}
     <h1>This is the About Page</h1>
@@ -71,42 +63,45 @@ The first step to adding a new page to the app is to create a new controller and
 2. Modify Header Buttons to Navigate between About Page and Home Page
 =====================================================================
 
-In this step you will add a new button to the page header that will link to the new About page. This button will be added in the base templat so the About link is available from any page of the app. You'll also move the Home button from the Viewer page to the base template so that it is available on every page, including the About page.
+In this step you will add a new button to the page header that will link to the new About page. This button will be added in the base template so the About link is available from any page that inherits from it, including the Viewer page. You'll also add it to the Home and About pages because they inherit from different base templates. 
 
-1. Move Home header button from :file:`templates/earth_engine/viewer.html` to :file:`templates/earth_engine/base.html`:
+To minimize the amount of code that is duplicated, you will create a new :file:`header_buttons.html` templateand use the Django ``include`` tag to insert it in each page.
+
+1. Create a new template :file:`templates/earth_engine/header_buttons.html` with the following contents:
+
+.. code-block:: html+django
+
+    <div class="header-button glyphicon-button">
+      <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
+    </div>
+    <div class="header-button glyphicon-button">
+      <a href="{% url 'earth_engine:about' %}" title="About"><i class="bi bi-info-circle-fill"></i></a>
+    </div>
+
+2. Add the following lines to the :file:`templates/earth_engine/base.html`, :file:`templates/earth_engine/home.html`, and :file:`templates/earth_engine/about.html` templates:
 
 .. code-block:: html+django
 
     {% block header_buttons %}
-      <div class="header-button glyphicon-button">
-        <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
-      </div>
+      {% include "earth_engine/header_buttons.html" %}
     {% endblock %}
 
-.. important::
+3. The Home button is included in :file:`header_buttons.html` and provided by :file:`base.html`, so it will be removed from :file:`viewer.html`. Delete the ``header_buttons`` block in :file:`templates/earth_engine/viewer.html`:
 
-    Be sure to delete these lines in :file:`templates/earth_engine/viewer.html`.
+.. code-block:: diff
 
-2. Create new About header button in :file:`templates/earth_engine/base.html`:
+    -{% block header_buttons %}
+    -  <div class="header-button glyphicon-button">
+    -    <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
+    -  </div>
+    -{% endblock %}
 
-.. code-block:: html+django
-    :emphasize-lines: 5-7
-
-    {% block header_buttons %}
-      <div class="header-button glyphicon-button">
-        <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
-      </div>
-      <div class="header-button glyphicon-button">
-        <a href="{% url 'earth_engine:about' %}" title="About"><i class="bi bi-info-circle-fill"></i></a>
-      </div>
-    {% endblock %}
-
-3. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify that the Home and About buttons in the header function as expected. Also navigate to the viewer page and verify that the Home and About buttons appear on that page as well.
+4. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify that the Home and About buttons in the header function as expected. Also navigate to the viewer page and verify that the Home and About buttons appear on that page as well.
 
 3. Build out About Page
 =======================
 
-In this step you'll build out the layout of the About page using the `Bootstrap Grid System <https://getbootstrap.com/docs/3.3/css/#grid>`_ as you did with the Home page. However, the about page will use the more rigid ``container`` element instead of a ``container-fluid`` element that was used on the Home page. The ``container`` element has a fixed width with wide margins that gives it a classic website look. The width of a ``container-fluid`` element, on the other hand, resizes dynamically or fluidly with the window.
+In this step you'll build out the layout of the About page using the `Bootstrap Grid System <https://getbootstrap.com/docs/5.2/layout/grid/>`_ as you did with the Home page. However, the about page will use the more rigid ``container`` element instead of a ``container-fluid`` element that was used on the Home page. The ``container`` element has a fixed width with wide margins that gives it a classic website look. The width of a ``container-fluid`` element, on the other hand, resizes dynamically or fluidly with the window.
 
 1. Create a ``<div>`` element with class ``container`` in the ``app_content`` block:
 
@@ -225,18 +220,16 @@ In this step you'll build out the layout of the About page using the `Bootstrap 
 4. Customize the About Page Styles
 ==================================
 
-As with the Home page, the `Bootstrap Grid System <https://getbootstrap.com/docs/3.3/css/#grid>`_ does a good job providing the base layout for the page, but there are a few tweaks that need to be made to finish the About page. In this step you will create a stylesheet for the About page and use it to polish the page styles.
+As with the Home page, the Bootstrap Grid System does a good job providing the base layout for the page, but there are a few tweaks that need to be made to finish the About page. In this step you will create a stylesheet for the About page and use it to polish the page styles.
 
 1. Create a new :file:`public/earth_engine/about.css` stylesheet.
 
-2. Include the new :file:`about.css` in :file:`templates/earth_engine/about.html`:
+2. Include the new :file:`about.css` by adding the ``styles`` block to the :file:`templates/earth_engine/about.html`:
 
 .. code-block:: html+django
-    :emphasize-lines: 4
 
     {% block styles %}
       {{ block.super }}
-      <link rel="stylesheet" href="{% static 'earth_engine/css/no_nav.css' %}" />
       <link rel="stylesheet" href="{% static 'earth_engine/css/about.css' %}" />
     {% endblock %}
 
@@ -286,57 +279,50 @@ As with the Home page, the `Bootstrap Grid System <https://getbootstrap.com/docs
 5. Create the Disclaimer Modal
 ==============================
 
-In this step you will create a new modal that will contain a disclaimer for the app. This modal will need to be available on all pages, so it will be added to the base template.
+In this step you will create a new modal that will contain a disclaimer for the app. This modal will need to be available on all pages, so a similar strategy will be used as was used with the header buttons.
 
 
-1. Create a new Bootstrap modal in :file:`templates/earth_engine/base.html`. Modals should be placed in the ``after_app_content`` block:
+1. Create a new :file:`templates/earth_engine/disclaimer.html` with the following contents:
 
 .. code-block:: html+django
 
-    {# Use the after_app_content block for modals #}
-    {% block after_app_content %}
-      {{ block.super }}
-      <!-- Info Modal -->
-      <div class="modal fade" id="disclaimer-modal" tabindex="-1" role="dialog" aria-labelledby="disclaimer-modal-label">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h2 class="modal-title" id="disclaimer-modal-label">Disclaimer</h2>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer">
-            </div>
+    <div class="modal fade" id="disclaimer-modal" tabindex="-1" role="dialog" aria-labelledby="disclaimer-modal-label">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h2 class="modal-title" id="disclaimer-modal-label">Disclaimer</h2>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+          </div>
+          <div class="modal-footer">
           </div>
         </div>
       </div>
-      <!-- End Info Modal -->
-    {% endblock %}
+    </div>
 
-2. Add a header button to launch the modal in :file:`templates/earth_engine/base.html`:
+2. Add a header button to launch the modal in :file:`templates/earth_engine/header_buttons.html`:
 
 .. code-block:: html+django
-    :emphasize-lines: 9-11
 
-    {% block header_buttons %}
-      {{ block.super }}
-      <div class="header-button glyphicon-button">
-        <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
-      </div>
-      <div class="header-button glyphicon-button">
-        <a href="{% url 'earth_engine:about' %}" title="About"><i class="bi bi-info-circle-fill"></i></a>
-      </div>
       <div class="header-button glyphicon-button">
         <a data-bs-toggle="modal" data-bs-target="#disclaimer-modal" title="Disclaimer"><i class="bi bi-exclamation-diamond-fill"></i></a>
       </div>
+
+3. Add the following lines to the :file:`templates/earth_engine/base.html`, :file:`templates/earth_engine/home.html`, and :file:`templates/earth_engine/about.html` templates:
+
+.. code-block:: html+django
+
+    {% block after_app_content %}
+      {{ block.super }}
+      {% include "earth_engine/disclaimer.html" %}
     {% endblock %}
 
-3. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify that the modal opens when the Disclaimer header button is pressed.
+4. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify that the modal opens when the Disclaimer header button is pressed.
 
-4. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_ and attempt to open the disclaimer modal. It doesn't work, because the ``viewer.html`` template overrides the ``after_app_content`` block with its own modals for the functionality on the viewer page.
+5. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_ and attempt to open the disclaimer modal. It doesn't work, because the ``viewer.html`` template overrides the ``after_app_content`` block with its own modals for the functionality on the viewer page.
 
-5. Include the ``block.super`` content in the ``after_app_content`` block of :file:`templates/earth_engine/viewer.html` to include the disclaimer modal from the ``base.html`` template when overriding the block in the ``viewer`` template:
+6. Include the ``block.super`` content in the ``after_app_content`` block of :file:`templates/earth_engine/viewer.html` to include the disclaimer modal from the ``base.html`` template when overriding the block in the ``viewer`` template:
 
 .. code-block:: html+django
     :emphasize-lines: 3
@@ -367,7 +353,7 @@ In this step you will create a new modal that will contain a disclaimer for the 
 
 6. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_ and verify that the modal opens when the Disclaimer header button is pressed. Press the **Plot AOI** button to verify that the *Area of Interest* modal still opens as well.
 
-7. Add the following content to the ``modal-body`` ``<div>`` element in :file:`templates/earth_engine/base.html`:
+7. Add the following content to the ``modal-body`` ``<div>`` element in :file:`templates/earth_engine/disclaimer.html`:
 
 .. code-block:: html+django
 
@@ -381,7 +367,7 @@ In this step you will create a new modal that will contain a disclaimer for the 
       </div>
     </div>
 
-8. Add the following content to the ``modal-footer`` ``<div>`` element in :file:`templates/earth_engine/base.html`:
+8. Add the following content to the ``modal-footer`` ``<div>`` element in :file:`templates/earth_engine/disclaimer.html`:
 
 .. code-block:: html+django
 
@@ -405,43 +391,38 @@ In this step you will create a new modal that will contain a disclaimer for the 
 
 In this step, you will add a new stylesheet for the disclaimer modal and add styles to adjust the presetnation of the modal and sponsor images.
 
-1. Create a new :file:`public/earth_engine/disclaimer_modal.css` stylesheet with the following contents:
+1. Add the following ``<style>`` element to the top of :file:`templates/earth_engine/disclaimer.html`:
 
-.. code-block:: css
+.. code-block:: html
 
-    #disclaimer-container {
-      height: 400px;
-      overflow-y: auto;
-    }
+    <style>
+      #disclaimer-modal .modal-dialog {
+        max-width: 600px;
+      }
 
-    #sponsors-container {
-      text-align: left;
-    }
-
-    #sponsors-container img {
-      height: 50px;
-      width: 50px;
-      margin-right: 10px;
-      border-radius: 5px;
-    }
-
-    #sponsors-container h6 {
+      #disclaimer-container {
+        height: 400px;
+        overflow-y: auto;
+      }
+      
+      #sponsors-container {
+        text-align: left;
+      }
+      
+      #sponsors-container img {
+        height: 50px;
+        width: 50px;
+        margin-right: 10px;
+        border-radius: 5px;
+      }
+      
+      #sponsors-container h6 {
         display: inline-block;
         margin-right: 10px;
-    }
+      }
+    </style>
 
-2. Include the new stylesheet in the ``content_dependent_styles`` block of the :file:`templates/earth_engine/base.html`:
-
-.. code-block:: html+django
-    :emphasize-lines: 4
-
-    {% block content_dependent_styles %}
-      {{ block.super }}
-      <link href="{% static 'earth_engine/css/main.css' %}" rel="stylesheet"/>
-      <link href="{% static 'earth_engine/css/disclaimer_modal.css' %}" rel="stylesheet"/>
-    {% endblock %}
-
-3. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify the style changes worked. Hard-refresh the page if necessary (:kbd:`CTRL-SHIFT-R` or :kbd:`CTRL-F5`). Open the Disclaimer modal on the other pages of the app to verify that the modal looks the same on all pages.
+2. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify the style changes worked. Hard-refresh the page if necessary (:kbd:`CTRL-SHIFT-R` or :kbd:`CTRL-F5`). Open the Disclaimer modal on the other pages of the app to verify that the modal looks the same on all pages.
 
 7. Solution
 ===========

--- a/docs/tutorials/google_earth_engine/part_2/clip_by_asset.rst
+++ b/docs/tutorials/google_earth_engine/part_2/clip_by_asset.rst
@@ -2,7 +2,7 @@
 Clip by Asset
 *************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will use the shapefile uploaded using the file upload form to clip the dataset imagery. This will be done by uploading the shapefile to Google Earth Engine as an asset. Then the map will be reconfigured to check for the asset and clip the imagery if it exists. It will also use the bounding box of the asset to set the default map extent. The following topics will be reviewed in this tutorial:
 
@@ -45,12 +45,15 @@ In this step you will stub out a new GEE method called ``upload_shapefile_to_gee
         print(user.username)
         print(shp_file)
 
-2. Import the new ``upload_shapefile_to_gee`` function and call it in ``handle_shapefile_upload`` function in :file:`controllers.py` after validating the shapefile upload. Also add an additional ``except`` clause to handle any uncaught Google Earth Engine errors:
+2. Import the new ``upload_shapefile_to_gee`` function and call it in ``handle_shapefile_upload`` function in :file:`helpers.py` after validating the shapefile upload. Also add an additional ``except`` clause to handle any uncaught Google Earth Engine errors:
 
 .. code-block:: python
 
+    import logging
     import ee
     from .gee.methods import upload_shapefile_to_gee
+
+    log = logging.getLogger(f'tethys.apps.{__name__}')
 
 .. code-block:: python
     :emphasize-lines: 51-52, 57-60
@@ -471,7 +474,7 @@ In this step you will modify the ``get_image_collection_asset`` method to attemp
 .. code-block:: python
     :emphasize-lines: 22
 
-    @controller
+    @controller(url='viewer/get-image-collection')
     def get_image_collection(request):
         """
         Controller to handle image collection requests.

--- a/docs/tutorials/google_earth_engine/part_2/home_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/home_page.rst
@@ -464,7 +464,7 @@ The Bootstrap CSS framework provides a good base for styling pages in the apps. 
 
 9. Refresh the page to see how the styles change the look and feel of the page. Hard-refresh if necessary (:kbd:`CTRL-SHIFT-R` or :kbd:`CTRL-F5`).
 
-10. Notice the white space around the border of the page? This is padding in the content area of our base template. To remove the white space so the backdrop iimage fills the page, add the following lines to :file:`public/css/home.css`:
+10. Notice the white space around the border of the page? This is padding in the content area of our base template. To remove the white space so the backdrop image fills the page, add the following lines to :file:`public/css/home.css`:
 
 .. code-block:: css
 

--- a/docs/tutorials/google_earth_engine/part_2/home_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/home_page.rst
@@ -2,7 +2,7 @@
 Add a Home Page
 ***************
 
-**Last Updated:** May 2020
+**Last Updated:** January 2023
 
 In this tutorial you will create a home page for the Google Earth Engine app that you created in :ref:`google_earth_engine_part_1`. This page will contain introductory information about that app. This will involve moving the current "home page", which contains the map viewer, to a new endpoint. Then you will set up a new controller and template for the new home page. The following topics will be reviewed in this tutorial:
 
@@ -52,12 +52,19 @@ Currently, the map viewer page is the "home" page of the app as evidenced by it 
 
     return render(request, 'earth_engine/viewer.html', context)
 
-4. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_ and verify that the map view still functions as it should. Be sure to test loading a dataset or two and plot data at a location.
+4. Set custom URLs for the ``get_image_collection`` and  ``get_time_series_plot`` controllers in :file:`controllers.py`: so that their URLs are relative to the ``viewer`` url:
 
-    .. note::
-    
-        The root URL endpoint for the app (`<http://localhost:8000/apps/earth-engine/>`_) is not defined and will raise an error. This error will also be raised if you exit the app and launch it again, because the root URL endpoint is the default primary view of the app.
+.. code-block:: python
 
+    @controller(url='viewer/get-image-collection')
+    def get_image_collection(request):
+        ...
+
+.. code-block:: python
+
+    @controller(url='viewer/get-time-series-plot')
+    def get_time_series_plot(request):
+        ...
 
 2. Create New Home Endpoint
 ===========================
@@ -91,55 +98,32 @@ In this step you will create a new ``home`` controller and :file:`home.html` tem
 
 4. Exit the app and launch it again from the Apps Library to verify that loads the new home page.
 
+5. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_ and verify that the map view still functions as it should. Be sure to test loading a dataset or two and plot data at a location.
+
 
 3. Remove Navigation from Home Page
 ===================================
 
-As the app is not very complex (i.e. it only has two pages), the navigation menu will not be needed. In this step you will remove it using the ``app_navigation_override`` block. Doing so also causes the hamburger menu in the header to be removed, which causes some styling issues. These will also be addressed by adding a new stylesheet to the page.
+As the app is not very complex (i.e. it only has two pages), the navigation menu will not be needed. Tethys Platform provides a variety of base templates including several without the navigation menu (see: :ref:`additional_base_templates`). In this step you remove the app navigation menu by changing the base template used by ``home.html``.
 
-1. Add the ``app_navigation_override`` block in :file:`templates/earth_engine/home.html` to remove the navigation panel from the home page:
+1. Change the ``extends`` tag in :file:`templates/earth_engine/home.html` to use the base template called ``app_header_content.html``:
 
-.. code-block:: html+django
+.. code-block:: diff
 
-    {% block app_navigation_override %}
+   -{% extends "earth_engine/base.html" %}
+   +{% extends "tethys_apps/app_header_content.html" %}
+    {% load tethys_gizmos static %}
+
+    {% block app_content %}
+    <h1>Home Page</h1>
     {% endblock %}
 
-2. Create a new :file:`public/css/no_nav.css` style sheet with styles to adjust the header appropriately when there is no navigation toggle button in the header:
-
-.. code-block:: css
-
-    #nav-title-wrapper {
-      margin-left: 15px;
-    }
-
-    #app-content-wrapper #app-content {
-      height: 100%;
-    }
-
-    #app-content-wrapper.show-nav #app-content {
-      padding-right: 0;
-      transform: none;
-    }
-
-    #inner-app-content {
-      padding: 0;
-    }
-
-3. Include the :file:`public/css/no_nav.css` stylesheet in :file:`templates/earth_engine/home.html`:
-
-.. code-block:: html+django
-
-    {% block styles %}
-      {{ block.super }}
-      <link rel="stylesheet" href="{% static 'earth_engine/css/no_nav.css' %}" />
-    {% endblock %}
-
-4. Navigate to `<http://localhost:8000/apps/earth-engine/>`_ and verify that the app icon in the header has spacing on the left.
+2. Navigate to `<http://localhost:8000/apps/earth-engine/>`_ and verify that the navigation menu is gone.
 
 4. Layout Home Page Grid with Bootstrap
 =======================================
 
-In this step, you will create a responsive two column layout using the `Bootstrap Grid System <https://getbootstrap.com/docs/3.3/css/#grid>`_, which is part of the Bootstrap CSS framework. Bootstrap provides a number of simple recipes for implementing common HTML + CSS patterns. It is built-in with Tethys Platform, so no additional installation is required. 
+In this step, you will create a responsive two column layout using the `Bootstrap Grid System <https://getbootstrap.com/docs/5.2/layout/grid/>`_, which is part of the `Bootstrap CSS framework <https://getbootstrap.com/docs/5.2/getting-started/introduction/>`_. Bootstrap provides a number of simple recipes for implementing common HTML + CSS patterns. It is built-in with Tethys Platform, so no additional installation is required. 
 
 1. Create a ``<div>`` element with class ``container-fluid`` in the ``app_content`` block:
 
@@ -185,7 +169,7 @@ In this step, you will create a responsive two column layout using the `Bootstra
     
 .. note::
 
-    Each row in a `Bootstrap Grid <https://getbootstrap.com/docs/3.3/css/#grid>`_ can be divided into as many as 12 columns by specifying different numbers at the end of the ``col-md-X`` classes. A column of size 1 is effectively 1/12th of the width of the row. For example, to divide a row into two equal columns you would add two columns with size of 6 (6/12ths).
+    Each row in a Bootstrap Grid can be divided into as many as 12 columns by specifying different numbers at the end of the ``col-md-X`` classes. A column of size 1 is effectively 1/12th of the width of the row. For example, to divide a row into two equal columns you would add two columns with size of 6 (6/12ths).
     
     Our home page has two columns but instead of being evenly divided, one of them takes up 8 of the available 12 column widths and the other takes the remaining 4 column widths. This effectively give our columns a 2 to 1 ratio. 
 
@@ -247,7 +231,7 @@ In this step, you will create a responsive two column layout using the `Bootstra
 5. Create About Panel Content
 =============================
 
-In this step we'll add a the title and some filler content to the About panel of the home page. The filler content was generated using a `Lorem Ipsum <https://loremipsum.io/>`_ generator. This is a commonly used strategy that allows the developer to test the structure ans style of the page even if the content has not been finalized yet.
+In this step we'll add a the title and some filler content to the About panel of the home page. The filler content was generated using a `Lorem Ipsum <https://loremipsum.io/>`_ generator. This is a commonly used strategy that allows the developer to test the structure and style of the page even if the content has not been finalized yet.
 
 1. Add the title, "About", and a few paragraphs of filler text (lorem ipsum) to the ``<div>`` element with id ``about-container``. Use the ``info-title`` class on the title element to allow for consistent styling of all the titles in a later step. Place the placeholder filler text in ``<p>`` elements:
 
@@ -268,8 +252,8 @@ In this step we'll add a the title and some filler content to the About panel of
 .. code-block:: html+django
     :emphasize-lines: 5
 
-    <div class="info-container">
-      <h2 id="about-container" class="info-title">About</h2>
+    <div id="about-container" class="info-container">
+      <h2 class="info-title">About</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eget est lorem ipsum dolor sit amet. Morbi tincidunt augue interdum velit euismod in pellentesque.</p>
       <p>Ac felis donec et odio pellentesque. Quis ipsum suspendisse ultrices gravida dictum fusce ut. Curabitur gravida arcu ac tortor dignissim convallis aenean et tortor. Sed euismod nisi porta lorem mollis. Nisi scelerisque eu ultrices vitae. Sit amet consectetur adipiscing elit duis. At in tellus integer feugiat scelerisque varius morbi enim.</p>
       <img id="feature-image" src="{% static 'earth_engine/images/earth-engine-viewer.png' %}">
@@ -281,7 +265,7 @@ In this step we'll add a the title and some filler content to the About panel of
 6. Create Resources Panel Content
 =================================
 
-In this step we'll add the content to the Resources panel of the home page. The Resouces panel needs to contain a list of links to external resources related to our app. `Boostrap Media Objects <https://getbootstrap.com/docs/3.3/components/#media>`_ will be used to represent our resource list. Each media object has a thumbnail image with the link, title, and short description. Once again, you'll use Lorem Ipsum as filler text.
+In this step we'll add the content to the Resources panel of the home page. The Resouces panel needs to contain a list of links to external resources related to our app.
 
 1. Add the title, "Resources", to the ``<div>`` element with id ``resources-container``. Again, use the ``info-title`` class on the title element.
 
@@ -302,44 +286,44 @@ In this step we'll add the content to the Resources panel of the home page. The 
 
     In addition to Lorem Ipsum generators, there are also `placeholder image generators <https://loremipsum.io/21-of-the-best-placeholder-image-generators/>`_ that can be used to generate placeholder images for development. Most of these services allow you to specify the size of the images and some of them allow you to specify text that is shown on the image. The images above were obtained from `PlaceIMG <http://placeimg.com/>`_.
 
-3. Add three resources to the ``<div>`` element with id ``resources-container``. Use `Boostrap Media Objects <https://getbootstrap.com/docs/3.3/components/#media>`_ to style each resource. Each media object/resource includes, a title, a short description and a thumbnail image. The image is wrapped in an ``<a>`` tag that can be used to provide a link to an external resource. Again, use the built-in ``static`` tag to get the paths for the images.
+3. Add three resources to the ``<div>`` element with id ``resources-container``. Use `Bootstrap Flex Utilities <https://getbootstrap.com/docs/5.2/utilities/flex/#media-object>`_ to create media "objects" for each resource. Each media object includes, a title, a short description and a thumbnail image. The image is wrapped in an ``<a>`` tag that can be used to provide a link to an external resource. Again, use the built-in ``static`` tag to get the paths for the images.
 
 .. code-block:: html+django
     :emphasize-lines: 3-37
 
     <div id="resources-container" class="info-container">
       <h2 class="info-title">Resources</h2>
-      <div class="media">
-        <div class="media-left">
+      <div class="d-flex align-items-center">
+        <div class="flex-shrink-0">
           <a href="#coast">
-            <img class="media-object" src="{% static 'earth_engine/images/coast_80_80.jpg' %}" alt="">
+            <img class="media-object" src="{% static 'earth_engine/images/coast_80_80.jpg' %}" alt="coast">
           </a>
         </div>
-        <div class="media-body">
+        <div class="media-body flex-grow-1 ms-3">
           <h4 class="media-heading">Lorem Ipsum Dolor</h4>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </div>
       </div>
 
-      <div class="media">
-        <div class="media-left">
+      <div class="d-flex align-items-center mt-2">
+        <div class="flex-shrink-0">
           <a href="#condensation">
-            <img class="media-object" src="{% static 'earth_engine/images/condensation_80_80.jpg' %}" alt="">
+            <img class="media-object" src="{% static 'earth_engine/images/condensation_80_80.jpg' %}" alt="condensation">
           </a>
         </div>
-        <div class="media-body">
+        <div class="media-body flex-grow-1 ms-3">
           <h4 class="media-heading">Ut Enim Ad Minim</h4>
           Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </div>
       </div>
 
-      <div class="media">
-        <div class="media-left">
+      <div class="d-flex align-items-center mt-2">
+        <div class="flex-shrink-0">
           <a href="#waterfall">
-            <img class="media-object" src="{% static 'earth_engine/images/waterfall_80_80.jpg' %}" alt="">
+            <img class="media-object" src="{% static 'earth_engine/images/waterfall_80_80.jpg' %}" alt="waterfall">
           </a>
         </div>
-        <div class="media-body">
+        <div class="media-body flex-grow-1 ms-3">
           <h4 class="media-heading">Duis Aute Irure</h4>
           Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
         </div>
@@ -374,14 +358,12 @@ The Bootstrap CSS framework provides a good base for styling pages in the apps. 
 
 1. Create a new :file:`public/css/home.css` stylesheet.
 
-2. Include the :file:`public/css/home.css` stylesheet in :file:`templates/earth_engine/home.html`:
+2. Include the :file:`public/css/home.css` stylesheet in :file:`templates/earth_engine/home.html` by adding the ``styles`` block:
 
 .. code-block:: html+django
-    :emphasize-lines: 4
 
     {% block styles %}
       {{ block.super }}
-      <link rel="stylesheet" href="{% static 'earth_engine/css/no_nav.css' %}" />
       <link rel="stylesheet" href="{% static 'earth_engine/css/home.css' %}" />
     {% endblock %}
 
@@ -481,6 +463,14 @@ The Bootstrap CSS framework provides a good base for styling pages in the apps. 
     }
 
 9. Refresh the page to see how the styles change the look and feel of the page. Hard-refresh if necessary (:kbd:`CTRL-SHIFT-R` or :kbd:`CTRL-F5`).
+
+10. Notice the white space around the border of the page? This is padding in the content area of our base template. To remove the white space so the backdrop iimage fills the page, add the following lines to :file:`public/css/home.css`:
+
+.. code-block:: css
+
+    #inner-app-content {
+      padding: 0;
+    }
 
 9. Add a Home Button to Viewer Page
 ===================================

--- a/docs/tutorials/google_earth_engine/part_2/primer.rst
+++ b/docs/tutorials/google_earth_engine/part_2/primer.rst
@@ -2,7 +2,7 @@
 Part 2 Primer: Boostrap, CSS, Assets and More
 *********************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 This tutorial extends the Earth Engine app developed in Part 1 and covers a wide range of additional topics for Tethys App development. In this tutorial you will learn how to add multiple pages to a Tethys App, create responsive layouts using the Boostrap CSS framework, upload files and manage them in the app, work with Google Earth Engine Assets, and add a REST API to your app.
 
@@ -11,7 +11,7 @@ This primer provides simple explanations for some of the concepts you and tools 
 Bootstrap CSS Framework
 =======================
 
-Bootstrap is self-described as "the most popular HTML, CSS, and JavaScript framework". It provides HTML patterns, CSS, and a bit of JavaScript for building responsive websites. Tethys Platform includes Bootstrap as one of its built-in tools, so there is no need to download or install the libraries to use it in your app. At the time of writing, Tethys Platform provided `Bootstrap version 3.4.1 <https://getbootstrap.com/docs/3.4/>`_, which is not the latest release. Take care to use the correct version of the documentation whenever you search for Bootstrap help.
+Bootstrap is self-described as "the most popular HTML, CSS, and JavaScript framework". It provides HTML patterns, CSS, and a bit of JavaScript for building responsive websites. Tethys Platform includes Bootstrap as one of its built-in tools, so there is no need to download or install the libraries to use it in your app. At the time of writing, Tethys Platform provided `Bootstrap version 5 <https://getbootstrap.com/docs/5.2/getting-started/introduction/>`_, which is not the latest release. Take care to use the correct version of the documentation whenever you search for Bootstrap help.
 
 Responsive Web Design
 ---------------------
@@ -21,17 +21,17 @@ Responsive web design is an approach to building websites that adjust to the dev
 Bootstrap Grid
 --------------
 
-Bootstrap provides a fluid grid system for creating just about any layout that you need. Using the grid system you can create a 2-column, 3-column, up to 12-column layout for larger screens. On narrow screens, no matter the layout, the columns stack on top of each other and fill the screen width. See `Bootstrap Grid System <https://getbootstrap.com/docs/3.4/css/#grid>`_ for more details and tips.
+Bootstrap provides a fluid grid system for creating just about any layout that you need. Using the grid system you can create a 2-column, 3-column, up to 12-column layout for larger screens. On narrow screens, no matter the layout, the columns stack on top of each other and fill the screen width. See `Bootstrap Grid System <https://getbootstrap.com/docs/5.2/layout/grid/>`_ for more details and tips.
 
 Bootstrap Containers
 --------------------
 
-The Bootstrap grid elements need to be placed inside one of the containers it provides. There are two types of containers to choose from: ``.container`` and ``.container-fluid``. Using ``.container`` will create a responsive, fixed-width page with large margins, while the ``.container-fluid`` element will create a full-width page that changes dynamically if the viewport changes size. Both types of containers will be demonstrated in this tutorial. See `Bootstrap Containers <https://getbootstrap.com/docs/3.4/css/#overview-container>`_ for more details.
+The Bootstrap grid elements need to be placed inside one of the containers it provides. There are two types of containers to choose from: ``.container`` and ``.container-fluid``. Using ``.container`` will create a responsive, fixed-width page with large margins, while the ``.container-fluid`` element will create a full-width page that changes dynamically if the viewport changes size. Both types of containers will be demonstrated in this tutorial. See `Bootstrap Containers <https://getbootstrap.com/docs/5.2/layout/containers/>`_ for more details.
 
 Modals
 ------
 
-Modals are a staple of web applications that can be used for dialogs and message boxes. Bootstrap provides a responsive modal with a JavaScript API to allow you bind to modal events and control it dynamically. See `Bootstrap Modals <https://getbootstrap.com/docs/3.4/javascript/#live-demo>`_ for more details.
+Modals are a staple of web applications that can be used for dialogs and message boxes. Bootstrap provides a responsive modal with a JavaScript API to allow you bind to modal events and control it dynamically. See `Bootstrap Modals <https://getbootstrap.com/docs/5.2/components/modal/>`_ for more details.
 
 CSS Primer for Tethys Developers
 ================================

--- a/docs/tutorials/google_earth_engine/part_3.rst
+++ b/docs/tutorials/google_earth_engine/part_3.rst
@@ -4,7 +4,7 @@
 Part 3: Publish Code and Deploy
 *******************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 This tutorial builds on the app developed in the :ref:`google_earth_engine_part_1` Tutorial.
 

--- a/docs/tutorials/google_earth_engine/part_3/deploy.rst
+++ b/docs/tutorials/google_earth_engine/part_3/deploy.rst
@@ -2,7 +2,7 @@
 Deploy App to Production Server
 *******************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will learn how to install the Google Earth Tethys app in a production environment. If you don't have access to a machine with a production installation of Tethys Platform, we recommend you create a new Virtual Machine and install Tethys on it. Refer to :ref:`production_installation`.
 

--- a/docs/tutorials/google_earth_engine/part_3/prepare.rst
+++ b/docs/tutorials/google_earth_engine/part_3/prepare.rst
@@ -4,7 +4,7 @@
 Prepare App for Publishing and Deploy
 *************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 In this tutorial you will prepare the app for publishing and deployment. The app source code will be published to `GitHub <https://github.com/>`_ under an `open source license <https://opensource.org/licenses>`_. Among other things, this will allow you to track future changes to the app and it will allow others to view the code and modify it for their own use. Having the app code published on GitHub will also make it easier to download when installing the app on a production server.
 
@@ -164,7 +164,7 @@ In this step you will add an appropriate open source license to your project. Th
 
 1. Navigate to `<https://opensource.org/licenses>`_ and peruse the list of Popular License.
 
-2. Click on the link for the `BSD 3-Clause "New" or "Revised" license <https://opensource.org/licenses/BSD-3-Clause>`_ or a license of your choice.
+2. Click on the link for the `BSD-3-Clause "New" or "Revised" license <https://opensource.org/licenses/BSD-3-Clause>`_ or a license of your choice.
 
 3. Create a new file called :file:`LICENSE` in the same directory as the :file:`setup.py`.
 
@@ -195,7 +195,7 @@ In this step you will add appropriate metadata to the :file:`setup.py`. This met
         author='<YOUR NAME>',
         author_email='<YOUR EMAIL>',
         url='',  # The URL will be set in a future step.
-        license='BSD 3-Clause',
+        license='BSD-3-Clause',
         packages=find_namespace_packages(),
         package_data={'': resource_files},
         include_package_data=True,
@@ -250,20 +250,21 @@ Up to this point, the app has been installed in development mode (``tethys insta
 
 In a production environment you will want to install the app normally (``tethys install``). When a Python package is installed, the files are **copied** to the Python :file:`site-packages` directory. By default, only Python files (with the ``py`` extension) are copied to the :file:`site-packages` directory. Other types of files needed by a a Python package are referred to as "package data" or "resource files".
 
-Resource files that are required by in Tethys Apps include CSS, JavaScript, HTML, and images. Open :file:`setup.py` and inspect lines 12-13:
+Resource files that are required by in Tethys Apps include CSS, JavaScript, HTML, and images. Open :file:`setup.py` and inspect line 13:
 
-.. code-block::
+.. code-block:: python
 
-    resource_files = find_resource_files('tethysapp/' + app_package + '/templates', 'tethysapp/' + app_package)
-    resource_files += find_resource_files('tethysapp/' + app_package + '/public', 'tethysapp/' + app_package)
+    resource_files = find_all_resource_files(app_package, TethysAppBase.package_namespace)
 
-These lines use a helper function provided by Tethys Platform ``find_resource_files`` to automatically locate and include files in the :file:`templates` and :file:`public` directories. If your app had additional directories with non-python files that need to be included, you would need to add an additional call to ``find_resource_files`` like so:
+These lines use a helper function provided by Tethys Platform ``find_all_resource_files`` to automatically locate and include all files in the :file:`templates`, :file:`public`, and :file:`workspaces` directories. If your app had additional directories with non-python files that need to be included, you would need to add calls to another helper function, ``find_resource_files``, like so:
 
-.. code-block::
+.. code-block:: python
 
-    resource_files += find_resource_files('tethysapp/' + app_package + '<OTHER RESOURCE FILES DIR>', 'tethysapp/' + app_package)
+    from tethys_apps.app_installation import find_resource_files
 
-There are no additional resource files for the Earth Engine app, so no additional calls to ``find_resource_files`` are required.
+    resource_files += find_resource_files(f'{TethysAppBase.package_namespace}/{app_package}/<OTHER RESOURCE FILES DIR>', f'{TethysAppBase.package_namespace}/{app_package}')
+
+There are no additional resource files for the Earth Engine app, so no calls to ``find_resource_files`` are required.
 
 8. Solution
 ===========

--- a/docs/tutorials/google_earth_engine/part_3/primer.rst
+++ b/docs/tutorials/google_earth_engine/part_3/primer.rst
@@ -2,7 +2,7 @@
 Part 3 Primer: Publishing and Deploying
 ***************************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 Publishing and deploying your Tethys app to a production Tethys Portal server are the final steps in the life cycle of a Tethys app. Unfortunately, deploying is also one of the more challenging aspects of Tethys development. Many of the challenges of installing apps in production can be avoided through preparation and experience. In this tutorial you will learn how to prepare the Earth Engine app for publishing and deployment. You will then publish the app on GitHub and deploy the app on a production Tethys Portal server.
 

--- a/docs/tutorials/google_earth_engine/part_3/publish.rst
+++ b/docs/tutorials/google_earth_engine/part_3/publish.rst
@@ -4,7 +4,7 @@
 Publish App Code to GitHub
 **************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 `GitHub <https://github.com/>`_ is among the most popular git repositories and is an excellent place to publish open source code. In this tutorial you will learn how to setup a new GitHub repository and push your code to it. Be sure to properly sanitize your code before pushing it to GitHub (see: :ref:`prepare_for_publish_and_deploy`).
 

--- a/docs/tutorials/google_earth_engine/part_3/service_account.rst
+++ b/docs/tutorials/google_earth_engine/part_3/service_account.rst
@@ -4,7 +4,7 @@
 Google Earth Engine Service Account
 ***********************************
 
-**Last Updated:** June 2022
+**Last Updated:** January 2023
 
 Up to this point, you've been using your personal Google account to authenticate with Google Earth Engine (see: :ref:`gee_authentication_step`). However, when you run an app that uses Google Earth Engine in a production environment, you will not want it to be using your personal credentials. Instead you will use a `service account <https://developers.google.com/earth-engine/service_account>`_, which is an account associated with an application instead of a user.
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,7 +31,7 @@ Bootstrap 5
 * Upgraded to use Bootstrap version 5 (Tethys 3 used version 3).
 * Tethys Portal overhauled and re-themed using new capabilities of Bootstrap 5.
 
-See: `Boostrap 5 Documentation <https://getbootstrap.com/docs/5.22/getting-started/introduction/>`_
+See: `Boostrap 5 Documentation <https://getbootstrap.com/docs/5.2/getting-started/introduction/>`_
 
 Controller Decorators
 ---------------------

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,7 +31,7 @@ Bootstrap 5
 * Upgraded to use Bootstrap version 5 (Tethys 3 used version 3).
 * Tethys Portal overhauled and re-themed using new capabilities of Bootstrap 5.
 
-See: `Boostrap 5 Documentation <https://getbootstrap.com/docs/5.0/getting-started/introduction/>`_
+See: `Boostrap 5 Documentation <https://getbootstrap.com/docs/5.22/getting-started/introduction/>`_
 
 Controller Decorators
 ---------------------

--- a/docs/whats_new/app_migration.rst
+++ b/docs/whats_new/app_migration.rst
@@ -139,7 +139,7 @@ needs to be changed to this:
 Theme and Styles
 ================
 
-The frontend CSS framework, Bootstrap, was upgraded from version 3 to version 5 in Tethys Platform 4. As a result, any Boostrap components that are used in templates will need to be updated to use the `Bootstrap 5 <https://getbootstrap.com/docs/5.0/getting-started/introduction/>`_ syntax so they function and look as expected. This section describes how to update the most common Bootstrap components that are used in Tethys Apps.
+The frontend CSS framework, Bootstrap, was upgraded from version 3 to version 5 in Tethys Platform 4. As a result, any Boostrap components that are used in templates will need to be updated to use the `Bootstrap 5 <https://getbootstrap.com/docs/5.2/getting-started/introduction/>`_ syntax so they function and look as expected. This section describes how to update the most common Bootstrap components that are used in Tethys Apps.
 
 .. note::
 
@@ -217,12 +217,12 @@ All Boostrap related data attributes on HTML elements now include a ``bs`` names
 
 1. Perform a project-wide search on your app source code for ``data-`` to find instances of data attributes.
 2. Review the tips below for Tooltips, Dropdowns, and Modals.
-3. Review the `Bootstrap 5 documentation <https://getbootstrap.com/docs/5.0/components/accordion/>`_ for details about changes to other components that your app uses that are not listed below.
+3. Review the `Bootstrap 5 documentation <https://getbootstrap.com/docs/5.2/components/accordion/>`_ for details about changes to other components that your app uses that are not listed below.
 
 Buttons
 -------
 
-The ``btn-default`` class no longer exists in Bootstrap 5. Change it to ``btn-outline-secondary`` for a similar looking button. Alternatively, choose from several new styles of buttons that can be found here: `Boostrap Buttons <https://getbootstrap.com/docs/5.0/components/buttons/>`_.
+The ``btn-default`` class no longer exists in Bootstrap 5. Change it to ``btn-outline-secondary`` for a similar looking button. Alternatively, choose from several new styles of buttons that can be found here: `Boostrap Buttons <https://getbootstrap.com/docs/5.2/components/buttons/>`_.
 
 Tooltips
 --------
@@ -471,7 +471,7 @@ Other Resources
 It is not possible to anticipate every migration step that will be needed. The suggestions are for the cases that will be most commonly encountered. The following resources may provide additional guidance for migrating your app(s).
 
 * Tethys is powered by Django. If your app makes uses of Django features directly, you may need to perform additional migration steps. See `Upgrading Django to a newer version <https://docs.djangoproject.com/en/3.2/howto/upgrade-version/>`_ and `Django 3.2 Release Notes <https://docs.djangoproject.com/en/3.2/releases/>`_.
-* Apps are styled using Bootstrap, a frontend CSS framework. If your app uses Bootstrap components other than those described above, use these links to help you migrate: `Migrating to v4 | Bootstrap <https://getbootstrap.com/docs/4.0/migration/>`_ and `Migrating to v5 | Bootstrap <https://getbootstrap.com/docs/5.0/migration/>`_.
+* Apps are styled using Bootstrap, a frontend CSS framework. If your app uses Bootstrap components other than those described above, use these links to help you migrate: `Migrating to v4 | Bootstrap <https://getbootstrap.com/docs/4.0/migration/>`_ and `Migrating to v5 | Bootstrap <https://getbootstrap.com/docs/5.2/migration/>`_.
 
 .. _app_migration_older_apps:
 

--- a/tethys_cli/scaffold_templates/app_templates/default/install.yml_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/install.yml_tmpl
@@ -1,5 +1,5 @@
 # This file should be committed to your app code.
-version: 1.0
+version: 1.1
 # This should be greater or equal to your tethys-platform in your environment
 tethys_version: ">=4.0.0"
 # This should match the app - package name in your setup.py

--- a/tethys_cli/scaffold_templates/app_templates/react/install.yml_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/react/install.yml_tmpl
@@ -1,5 +1,7 @@
 # This file should be committed to your app code.
-version: 1.0
+version: 1.1
+# This should be greater or equal to your tethys-platform in your environment
+tethys_version: ">=4.0.0"
 # This should match the app - package name in your setup.py
 name: {{project}}
 


### PR DESCRIPTION
The Pull request addresses #903 by switching to a new Documentation Theme: [Awsome Sphinx Theme](https://sphinxawesome.xyz/). This theme has had regular development since 2020 and works with Sphinx 6.

To preview the new theme, click on the "details" link in the Read the docs check below.

![image](https://user-images.githubusercontent.com/5123221/211113942-184444f1-f7c8-47e3-ac9a-4138729d4dea.png)

Pros:
- Optional "copy" button on code cells (though it will copy everything automatically on that cell after you have pushed the button).
- Collapsable API docs (class/function docs; collapsed by default)
- Theme is maintained and has had recent development
- Supports Sphinx 6

Cons:
- Secondary header with shortcut links isn't there. Added these links to the header for now, but has issues on narrow screens. Could override the header and create our own secondary header for the same functionality?

This PR also includes:
- some updates to address errors that were occurring during the docs build
- updates to the Earth Engine tutorial (fixes #904)
- fixes #910 too