### PR TITLE
Pin SQLAlchemy temporarily to fix failing tests + black update

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   # database dependencies
   - postgresql
   - psycopg2
-  - sqlalchemy
+  - sqlalchemy=1.*  # TODO: what will it take to support sqlalchemy 2.0?
   - geoalchemy2
 
   # plotting dependencies

--- a/tests/intermediate_tests/test_tethys_services/test_backends/test_hydroshare.py
+++ b/tests/intermediate_tests/test_tethys_services/test_backends/test_hydroshare.py
@@ -35,7 +35,6 @@ class HydroShareBackendTest(TestCase):
     """
 
     def setUp(self):
-
         self.backend_module_path = (
             "tethys_services.backends.hydroshare.HydroShareOAuth2"
         )
@@ -149,7 +148,6 @@ class HydroShareBackendTest(TestCase):
         self.assertEqual(UserSocialAuth.objects.count(), 0)
 
     def run_oauth(self, m, user=None):
-
         strategy = DjangoStrategy(DjangoStorage)
         backend = self.Backend_Class(strategy, redirect_uri=self.client_complete_url)
 

--- a/tests/unit_tests/test_tethys_apps/test_base/test_handoff.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_handoff.py
@@ -6,7 +6,6 @@ from tethys_sdk.testing import TethysTestCase
 
 
 def test_function(*args):
-
     if args is not None:
         arg_list = []
         for arg in args:

--- a/tests/unit_tests/test_tethys_apps/test_cli/test_install_commands.py
+++ b/tests/unit_tests/test_tethys_apps/test_cli/test_install_commands.py
@@ -223,7 +223,6 @@ class TestInstallServicesCommands(TestCase):
     @mock.patch("tethys_apps.cli.cli_colors.pretty_output")
     @mock.patch("tethys_apps.cli.install_commands.os")
     def test_run_portal_install_path_none(self, mock_os, _):
-
         mock_os.path.exists.return_value = False
 
         self.assertFalse(install_commands.run_portal_install(None, "foo"))

--- a/tests/unit_tests/test_tethys_apps/test_management/test_commands/test_pre_collectstatic.py
+++ b/tests/unit_tests/test_tethys_apps/test_management/test_commands/test_pre_collectstatic.py
@@ -61,7 +61,6 @@ class ManagementCommandsPreCollectStaticTests(unittest.TestCase):
         mock_shutil_copytree,
         mock_print,
     ):
-
         options = {"link": False}  # Don't create symbolic link (copy instead)
         static_root_dir = "/foo/static/root"
         app_source_dir = "/foo/sources/foo_app"
@@ -153,7 +152,6 @@ class ManagementCommandsPreCollectStaticTests(unittest.TestCase):
         mock_shutil_copytree,
         mock_print,
     ):
-
         options = {"link": False}  # Don't create symbolic link (copy instead)
         static_root_dir = "/foo/static/root"
         app_source_dir = "/foo/sources/foo_app"

--- a/tests/unit_tests/test_tethys_apps/test_models/test_ProxyApp.py
+++ b/tests/unit_tests/test_tethys_apps/test_models/test_ProxyApp.py
@@ -60,7 +60,6 @@ class ProxyAppTests(TethysTestCase):
         self.assertEqual(self.app_name, ret)
 
     def test_create(self):
-
         proxy_app = ProxyApp.objects.create(
             name=self.app_name,
             endpoint=self.endpoint,

--- a/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
+++ b/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
@@ -283,7 +283,6 @@ class TestCliAppSettingsCommand(unittest.TestCase):
     def test_app_settings_create_ps_database_command_with_no_success(
         self, mock_database_settings, mock_exit
     ):
-
         # mock the args
         mock_arg = mock.MagicMock(app="foo")
         mock_arg.name = None

--- a/tests/unit_tests/test_tethys_cli/test_cli_helper.py
+++ b/tests/unit_tests/test_tethys_cli/test_cli_helper.py
@@ -43,7 +43,6 @@ class TestCliHelper(unittest.TestCase):
     @mock.patch("tethys_cli.cli_helpers.subprocess.call")
     @mock.patch("tethys_cli.cli_helpers.set_testing_environment")
     def test_run_process(self, mock_te_call, mock_subprocess_call):
-
         # mock the process
         mock_process = ["test"]
 
@@ -56,7 +55,6 @@ class TestCliHelper(unittest.TestCase):
     @mock.patch("tethys_cli.cli_helpers.subprocess.call")
     @mock.patch("tethys_cli.cli_helpers.set_testing_environment")
     def test_run_process_keyboardinterrupt(self, mock_te_call, mock_subprocess_call):
-
         # mock the process
         mock_process = ["foo"]
 

--- a/tests/unit_tests/test_tethys_cli/test_docker_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_docker_commands.py
@@ -672,7 +672,6 @@ class TestDockerCommands(unittest.TestCase):
 
     @mock.patch("tethys_cli.docker_commands.write_pretty_output")
     def test_cm_start(self, mock_pretty_output):
-
         container = cli_docker_commands.PostGisContainerMetadata()
         msg = container.start()
         self.assertIsNone(msg)

--- a/tests/unit_tests/test_tethys_cli/test_gen_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_gen_commands.py
@@ -897,7 +897,6 @@ class CLIGenCommandsTest(unittest.TestCase):
     @mock.patch("tethys_cli.gen_commands.check_for_existing_file")
     @mock.patch("tethys_cli.gen_commands.os.path.isdir", return_value=True)
     def test_get_destination_path_vendor(self, mock_isdir, mock_check_file):
-
         mock_args = mock.MagicMock(
             type=GEN_PACKAGE_JSON_OPTION,
             directory=False,

--- a/tests/unit_tests/test_tethys_cli/test_install_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_install_commands.py
@@ -544,7 +544,6 @@ class TestInstallServicesCommands(TestCase):
 
     @mock.patch("tethys_cli.cli_colors.pretty_output")
     def test_run_portal_install_path_none(self, _):
-
         self.mock_path.__truediv__().exists.return_value = False
 
         self.assertFalse(install_commands.run_portal_install("foo"))

--- a/tests/unit_tests/test_tethys_cli/test_scaffold_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_scaffold_commands.py
@@ -142,7 +142,6 @@ class TestScaffoldCommands(unittest.TestCase):
         mock_logger,
         mock_copy,
     ):
-
         # mock the input args
         mock_args = mock.MagicMock()
 

--- a/tests/unit_tests/test_tethys_cli/test_services_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_services_commands.py
@@ -879,7 +879,6 @@ class ServicesCommandsTest(unittest.TestCase):
     def test_services_create_dataset_command_IndexError(
         self, mock_service, mock_pretty_output
     ):
-
         mock_args = mock.MagicMock()
         mock_args.connection = "IndexError:9876@IndexError"  # No 'http' or '://'
         mock_args.type = "HydroShare"
@@ -902,7 +901,6 @@ class ServicesCommandsTest(unittest.TestCase):
     def test_services_create_dataset_command_FormatError(
         self, mock_service, mock_pretty_output
     ):
-
         mock_args = mock.MagicMock()
         mock_args.connection = "foo:pass@http:://foo:1234"
         mock_args.public_endpoint = "foo@foo:foo"  # No 'http' or '://'
@@ -925,7 +923,6 @@ class ServicesCommandsTest(unittest.TestCase):
     def test_services_create_dataset_command_IntegrityError(
         self, mock_service, mock_pretty_output
     ):
-
         mock_args = mock.MagicMock()
         mock_args.connection = "foo:pass@http:://foo:1234"
         mock_args.public_endpoint = "http://foo:1234"
@@ -1012,7 +1009,6 @@ class ServicesCommandsTest(unittest.TestCase):
     def test_services_remove_dataset_command_proceed(
         self, mock_service, mock_exit, mock_pretty_output, mock_input
     ):
-
         mock_args = mock.MagicMock()
         mock_service.__str__.return_value = "Dataset"
 
@@ -1040,7 +1036,6 @@ class ServicesCommandsTest(unittest.TestCase):
     def test_services_create_wps_command_IndexError(
         self, mock_service, mock_pretty_output
     ):
-
         mock_args = mock.MagicMock()
         mock_args.connection = "IndexError:9876@IndexError"  # No 'http' or '://'
 
@@ -1062,7 +1057,6 @@ class ServicesCommandsTest(unittest.TestCase):
     def test_services_create_wps_command_IntegrityError(
         self, mock_service, mock_pretty_output
     ):
-
         mock_args = mock.MagicMock()
         mock_args.connection = "foo:pass@http:://foo:1234"
         mock_args.public_endpoint = "http://foo:1234"

--- a/tests/unit_tests/test_tethys_cli/test_site_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_site_commands.py
@@ -20,7 +20,6 @@ class CLISiteCommandsTest(unittest.TestCase):
     @mock.patch("tethys_cli.site_commands.update_site_settings_content")
     @mock.patch("tethys_cli.site_commands.load_apps")
     def test_gen_site_content(self, mock_load_apps, mock_update_settings):
-
         mock_args = mock.MagicMock(
             brand_text="New Title", restore_defaults=False, from_file=False
         )
@@ -131,7 +130,6 @@ class CLISiteCommandsTest(unittest.TestCase):
     @mock.patch("tethys_cli.site_commands.timezone.now")
     @mock.patch("tethys_config.models.Setting.objects.filter")
     def test_update_site_settings_content(self, mock_filter, mock_now):
-
         update_site_settings_content({"brand_text": "New Title"})
         mock_filter.assert_called_with(name="Brand Text")
         call_args = mock_filter(name="Brand Text").update.call_args_list

--- a/tests/unit_tests/test_tethys_compute/test_job_manager.py
+++ b/tests/unit_tests/test_tethys_compute/test_job_manager.py
@@ -103,21 +103,18 @@ class TestJobManager(unittest.TestCase):
         )
 
     def test_JobManager_list_job_with_user(self):
-
         mgr = JobManager(self.app_model)
         ret = mgr.list_jobs(user=self.user_model)
 
         self.assertEqual(ret[0], self.tethysjob)
 
     def test_JobManager_list_job_with_groups(self):
-
         mgr = JobManager(self.app_model)
         ret = mgr.list_jobs(groups=[self.group_model])
 
         self.assertEqual(ret[0], self.tethysjob)
 
     def test_JobManager_list_job_value_error(self):
-
         mgr = JobManager(self.app_model)
         self.assertRaises(
             ValueError, mgr.list_jobs, user=self.user_model, groups=[self.group_model]

--- a/tests/unit_tests/test_tethys_compute/test_models/test_dask/test_DaskJob.py
+++ b/tests/unit_tests/test_tethys_compute/test_models/test_dask/test_DaskJob.py
@@ -214,7 +214,6 @@ class DaskJobTest(TethysTestCase):
     @mock.patch("django.db.models.base.Model.save")
     @mock.patch("tethys_compute.models.dask.dask_scheduler.Client")
     def test_execute_future(self, mock_client, mock_save, mock_ff, mock_isinstance):
-
         mock_client.return_value = mock.MagicMock()
 
         mock_isinstance.side_effect = [True, False]

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_date_picker.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_date_picker.py
@@ -36,14 +36,12 @@ class TestButton(unittest.TestCase):
         self.assertIn(self.min_view_mode, self.gizmo["min_view_mode"])
 
     def test_get_vendor_css(self):
-
         result = gizmo_date_picker.DatePicker.get_vendor_css()
 
         self.assertIn("bootstrap-datepicker3.min.css", result[0])
         self.assertNotIn("bootstrap-datepicker.min.js", result[0])
 
     def test_get_vendor_js(self):
-
         result = gizmo_date_picker.DatePicker.get_vendor_js()
 
         self.assertIn("bootstrap-datepicker.min.js", result[0])

--- a/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_gizmo_options/test_map_view.py
@@ -154,7 +154,6 @@ class TestMapView(unittest.TestCase):
         self.assertDictEqual({"not_data.foo": "bar"}, result.snapping_layer)
 
     def test_MVDraw_invalid_initial_control(self):
-
         # Raise Error if Initial is not in Controls list
         self.assertRaises(ValueError, gizmo_map_view.MVDraw, initial="foo")
 

--- a/tests/unit_tests/test_tethys_gizmos/test_templatetags/test_tethys_gizmos.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_templatetags/test_tethys_gizmos.py
@@ -10,7 +10,6 @@ from importlib import reload
 
 
 class TestGizmo(TethysGizmoOptions):
-
     gizmo_name = "test_gizmo"
 
     def __init__(self, name, *args, **kwargs):

--- a/tests/unit_tests/test_tethys_portal/test_forms.py
+++ b/tests/unit_tests/test_tethys_portal/test_forms.py
@@ -43,7 +43,6 @@ class TethysPortalFormsTests(TestCase):
     # Login Form
 
     def test_LoginForm_no_captcha(self):
-
         login_data = {"username": "admin", "password": "test1231"}
 
         with self.settings(ENABLE_CAPTCHA=False):
@@ -68,7 +67,6 @@ class TethysPortalFormsTests(TestCase):
             self.assertFalse(login_form.is_valid())
 
     def test_LoginForm_simple_captcha(self):
-
         login_data = {
             "username": "admin",
             "password": "test1231",

--- a/tests/unit_tests/test_tethys_services/test_utilities.py
+++ b/tests/unit_tests/test_tethys_services/test_utilities.py
@@ -42,7 +42,6 @@ class TestUtilites(unittest.TestCase):
     @mock.patch("tethys_services.utilities.reverse")
     @mock.patch("tethys_services.utilities.redirect")
     def test_ensure_oauth2(self, mock_redirect, mock_reverse, mock_ls):
-
         mock_user = mock.MagicMock()
         mock_request = mock.MagicMock(user=mock_user, path="path")
         mock_redirect_url = mock.MagicMock()
@@ -61,7 +60,6 @@ class TestUtilites(unittest.TestCase):
     def test_ensure_oauth2_token_expired(
         self, mock_redirect, mock_reverse, mock_ls, mock_logger
     ):
-
         mock_user = mock.MagicMock()
         mock_social = mock.MagicMock()
         mock_user.social_auth.get.return_value = mock_social
@@ -85,7 +83,6 @@ class TestUtilites(unittest.TestCase):
     def test_ensure_oauth2_token_expired_exception(
         self, mock_redirect, mock_reverse, mock_ls, mock_logger
     ):
-
         mock_user = mock.MagicMock()
         mock_social = mock.MagicMock()
         mock_user.social_auth.get.return_value = mock_social
@@ -266,7 +263,6 @@ class TestUtilites(unittest.TestCase):
     @mock.patch("tethys_services.utilities.DsModel.objects")
     @mock.patch("tethys_services.utilities.initialize_engine_object")
     def test_list_dataset_engines(self, mock_initialize_engine_object, mock_dsmodel):
-
         mock_engine = mock.MagicMock()
         mock_endpoint = mock.MagicMock()
         mock_api_key = mock.MagicMock()

--- a/tethys_apps/app_installation.py
+++ b/tethys_apps/app_installation.py
@@ -12,7 +12,7 @@ import os
 
 def find_resource_files(directory, relative_to=None):
     paths = []
-    for (path, _, filenames) in os.walk(directory):
+    for path, _, filenames in os.walk(directory):
         for filename in filenames:
             if relative_to is not None:
                 paths.append(os.path.join(os.path.relpath(path, relative_to), filename))

--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -900,7 +900,6 @@ class TethysAppBase(TethysBase):
             if (len(db_group_name_parts) > 1) and (
                 db_group_name_parts[0] in db_app_names
             ):
-
                 # Delete groups that is no longer required by this app
                 if db_group.name not in app_groups:
                     db_group.delete()
@@ -1742,7 +1741,6 @@ class TethysAppBase(TethysBase):
                 f"Do you want to remove it from the database?"
             )
             while proceed is None:
-
                 response = input("[y/n]")
                 if response.lower() == "y":
                     proceed = True

--- a/tethys_apps/decorators.py
+++ b/tethys_apps/decorators.py
@@ -31,7 +31,6 @@ def login_required(
 
     def decorator(controller_func):
         def wrapper(request, *args, **kwargs):
-
             if not getattr(settings, "ENABLE_OPEN_PORTAL", False):
                 from django.contrib.auth.decorators import login_required as lr
 

--- a/tethys_apps/harvester.py
+++ b/tethys_apps/harvester.py
@@ -181,7 +181,6 @@ class SingletonHarvester:
         loaded_extensions = []
 
         for extension_name, extension_package in extension_packages.items():
-
             try:
                 # Import the "ext" module from the extension package
                 ext_module = __import__(extension_package + ".ext", fromlist=[""])
@@ -252,7 +251,6 @@ class SingletonHarvester:
         valid_app_modules = {}
         loaded_apps = []
         for app_name, app_package in app_packages_list.items():
-
             # Skip these things
             if app_package in [
                 "__init__.py",

--- a/tethys_apps/migrations/0001_initial_30.py
+++ b/tethys_apps/migrations/0001_initial_30.py
@@ -8,7 +8,6 @@ import tethys_services.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/tethys_apps/migrations/0001_initial_40.py
+++ b/tethys_apps/migrations/0001_initial_40.py
@@ -9,7 +9,6 @@ import tethys_services.models
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ("tethys_apps", "0001_initial_30"),
         ("tethys_apps", "0002_auto_20200326_1657"),

--- a/tethys_apps/migrations/0002_auto_20200326_1657.py
+++ b/tethys_apps/migrations/0002_auto_20200326_1657.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_apps", "0001_initial_30"),
     ]

--- a/tethys_apps/migrations/0002_auto_20221130_2305.py
+++ b/tethys_apps/migrations/0002_auto_20221130_2305.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_apps", "0001_initial_40"),
     ]

--- a/tethys_apps/migrations/0003_alter_tethysapp_feedback_emails.py
+++ b/tethys_apps/migrations/0003_alter_tethysapp_feedback_emails.py
@@ -31,7 +31,6 @@ def save_feedback_emails_as_list(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_apps", "0002_auto_20221130_2305"),
     ]

--- a/tethys_apps/migrations/0003_auto_20201209_0432.py
+++ b/tethys_apps/migrations/0003_auto_20201209_0432.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_apps", "0002_auto_20200326_1657"),
     ]

--- a/tethys_apps/migrations/0004_auto_20211221_2300.py
+++ b/tethys_apps/migrations/0004_auto_20211221_2300.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_apps", "0003_auto_20201209_0432"),
     ]

--- a/tethys_apps/migrations/0005_schedulersetting.py
+++ b/tethys_apps/migrations/0005_schedulersetting.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0006_alter_condorpyjob__attributes"),
         ("tethys_apps", "0004_auto_20211221_2300"),

--- a/tethys_apps/migrations/0006_app_order.py
+++ b/tethys_apps/migrations/0006_app_order.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_apps", "0005_schedulersetting"),
     ]

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -440,7 +440,6 @@ class DatasetServiceSetting(TethysAppSetting):
             raise ValidationError("Required.")
 
     def get_value(self, as_public_endpoint=False, as_endpoint=False, as_engine=False):
-
         if not self.dataset_service:
             raise TethysAppSettingNotAssigned(
                 f"Cannot create engine or endpoint for DatasetServiceSetting "
@@ -515,7 +514,6 @@ class SpatialDatasetServiceSetting(TethysAppSetting):
         as_engine=False,
         as_wcs=False,
     ):
-
         if not self.spatial_dataset_service:
             raise TethysAppSettingNotAssigned(
                 f"Cannot create engine or endpoint for SpatialDatasetServiceSetting "

--- a/tethys_cli/docker_commands.py
+++ b/tethys_cli/docker_commands.py
@@ -961,7 +961,6 @@ def log_pull_stream(stream):
                     )
                 )
     else:
-
         TERMINAL_STATUSES = ["Already exists", "Download complete", "Pull complete"]
         PROGRESS_STATUSES = ["Downloading", "Extracting"]
         STATUSES = (

--- a/tethys_cli/gen_commands.py
+++ b/tethys_cli/gen_commands.py
@@ -83,7 +83,6 @@ TETHYS_HOME = get_tethys_home_dir()
 
 
 def add_gen_parser(subparsers):
-
     # Setup generate command
     gen_parser = subparsers.add_parser(
         "gen",
@@ -319,7 +318,6 @@ def gen_portal_yaml(args):
     try:
         tethys_portal_settings.update(args.tethys_portal_settings)
     except AttributeError:
-
         write_info(
             "A Tethys Portal configuration file is being generated. "
             "Please review the file and fill in the appropriate settings."

--- a/tethys_cli/install_commands.py
+++ b/tethys_cli/install_commands.py
@@ -458,7 +458,6 @@ def configure_services_from_file(services, app_name):
                     setting_found = False
 
                     for setting in unlinked_settings:
-
                         if setting.name != setting_name:
                             continue
 
@@ -483,7 +482,6 @@ def configure_services_from_file(services, app_name):
 
 
 def run_portal_install(app_name):
-
     file_path = Path(get_tethys_home_dir()) / "portal_config.yml"
 
     if not file_path.exists():

--- a/tethys_compute/graveyard.py
+++ b/tethys_compute/graveyard.py
@@ -27,7 +27,6 @@ class SubfieldBase(type):
     """
 
     def __new__(cls, name, bases, attrs):
-
         new_class = super().__new__(cls, name, bases, attrs)
         new_class.contribute_to_class = make_contrib(
             new_class, attrs.get("contribute_to_class")

--- a/tethys_compute/migrations/0001_initial_30.py
+++ b/tethys_compute/migrations/0001_initial_30.py
@@ -9,7 +9,6 @@ import tethys_compute.models.dask.dask_field
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/tethys_compute/migrations/0001_initial_40.py
+++ b/tethys_compute/migrations/0001_initial_40.py
@@ -8,7 +8,6 @@ import tethys_compute.models.dask.dask_field
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ("tethys_compute", "0001_initial_30"),
         ("tethys_compute", "0002_tethysjob_groups"),

--- a/tethys_compute/migrations/0002_alter_condorpyjob__remote_input_files.py
+++ b/tethys_compute/migrations/0002_alter_condorpyjob__remote_input_files.py
@@ -30,7 +30,6 @@ def save_remote_files_as_list(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0001_initial_40"),
     ]

--- a/tethys_compute/migrations/0002_tethysjob_groups.py
+++ b/tethys_compute/migrations/0002_tethysjob_groups.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0001_initial_30"),
     ]

--- a/tethys_compute/migrations/0003_tethysjob_status_message.py
+++ b/tethys_compute/migrations/0003_tethysjob_status_message.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0002_tethysjob_groups"),
     ]

--- a/tethys_compute/migrations/0004_auto_20211221_2300.py
+++ b/tethys_compute/migrations/0004_auto_20211221_2300.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0003_tethysjob_status_message"),
     ]

--- a/tethys_compute/migrations/0005_auto_20211221_2313.py
+++ b/tethys_compute/migrations/0005_auto_20211221_2313.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0004_auto_20211221_2300"),
     ]

--- a/tethys_compute/migrations/0006_alter_condorpyjob__attributes.py
+++ b/tethys_compute/migrations/0006_alter_condorpyjob__attributes.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0005_auto_20211221_2313"),
     ]

--- a/tethys_compute/migrations/0007_scheduler_settings.py
+++ b/tethys_compute/migrations/0007_scheduler_settings.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     replaces = []
 
     dependencies = [

--- a/tethys_compute/migrations/0008_alter_tethysjob__status.py
+++ b/tethys_compute/migrations/0008_alter_tethysjob__status.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_compute", "0007_scheduler_settings"),
     ]

--- a/tethys_compute/models/condor/condor_py_job.py
+++ b/tethys_compute/models/condor/condor_py_job.py
@@ -45,7 +45,6 @@ class CondorPyJob(models.Model):
 
     @property
     def condorpy_job(self):
-
         if not hasattr(self, "_condorpy_job"):
             job = Job(
                 name=self.name.replace(" ", "_"),

--- a/tethys_compute/models/dask/dask_field.py
+++ b/tethys_compute/models/dask/dask_field.py
@@ -5,7 +5,6 @@ from distributed.protocol.serialize import serialize, deserialize
 
 
 class DaskSerializedField(models.Field):
-
     description = "A field the automatically serializes and deserializes using Dask serialization."
 
     def get_internal_type(self):

--- a/tethys_compute/models/dask/dask_job.py
+++ b/tethys_compute/models/dask/dask_job.py
@@ -57,7 +57,6 @@ class DaskJob(TethysJob):
 
     @property
     def client(self):
-
         if self.scheduler:
             return self.scheduler.client
         else:

--- a/tethys_config/init.py
+++ b/tethys_config/init.py
@@ -257,7 +257,6 @@ def setting_defaults(category):
             "Register CSS",
             "User Base CSS",
         ]:
-
             category.setting_set.create(
                 name=setting_name, content="", date_modified=now
             )

--- a/tethys_config/migrations/0001_initial_30.py
+++ b/tethys_config/migrations/0001_initial_30.py
@@ -6,7 +6,6 @@ from tethys_config.init import initial_settings, reverse_init
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/tethys_config/migrations/0001_initial_40.py
+++ b/tethys_config/migrations/0001_initial_40.py
@@ -11,7 +11,6 @@ from tethys_config.init import (
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ("tethys_config", "0001_initial_30"),
         ("tethys_config", "0002_auto_20200410_1731"),

--- a/tethys_config/migrations/0002_auto_20200410_1731.py
+++ b/tethys_config/migrations/0002_auto_20200410_1731.py
@@ -5,7 +5,6 @@ from tethys_config.init import custom_settings, reverse_custom
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_config", "0001_initial_30"),
     ]

--- a/tethys_config/migrations/0003_auto_20211220_2307.py
+++ b/tethys_config/migrations/0003_auto_20211220_2307.py
@@ -6,7 +6,6 @@ from tethys_config.init import tethys4_site_settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_config", "0002_auto_20200410_1731"),
     ]

--- a/tethys_config/migrations/0004_auto_20211221_2300.py
+++ b/tethys_config/migrations/0004_auto_20211221_2300.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_config", "0003_auto_20211220_2307"),
     ]

--- a/tethys_config/migrations/0005_add_new_settings.py
+++ b/tethys_config/migrations/0005_add_new_settings.py
@@ -61,7 +61,6 @@ def remove_new_settings(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_config", "0004_auto_20211221_2300"),
     ]

--- a/tethys_portal/forms.py
+++ b/tethys_portal/forms.py
@@ -32,7 +32,6 @@ def get_captcha():
 
 
 class LoginForm(forms.Form):
-
     username = forms.RegexField(
         label="",
         max_length=150,

--- a/tethys_quotas/migrations/0001_initial_30.py
+++ b/tethys_quotas/migrations/0001_initial_30.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/tethys_quotas/migrations/0001_initial_40.py
+++ b/tethys_quotas/migrations/0001_initial_40.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ("tethys_quotas", "0001_initial_30"),
         ("tethys_quotas", "0002_auto_20211221_2300"),

--- a/tethys_quotas/migrations/0002_auto_20211221_2300.py
+++ b/tethys_quotas/migrations/0002_auto_20211221_2300.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_quotas", "0001_initial_30"),
     ]

--- a/tethys_services/migrations/0001_initial_30.py
+++ b/tethys_services/migrations/0001_initial_30.py
@@ -5,7 +5,6 @@ import tethys_services.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/tethys_services/migrations/0001_initial_40.py
+++ b/tethys_services/migrations/0001_initial_40.py
@@ -5,7 +5,6 @@ import tethys_services.models
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ("tethys_services", "0001_initial_30"),
         ("tethys_services", "0002_auto_20211221_2300"),

--- a/tethys_services/migrations/0002_auto_20211221_2300.py
+++ b/tethys_services/migrations/0002_auto_20211221_2300.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("tethys_services", "0001_initial_30"),
     ]

--- a/tethys_services/utilities.py
+++ b/tethys_services/utilities.py
@@ -192,7 +192,6 @@ def get_dataset_engine(name, app_class=None, request=None):
     if app_dataset_services:
         # Search for match
         for app_dataset_service in app_dataset_services:
-
             # If match is found, initiate engine object
             if app_dataset_service.name == name:
                 return initialize_engine_object(
@@ -210,7 +209,6 @@ def get_dataset_engine(name, app_class=None, request=None):
     if site_dataset_services:
         # Search for match
         for site_dataset_service in site_dataset_services:
-
             # If match is found initiate engine object
             if site_dataset_service.name == name:
                 dataset_service_object = initialize_engine_object(
@@ -281,7 +279,6 @@ def get_spatial_dataset_engine(name, app_class=None):
     if app_spatial_dataset_services:
         # Search for match
         for app_spatial_dataset_service in app_spatial_dataset_services:
-
             # If match is found, initiate engine object
             if app_spatial_dataset_service.name == name:
                 return initialize_engine_object(
@@ -298,7 +295,6 @@ def get_spatial_dataset_engine(name, app_class=None):
     if site_spatial_dataset_services:
         # Search for match
         for site_spatial_dataset_service in site_spatial_dataset_services:
-
             # If match is found initiate engine object
             if site_spatial_dataset_service.name == name:
                 spatial_dataset_object = initialize_engine_object(
@@ -413,7 +409,6 @@ def list_wps_service_engines(app_class=None):
     site_wps_services = WpsModel.objects.all()
 
     for site_wps_service in site_wps_services:
-
         # Create OWSLib WebProcessingService engine object
         wps = WebProcessingService(
             site_wps_service.endpoint,
@@ -456,7 +451,6 @@ def get_wps_service_engine(name, app_class=None):
     if app_wps_services:
         # Search for match
         for app_wps_service in app_wps_services:
-
             # If match is found, initiate engine object
             if app_wps_service.name == name:
                 wps = WebProcessingService(
@@ -479,7 +473,6 @@ def get_wps_service_engine(name, app_class=None):
     if site_wps_services:
         # Search for match
         for site_wps_service in site_wps_services:
-
             # If match is found initiate engine object
             if site_wps_service.name == name:
                 # Create OWSLib WebProcessingService engine object


### PR DESCRIPTION
SQLAlchemy released version 2.0 and it appears to be causing some of our tests to fail (see: #918).

This PR:
-  pins SQLAlchemy to 1.*
-  formatting changes from the black 23.1.0 update.