### PR TITLE
Update the docker command to use unidata/thredds-docker:4.6.20

### DIFF
--- a/tests/unit_tests/test_tethys_cli/test_docker_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_docker_commands.py
@@ -560,7 +560,7 @@ class TestDockerCommands(unittest.TestCase):
         mock_port_bindings_prop.return_value = mock_port_bindings
         expected_options = dict(
             name="tethys_thredds",
-            image="unidata/thredds-docker:4.6.20-SNAPSHOT",
+            image="unidata/thredds-docker:4.6.20",
             environment=dict(
                 TDM_PW="CHANGEME!",
                 TDS_HOST="http://localhost",

--- a/tethys_cli/docker_commands.py
+++ b/tethys_cli/docker_commands.py
@@ -541,7 +541,7 @@ class ThreddsContainerMetadata(ContainerMetadata):
     name = "tethys_thredds"
     display_name = "THREDDS"
     image_name = "unidata/thredds-docker"
-    tag = "4.6.20-SNAPSHOT"
+    tag = "4.6.20"
     host_port = 8383
     container_port = 8080
 


### PR DESCRIPTION
The `unidata/thredds-docker:4.6.20-SNAPSHOT` image has been removed now that 4.6.20 is out.

Fixes #929 