### PR TITLE
Fixed migration with apps that use ATCORE.

### DIFF
--- a/tethys_apps/migrations/0002_auto_20230407_2337.py
+++ b/tethys_apps/migrations/0002_auto_20230407_2337.py
@@ -23,8 +23,6 @@ def forward(apps, schema_editor):
             type=cs.type,
         )
         cs_child.save()
-        # cs.delete()
-
 
 def backward(apps, schema_editor):
     """From CustomBaseSetting inheritance to non inheritance"""
@@ -45,11 +43,6 @@ def backward(apps, schema_editor):
             type=cs.type,
         )
         cs_old.save()
-        # cs.delete()
-
-    # for cs_parent in CustomBaseSetting.objects.using(db_alias).all():
-    #     cs_parent.delete()
-
 
 class Migration(migrations.Migration):
     dependencies = [

--- a/tethys_apps/migrations/0002_auto_20230407_2337.py
+++ b/tethys_apps/migrations/0002_auto_20230407_2337.py
@@ -24,6 +24,7 @@ def forward(apps, schema_editor):
         )
         cs_child.save()
 
+
 def backward(apps, schema_editor):
     """From CustomBaseSetting inheritance to non inheritance"""
     # CustomBaseSetting = apps.get_model("tethys_apps", "CustomSettingBase")
@@ -43,6 +44,7 @@ def backward(apps, schema_editor):
             type=cs.type,
         )
         cs_old.save()
+
 
 class Migration(migrations.Migration):
     dependencies = [

--- a/tethys_apps/migrations/0002_auto_20230407_2337.py
+++ b/tethys_apps/migrations/0002_auto_20230407_2337.py
@@ -23,12 +23,12 @@ def forward(apps, schema_editor):
             type=cs.type,
         )
         cs_child.save()
-        cs.delete()
+        # cs.delete()
 
 
 def backward(apps, schema_editor):
     """From CustomBaseSetting inheritance to non inheritance"""
-    CustomBaseSetting = apps.get_model("tethys_apps", "CustomSettingBase")
+    # CustomBaseSetting = apps.get_model("tethys_apps", "CustomSettingBase")
     CustomSetting = apps.get_model("tethys_apps", "customsetting")
     OldCustomSetting = apps.get_model("tethys_apps", "oldcustomsetting")
 
@@ -45,10 +45,10 @@ def backward(apps, schema_editor):
             type=cs.type,
         )
         cs_old.save()
-        cs.delete()
+        # cs.delete()
 
-    for cs_parent in CustomBaseSetting.objects.using(db_alias).all():
-        cs_parent.delete()
+    # for cs_parent in CustomBaseSetting.objects.using(db_alias).all():
+    #     cs_parent.delete()
 
 
 class Migration(migrations.Migration):

--- a/tethys_apps/migrations/0002_auto_20230407_2337.py
+++ b/tethys_apps/migrations/0002_auto_20230407_2337.py
@@ -27,7 +27,6 @@ def forward(apps, schema_editor):
 
 def backward(apps, schema_editor):
     """From CustomBaseSetting inheritance to non inheritance"""
-    # CustomBaseSetting = apps.get_model("tethys_apps", "CustomSettingBase")
     CustomSetting = apps.get_model("tethys_apps", "customsetting")
     OldCustomSetting = apps.get_model("tethys_apps", "oldcustomsetting")
 


### PR DESCRIPTION
Fixes the missing trigger problem:

```
Running migrations:
  Applying tethys_apps.0002_auto_20230407_2337...Traceback (most recent call last):
  File "/home/user/miniconda3/envs/tethys/lib/python3.10/site-packages/django/db/backends/base/base.py", line 242, in _commit
    return self.connection.commit()
psycopg2.errors.InternalError_: could not find trigger 21935
bash```
