### PR TITLE
Add Docker Image Name and Tag Options to Tethys Docker Command

### DIFF
--- a/docs/tutorials/thredds/thredds_primer.rst
+++ b/docs/tutorials/thredds/thredds_primer.rst
@@ -4,7 +4,7 @@
 THREDDS Primer
 **************
 
-**Last Updated:** June 2022
+**Last Updated:** May 2023
 
 In this tutorial you will be introduced to THREDDS using the Docker container that is included with Tethys Platform. This primer is adapted from the `THREDDS Data Server Documentation <https://docs.unidata.ucar.edu/tds/5.0/userguide/index.html>`_. Topics covered include:
 
@@ -120,7 +120,7 @@ The TDS Configuration File (:file:`threddsConfig.xml`) is used to control the be
 4. Navigate to the following locations to see how this metadata is incorporated into the TDS:
 
 * http://localhost:8383/thredds/catalog.html
-* http://localhost:8383/thredds/serverInfo.html
+* http://localhost:8383/thredds/info/serverInfo.html
 
 .. tip::
 

--- a/tests/unit_tests/test_tethys_cli/test_docker_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_docker_commands.py
@@ -588,7 +588,7 @@ class TestDockerCommands(unittest.TestCase):
         mock_port_bindings_prop.return_value = mock_port_bindings
         expected_options = dict(
             name="tethys_thredds",
-            image="unidata/thredds-docker:4.6.20",
+            image="unidata/thredds-docker:5.4",
             environment=dict(
                 TDM_PW="CHANGEME!",
                 TDS_HOST="http://localhost",

--- a/tests/unit_tests/test_tethys_cli/test_docker_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_docker_commands.py
@@ -108,19 +108,17 @@ class TestDockerCommands(unittest.TestCase):
 
     def test_container_metadata_get_containers_with_image_name_arg(self):
         all_containers = cli_docker_commands.ContainerMetadata.get_containers(
-            containers=['thredds'],
-            image_name='some/image'
+            containers=["thredds"], image_name="some/image"
         )
         self.assertEqual(1, len(all_containers))
-        self.assertEqual('some/image', all_containers[0].image_name)
+        self.assertEqual("some/image", all_containers[0].image_name)
 
     def test_container_metadata_get_containers_with_image_tag_arg(self):
         all_containers = cli_docker_commands.ContainerMetadata.get_containers(
-            containers=['thredds'],
-            image_name='1.2.3'
+            containers=["thredds"], image_name="1.2.3"
         )
         self.assertEqual(1, len(all_containers))
-        self.assertEqual('1.2.3', all_containers[0].image_name)
+        self.assertEqual("1.2.3", all_containers[0].image_name)
 
     @mock.patch(
         "tethys_cli.docker_commands.ContainerMetadata.container",

--- a/tethys_cli/docker_commands.py
+++ b/tethys_cli/docker_commands.py
@@ -566,7 +566,7 @@ class ThreddsContainerMetadata(ContainerMetadata):
     name = "tethys_thredds"
     display_name = "THREDDS"
     image_name = "unidata/thredds-docker"
-    tag = "4.6.20"
+    tag = "5.4"
     host_port = 8383
     container_port = 8080
 


### PR DESCRIPTION
This PR fixes #938 by:
- Updating the default thredds image tag to "5.4" (current release)
- Adding the image name and tag options to the docker command to allow users to override the defaults we provide:

```bash
tethys docker init -c thredds -i "tethysplatform/thredds-docker" -t 4.6.20-SNAPSHOT
```