### PR TITLE
Issue943

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@
 Getting Started
 ***************
 
-**Last Updated:** June 2022
+**Last Updated:** May 2023
 
 This section describes how to get Tethys Platform up and running as a fresh installation for app development. If you are upgrading an existing installation then refer to the :ref:`update_tethys` docs. If you are deploying a production instance of Tethys Portal refer to the :ref:`production_installation` docs. If you want to contribute to the Tethys Platform source code itself then refer to the :ref:`developer_installation` docs.
 
@@ -27,27 +27,15 @@ a. To install the ``tethys-platform`` into a new conda environment then run the 
 
 .. tip::
 
-    If conda is taking too long to solve the Tethys environment, try using the `experimental libmamba solver <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_:
+    **Installation Speedup**
 
-    .. code-block:: bash
-    
-        conda update -n base conda
-    
-    .. code-block:: bash
+    If conda is taking too long to solve the Tethys environment, try using the ``libmamba`` solver: :ref:`libmamba_solver`.
 
-        conda install -n base conda-libmamba-solver
+    **Install Development Build**
 
-    .. code-block:: bash
-
-        conda create --experimental-solver libmamba -n tethys -c tethysplatform -c conda-forge tethys-platform
-
-
-.. note::
-
-    To install the latest development build of ``tethys-platform`` add the ``tethys/label/dev`` channel to the list of conda channels::
+    To install the latest development build of ``tethys-platform`` add the ``tethysplatform/label/dev`` channel to the list of conda channels::
 
         conda create -n tethys -c tethysplatform/label/dev -c tethysplatform -c conda-forge tethys-platform
-
 
     Alternatively, to install from source refer to the :ref:`developer_installation` docs.
 
@@ -122,6 +110,7 @@ Related Docs
 
     installation/system_requirements
     tethys_portal/configuration
+    installation/conda
     installation/application
     installation/showcase_apps
     installation/update

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -1,0 +1,83 @@
+.. _conda_and_tethys:
+
+*************************
+Conda and Tethys Platform
+*************************
+
+**Last Updated:** May 2023
+
+This guide provides tips for using `Conda <https://docs.conda.io/en/latest/>`_ effectively in your Tethys environment.
+
+.. _conda_channels:
+
+Conda Channels
+==============
+
+All of the dependencies for Tethys Platform are installed from the ``conda-forge`` channel (see: `Conda-Forge <https://conda-forge.org/>`_). We recommend that you install any additional packages that you need for development from ``conda-forge`` as well to ensure compatibility with the dependencies already installed. To do so, provide the ``-c`` option when installing packages:
+
+.. code-block:: bash
+
+    conda install -c conda-forge <package>
+
+Install from Conda-Forge Automatically
+--------------------------------------
+
+You may wish to configure your conda environment to automatically install packages from the ``conda-forge`` channel as follows:
+
+.. code-block:: bash
+
+    conda config --add channels conda-forge
+
+This command will add the ``conda-forge`` channel to the top of the channel list, making it the highest priority channel for retrieving packages. To learn more see `Conda User Guide - Manage channels <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html>`_.
+
+.. _libmamba_solver:
+
+Using the libmamba Solver
+=========================
+
+The default solver for Conda is notoriously slow, especially in environments that have a lot of dependencies. Tethys development environments can accumulate dependencies as you install more packages and more apps.
+
+The ``libmamba`` solver is a much more efficient solver for Conda and is recommended when you run into issues where your environment is taking too long to solve or fails to solve (see: `A Faster Solver for Conda: Libmamba <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`_). Follow the steps below to use the ``libmamba`` solver with Tethys Platform.
+
+1. Install ``libmamba`` in base environment:
+
+.. code-block:: bash
+
+    conda update -n base conda
+    conda install -n base conda-libmamba-solver
+
+2. Optionally, you may wish to set the ``libmamba`` solver as the default solver:
+
+.. code-block:: bash
+
+    conda config --set solver libmamba
+
+Install Tethys Platform
+-----------------------
+
+To install Tethys Platform using the ``libmamba`` solver, run the command with the ``--solver`` option:
+
+.. code-block:: bash
+
+    conda create --solver libmamba -n tethys -c tethysplatform -c conda-forge tethys-platform
+
+Alternatively, if you set ``libmamba`` to be the default solver in step 2, run the install command as usual and ``libmamba`` will be used automatically:
+
+.. code-block:: bash
+
+    conda create -n tethys -c tethysplatform -c conda-forge tethys-platform
+
+Install Packages
+----------------
+
+You can also use the ``--solver`` option to install new packages in the Tethys environment. Don't forget to activate the Tethys environment first:
+
+.. code-block:: bash
+
+    conda activate tethys
+    conda install --solver libmamba -c conda-forge <package>
+
+App Installation
+----------------
+
+The ``tethys install`` command that is used to install apps, also installs dependencies of the app that are listed in its ``install.yml``. The ``tethys install`` command will use the default solver you have configured. So to install app dependencies using the ``libmamba`` solver, set the default solver to be ``libmamba`` (see above) and then run the ``tethys install`` command as usual.

--- a/docs/tutorials/google_earth_engine/part_2/file_upload.rst
+++ b/docs/tutorials/google_earth_engine/part_2/file_upload.rst
@@ -401,7 +401,7 @@ In this step you will add the logic to validate that the file contained in the Z
 
     conda install -c conda-forge pyshp
 
-2. Add ``pyshp`` as a new dependency in the ``install.yaml``:
+2. Add ``pyshp`` as a new dependency in the ``install.yml``:
 
 .. code-block:: yaml
     :emphasize-lines: 16

--- a/environment.yml
+++ b/environment.yml
@@ -89,3 +89,4 @@ dependencies:
 
   # Conda to allow Python API access to Conda Install
   - conda
+  - conda-libmamba-solver


### PR DESCRIPTION
Fixes #943 by installing the `conda-libmamba-solver` package with other dependencies. The package needs to be installed for the Python API to be able to use it.

Added new page to the docs with tips for using conda with Tethys, including an expanded and updated explanation of `libmamba`.