### PR TITLE
Fix for Feature Selection Hang on MapView Gizmo

### DIFF
--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -1252,9 +1252,10 @@ var MAP_LAYOUT = (function() {
           // Create the overlay
           m_props_popup_overlay = new ol.Overlay({
             element: m_$props_popup_container.get(0),
-            autoPan: true,
-            autoPanAnimation: {
-                duration: 250
+            autoPan: {
+                animation: {
+                    duration: 250
+                }
             }
           });
 

--- a/tethys_sdk/static/tethys_sdk/js/utilities.js
+++ b/tethys_sdk/static/tethys_sdk/js/utilities.js
@@ -39,8 +39,8 @@ function compute_center(features) {
         sum_y = 0,
         num_coordinates = 0;
 
-    for (var i = 0; i < features.length; i++) {
-        let feature = features[i], geometry;
+    for (var f = 0; f < features.length; f++) {
+        let feature = features[f], geometry;
 
         // If feature is a ol.Feature, we need to get the geometry
         if (feature instanceof ol.Feature) {
@@ -79,6 +79,7 @@ function compute_center(features) {
                 let line_string = line_strings[i];
 
                 for (var j = 0; j < line_string.length; j++) {
+                    console.log(i, j)
                     let coordinate = line_string[j];
                     sum_x += coordinate[0];
                     sum_y += coordinate[1];


### PR DESCRIPTION
- The WMS layer feature selection feature would hang when more than 2 layers were involved in the selection. This was due to nested loops using the same looping variable (`i`). This PR fixes the issue by renaming the variable in the outer loop.
- This PR also updates deprecated `autoPan` properties of `ol.Overlays`.