### PR TITLE
Hotfix - remove args and kwargs from default Bokeh controller

### DIFF
--- a/tethys_apps/base/bokeh_handler.py
+++ b/tethys_apps/base/bokeh_handler.py
@@ -54,7 +54,7 @@ def _get_bokeh_controller(template=None, app_package=None):
     )
     extends_template = f"{app_package}/base.html" if app_package else None
 
-    def bokeh_controller(request, *args, **kwargs):
+    def bokeh_controller(request):
         script = server_document(request.get_full_path())
         context = {"script": script}
         if extends_template:


### PR DESCRIPTION
I'm not sure why I added these, but I can't think of how they would ever be used and it turns out that it messes up the URL registration and requires that `args` and `kwargs` be passed in as URL variables.