### PR TITLE
Replace deprecated Django Axes setting

### DIFF
--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -462,7 +462,7 @@ for setting, value in MFA_CONFIG.items():
 AXES_ENABLED = not DEBUG
 AXES_FAILURE_LIMIT = 3
 AXES_COOLOFF_TIME = dt.timedelta(hours=0.5)
-AXES_LOCKOUT_PARAMETERS = ['username']
+AXES_LOCKOUT_PARAMETERS = ["username"]
 AXES_ENABLE_ADMIN = True
 AXES_LOCKOUT_TEMPLATE = "tethys_portal/accounts/lockout.html"
 AXES_VERBOSE = True

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -462,7 +462,7 @@ for setting, value in MFA_CONFIG.items():
 AXES_ENABLED = not DEBUG
 AXES_FAILURE_LIMIT = 3
 AXES_COOLOFF_TIME = dt.timedelta(hours=0.5)
-AXES_ONLY_USER_FAILURES = True
+AXES_LOCKOUT_PARAMETERS = ['username']
 AXES_ENABLE_ADMIN = True
 AXES_LOCKOUT_TEMPLATE = "tethys_portal/accounts/lockout.html"
 AXES_VERBOSE = True


### PR DESCRIPTION
Replaced deprecated setting `AXES_ONLY_USER_FAILURES` with recommended setting `AXES_LOCKOUT_PARAMETERS = ['username']`.