### PR TITLE
bokehjsdir() has been deprecated in favor of bokehjs_path()

### DIFF
--- a/tests/unit_tests/test_tethys_portal/test_settings.py
+++ b/tests/unit_tests/test_tethys_portal/test_settings.py
@@ -260,3 +260,12 @@ class TestSettings(TestCase):
         self.assertIn(
             "bokeh_django.static.BokehExtensionFinder", settings.STATICFILES_FINDERS
         )
+
+    @mock.patch("tethys_portal.optional_dependencies.optional_import")
+    def test_bokehjsdir_compatibility(self, mock_oi):
+        mock_bokeh_settings = mock.MagicMock()
+        mock_oi.return_value = mock_bokeh_settings
+        mock_bokeh_settings.bokehjs_path.side_effect = AttributeError()
+        reload(settings)
+        mock_bokeh_settings.bokehjs_path.assert_called_once()
+        mock_bokeh_settings.bokehjsdir.assert_called_once()

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -37,8 +37,8 @@ from tethys_cli.gen_commands import generate_secret_key
 from tethys_portal.optional_dependencies import optional_import, has_module
 
 # optional imports
-bokeh_settings, bokehjsdir = optional_import(
-    ("settings", "bokehjsdir"), from_module="bokeh.settings"
+bokeh_settings, bokehjs_path = optional_import(
+    ("settings", "bokehjs_path"), from_module="bokeh.settings"
 )
 bokeh_django = optional_import("bokeh_django")
 
@@ -407,8 +407,8 @@ STATIC_URL = portal_config_settings.pop("STATIC_URL", "/static/")
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
-if has_module(bokehjsdir):
-    STATICFILES_DIRS.append(bokehjsdir())
+if has_module(bokehjs_path):
+    STATICFILES_DIRS.append(bokehjs_path())
 
 STATICFILES_USE_NPM = TETHYS_PORTAL_CONFIG.pop("STATICFILES_USE_NPM", False)
 if STATICFILES_USE_NPM:

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -37,9 +37,7 @@ from tethys_cli.gen_commands import generate_secret_key
 from tethys_portal.optional_dependencies import optional_import, has_module
 
 # optional imports
-bokeh_settings, bokehjs_path = optional_import(
-    ("settings", "bokehjs_path"), from_module="bokeh.settings"
-)
+bokeh_settings = optional_import("settings", from_module="bokeh.settings")
 bokeh_django = optional_import("bokeh_django")
 
 log = logging.getLogger(__name__)
@@ -407,8 +405,13 @@ STATIC_URL = portal_config_settings.pop("STATIC_URL", "/static/")
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
-if has_module(bokehjs_path):
-    STATICFILES_DIRS.append(bokehjs_path())
+if has_module(bokeh_settings):
+    try:
+        bokeh_js_dir = bokeh_settings.bokehjs_path()
+    except AttributeError:
+        # support bokeh versions < 3.4
+        bokeh_js_dir = bokeh_settings.bokehjsdir()
+    STATICFILES_DIRS.append(bokeh_js_dir)
 
 STATICFILES_USE_NPM = TETHYS_PORTAL_CONFIG.pop("STATICFILES_USE_NPM", False)
 if STATICFILES_USE_NPM:


### PR DESCRIPTION
bokehjsdir() has been deprecated in favor of bokehjs_path()

Using bokehjsdir() now causes an error when running docker build

https://github.com/bokeh/bokeh/blob/69c084e692d79632c97ea1cfc5ceb10d0217e6f4/src/bokeh/settings.py#L779