### PR TITLE
Avoid using the app package as a hardcoded string

### DIFF
--- a/docs/installation/production/docker/tethys_docker_reference.rst
+++ b/docs/installation/production/docker/tethys_docker_reference.rst
@@ -100,6 +100,7 @@ Use these build arguments with the ``build`` command to customize how the image 
 +---------------------------+------------------------------------------------------------------------------------------+
 | MICRO_TETHYS              | Set to True to use `micro-tethys` environment. Defaults to False.                        |
 +---------------------------+------------------------------------------------------------------------------------------+
+
 Important Paths
 ---------------
 
@@ -166,6 +167,7 @@ These environment variables are used to configure the database and database user
 +--------------------------+-------------------------------------------------------------------------------------------------------------------------------------+
 | SKIP_DB_SETUP            | Set to True to skip database creation, useful for existing databases configured for Tethys. Defaults to False.                      |
 +--------------------------+-------------------------------------------------------------------------------------------------------------------------------------+
+
 Tethys Portal Admin User
 ------------------------
 

--- a/docs/tethys_sdk/app_class.rst
+++ b/docs/tethys_sdk/app_class.rst
@@ -104,4 +104,8 @@ Class Methods
 
 .. automethod:: tethys_apps.base.TethysAppBase.create_persistent_store
 
-.. automethod:: tethys_apps.base.TethysAppBase.drop_persistent_store
+.. automethod:: tethys_apps.base.app_base.TethysAppBase.render
+
+.. automethod:: tethys_apps.base.app_base.TethysBase.redirect
+
+.. automethod:: tethys_apps.base.app_base.TethysBase.reverse

--- a/docs/tethys_sdk/app_class.rst
+++ b/docs/tethys_sdk/app_class.rst
@@ -109,3 +109,5 @@ Class Methods
 .. automethod:: tethys_apps.base.app_base.TethysBase.redirect
 
 .. automethod:: tethys_apps.base.app_base.TethysBase.reverse
+
+.. automethod:: tethys_apps.base.app_base.TethysBase.render_to_string

--- a/docs/tethys_sdk/extensions/custom_gizmos.rst
+++ b/docs/tethys_sdk/extensions/custom_gizmos.rst
@@ -237,6 +237,7 @@ Import and create a new instance of the gizmo in your controller:
 ::
 
     from tethysext.my_first_extension.gizmos import CustomSelectInput
+    from .app import App
 
 
     def my_app_controller(request):
@@ -253,13 +254,13 @@ Import and create a new instance of the gizmo in your controller:
         context = {
             'my_select': my_select,
         }
-        return render(request, 'my_first_app/a_template.html', context)
+        return App.render(request, 'a_template.html', context)
 
 Then use the gizmo as usual in ``a_template.html``:
 
 .. code-block::django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo my_select %}
 

--- a/docs/tethys_sdk/extensions/models.rst
+++ b/docs/tethys_sdk/extensions/models.rst
@@ -47,7 +47,7 @@ To use the extension models to query the database, import them from the extensio
 
 ::
 
-    from tethysapp.my_first_app.app import MyFirstApp as app
+    from tethysapp.my_first_app.app import App
     from tethysext.my_first_extension.models import Project
 
 
@@ -63,4 +63,4 @@ To use the extension models to query the database, import them from the extensio
             'project': project
         }
 
-        return render(request, 'my_first_app/some_template.html', context)
+        return App.render(request, 'some_template.html', context)

--- a/docs/tethys_sdk/extensions/templates_and_static_files.rst
+++ b/docs/tethys_sdk/extensions/templates_and_static_files.rst
@@ -4,20 +4,22 @@ Templates and Static Files
 
 **Last Updated:** February 22, 2018
 
-Templates and static files in extensions can be used in other apps.  The advantage to using templates and static files from extensions in your apps is that when you update the template or static file in the extension, all the apps that use them will automatically be updated. Just as with apps, store the templates in the ``templates`` directory and store the static files (css, js, images, etc.) in the ``public`` directory. Then reference the template or static file in your app's controllers and templates using the namespaced path.
+Templates and static files in extensions can be used in other apps.  The advantage to using templates and static files from extensions in your apps is that when you update the template or static file in the extension, all the apps that use them will automatically be updated. Just as with apps, store the templates in the ``templates`` directory and store the static files (css, js, images, etc.) in the ``public`` directory. When using an extension template in your app's controllers, import the extension and use it to render the templates.
 
 For example, to use an extension template in one of your app's controllers:
 
 ::
+
+    from tethysext.my_first_extension import Extension as MyFirstExtension
 
     def my_controller(request):
         """
         A controller in my app, not the extension.
         """
         ...
-        return render(request, 'my_first_extension/a_template.html', context)
+        return MyFirstExtension.render(request, 'a_template.html', context)
 
-You can reference static files in your app's templates using the ``static`` tag, just as you would any other static resource:
+You can reference static files in your app's templates using the ``static`` tag, just as you would any other static resource. However, rather than using the ``public`` filter to namespace the file path for you, you will need to the use the namespaced path (i.e. include the extension package name):
 
 .. code-block:: html
 

--- a/docs/tethys_sdk/gizmos.rst
+++ b/docs/tethys_sdk/gizmos.rst
@@ -32,6 +32,7 @@ In this case, we import ``DatePicker`` and initialize a new object called ``date
 ::
 
     from tethys_sdk.gizmos import DatePicker
+    from .app import App
 
     def gizmo_controller(request):
         """
@@ -50,18 +51,18 @@ In this case, we import ``DatePicker`` and initialize a new object called ``date
 
         context = {'date_picker': date_picker}
 
-        return render(request, 'my_first_app/template.html', context)
+        return App.render(request, 'template.html', context)
 
 The :ref:`gizmo_options` section provides detailed descriptions of each Gizmo option object, valid parameters, and examples of how to use them.
 
 2. Load Gizmo Library in Template
 ---------------------------------
 
-Now near the top of the template where the Gizmo will be inserted, load the ``tethys_gizmos`` library using the `Django load tag <https://docs.djangoproject.com/en/1.9/ref/templates/builtins/#load>`_. This only needs to be done once per template:
+Now near the top of the template where the Gizmo will be inserted, load the ``tethys`` library using the `Django load tag <https://docs.djangoproject.com/en/1.9/ref/templates/builtins/#load>`_. This only needs to be done once per template:
 
 ::
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
 
 4. Insert the Gizmo
@@ -96,7 +97,11 @@ The Gizmo Showcase App provides live demos and code examples of every Tethys Giz
 API Documentation
 =================
 
-This section contains a brief explanation of the template tags that power Gizmos. These are provided by the ``tethys_gizmos`` library that you load at the top of templates that use Gizmos.
+This section contains a brief explanation of the template tags that power Gizmos. These are provided by the ``tethys`` library that you load at the top of templates that use Gizmos.
+
+.. code-block:: html+django
+
+    {% load tethys%}
 
 **gizmo**
 ---------
@@ -150,7 +155,7 @@ Tells the ``gizmo_dependencies`` to load in the dependencies for the gizmo. This
 **gizmo_dependencies**
 ----------------------
 
-Inserts of the CSS and JavaScript dependencies at the location of the tag for all gizmos loaded in the template with the **gizmo** tag. This tag must appear after all occurrences of the ``gizmo`` tag. In Tethys Apps, these depenencies are imported for you, so this tag is not required. For external Django projects that use the tethys_gizmos Django app, this tag is required.
+Inserts of the CSS and JavaScript dependencies at the location of the tag for all gizmos loaded in the template with the ``gizmo`` tag. This tag must appear after all occurrences of the ``gizmo`` tag. In Tethys Apps, these dependencies are imported for you, so this tag is not required. For external Django projects that use the tethys_gizmos Django app, this tag is required.
 
 *Parameters*:
 

--- a/docs/tethys_sdk/gizmos/bokeh_view.rst
+++ b/docs/tethys_sdk/gizmos/bokeh_view.rst
@@ -55,6 +55,7 @@ Three elements are required:
     from tethys_sdk.gizmos import BokehView
     from tethys_sdk.routing import controller
     from bokeh.plotting import figure
+    from .app import App
         
     @controller(name="bokeh_ajax", url="app-name/bokeh")
     def bokeh_ajax(request):
@@ -67,13 +68,13 @@ Three elements are required:
 
         context = {'bokeh_view_input': my_bokeh_view}
 
-        return render(request, 'app_name/bokeh_ajax.html', context)
+        return App.render(request, 'bokeh_ajax.html', context)
 
 2) A template for with the tethys gizmo (e.g. bokeh_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo bokeh_view_input %}
 

--- a/docs/tethys_sdk/gizmos/cesium_map_view.rst
+++ b/docs/tethys_sdk/gizmos/cesium_map_view.rst
@@ -71,13 +71,13 @@ Three elements are required:
 
             context = { "cesium_map_view": cesium_map_view }
 
-            return render(request, "dam_break_map_ajax/map_ajax.html", context)
+            return App.render(request, "map_ajax.html", context)
 
 2) A template for with the tethys gizmo (e.g. map_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo cesium_map_view %}
 

--- a/docs/tethys_sdk/gizmos/datatable_view.rst
+++ b/docs/tethys_sdk/gizmos/datatable_view.rst
@@ -33,6 +33,7 @@ Three elements are required:
 .. code-block:: python
 
     import json
+    from .app import App
 
     @controller
     def datatable_ajax(request):
@@ -57,13 +58,13 @@ Three elements are required:
 
         context = {"datatable_options": datatable_default}
 
-        return render(request, "app_name/datatable_ajax.html", context)
+        return App.render(request, "datatable_ajax.html", context)
 
 2) A template for with the tethys gizmo (e.g. datatable_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo datatable_options %}
 

--- a/docs/tethys_sdk/gizmos/map_view.rst
+++ b/docs/tethys_sdk/gizmos/map_view.rst
@@ -288,13 +288,13 @@ Three elements are required:
         
             context = { "map_options": map_options }
             
-            return render(request, "dam_break_map_ajax/map_ajax.html", context)
+            return App.render(request, "map_ajax.html", context)
 
 2) A template for with the tethys gizmo (e.g. map_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo map_options %}
 

--- a/docs/tethys_sdk/gizmos/plot_view.rst
+++ b/docs/tethys_sdk/gizmos/plot_view.rst
@@ -81,6 +81,8 @@ Three elements are required:
 
 .. code-block:: python
 
+    from .app import App
+
     @controller(
         url="dam-break/map/hydrograph",
     )
@@ -96,13 +98,13 @@ Three elements are required:
 
         context = {"flood_plot": flood_plot}
 
-        return render(request, "dam_break/hydrograph_ajax.html", context)
+        return App.render(request, "hydrograph_ajax.html", context)
 
 2) A template for with the tethys gizmo (e.g. hydrograph_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo flood_plot %}
 

--- a/docs/tethys_sdk/gizmos/plotly_view.rst
+++ b/docs/tethys_sdk/gizmos/plotly_view.rst
@@ -56,6 +56,7 @@ Three elements are required:
     import plotly.graph_objs as go
     from tethys_sdk.gizmos import PlotlyView
     from tethys_sdk.routing import controller
+    from .app import App
 
         
     @controller(name='plotly_ajax', url='app-name/plotly')
@@ -71,13 +72,13 @@ Three elements are required:
 
         context = {'plotly_view_input': my_plotly_view}
 
-        return render(request, 'app_name/plotly_ajax.html', context)
+        return App.render(request, 'plotly_ajax.html', context)
 
 2) A template for with the tethys gizmo (e.g. plotly_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo plotly_view_input %}
 

--- a/docs/tethys_sdk/gizmos/select_input.rst
+++ b/docs/tethys_sdk/gizmos/select_input.rst
@@ -34,6 +34,7 @@ Three elements are required:
 .. code-block:: python
 
     from tethys_sdk.gizmos import SelectInput
+    from .app import App
         
     @controller(
         url="app_name/select",
@@ -50,13 +51,13 @@ Three elements are required:
 
         context = {"select_input2": select_input2}
 
-        return render(request, "app_name/select_input_ajax.html", context)
+        return App.render(request, "select_input_ajax.html", context)
 
 2) A template for with the tethys gizmo (e.g. select_input_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo select_input2 %}
 

--- a/docs/tethys_sdk/gizmos/toggle_switch.rst
+++ b/docs/tethys_sdk/gizmos/toggle_switch.rst
@@ -33,6 +33,7 @@ Three elements are required:
 .. code-block:: python
 
     import json
+    from .app import App
 
     @controller
     def toggle_ajax(request):
@@ -45,13 +46,13 @@ Three elements are required:
 
         context = {"toggle_switch": toggle_switch}
 
-        return render(request, "app_name/toggle_ajax.html", context)
+        return App.render(request, "toggle_ajax.html", context)
 
 2) A template for with the tethys gizmo (e.g. toggle_ajax.html)
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% gizmo toggle_switch %}
 

--- a/docs/tethys_sdk/jobs.rst
+++ b/docs/tethys_sdk/jobs.rst
@@ -58,13 +58,13 @@ To use the Job Manager in your app you first need to import the TethysAppBase su
 
 ::
 
-    from app import MyFirstApp as app
+    from .app import App
 
 You can then get the job manager by calling the method ``get_job_manager`` on the app.
 
 ::
 
-    job_manager = app.get_job_manager()
+    job_manager = App.get_job_manager()
 
 You can now use the job manager to create a new job, or retrieve an existing job or jobs.
 
@@ -197,7 +197,7 @@ The Jobs Table Gizmo facilitates job management through the web interface and is
 
 ::
 
-    job_manager = app.get_job_manager()
+    job_manager = App.get_job_manager()
 
     jobs = job_manager.list_jobs(request.user)
 
@@ -209,7 +209,7 @@ The Jobs Table Gizmo facilitates job management through the web interface and is
         striped=False,
         bordered=False,
         condensed=False,
-        results_url='app_name:results_controller',
+        results_url=f'{App.package}:results_controller',
     )
 
 .. seealso::
@@ -238,7 +238,7 @@ This URL can be retrieved from the job manager with the ``get_job_status_callbac
 
 ::
 
-    job_manager = app.get_job_manager()
+    job_manager = App.get_job_manager()
     callback_url = job_manager.get_job_status_callback_url(request, job_id)
 
 API Documentation

--- a/docs/tethys_sdk/jobs/condor_job_type.rst
+++ b/docs/tethys_sdk/jobs/condor_job_type.rst
@@ -31,11 +31,14 @@ To create a job call the ``create_job`` method on the job manager. The required 
 
 .. code-block::
 
-    from tethysapp.my_first_app.app import MyFirstApp as app
-    from tethys_sdk.workspaces import app_workspace
+    from tethys_sdk.routing import controller
+    from .app import App
 
+    job_manager = App.get_job_manager()
 
-    @app_workspace
+    @controller(
+        app_workspace=True,
+    )
     def some_controller(request, app_workspace):
         # create a new job from the job manager
         job = job_manager.create_job(

--- a/docs/tethys_sdk/jobs/condor_workflow_type.rst
+++ b/docs/tethys_sdk/jobs/condor_workflow_type.rst
@@ -32,12 +32,16 @@ Creating a Condor Workflow job involves 3 steps:
 
 ::
 
-    from tethysapp.my_first_app.app import MyFirstApp as app
     from tethys_sdk.jobs import CondorWorkflowJobNode
-    from tethys_sdk.workspaces import app_workspace
+    from tethys_sdk.routing import controller
+    from .app import App
+
+    job_manager = App.get_job_manager()
 
 
-    @app_workspace
+    @controller(
+        app_workspace=True,
+    )
     def some_controller(request, app_workspace):
         workflow = job_manager.create_job(
             name='MyWorkflowABC',

--- a/docs/tethys_sdk/jobs/dask_job_type.rst
+++ b/docs/tethys_sdk/jobs/dask_job_type.rst
@@ -50,14 +50,14 @@ The example below shows the pattern used to create Dask Jobs using the ``dask.de
 
 ::
 
-    from tethysapp.my_first_app.app import MyFirstApp as app
     from tethysapp.my_first_app.job_functions import delayed_job
+    from .app import App
 
     # 1. Get a Dask Scheduler
-    scheduler = app.get_scheduler(name='dask_primary')
+    scheduler = App.get_scheduler(name='dask_primary')
 
     # 2. Get job manager for this app
-    job_manager = app.get_job_manager()
+    job_manager = App.get_job_manager()
 
     # 3. Call function that builds the ``dask.delayed`` job, returning one ``dask.Delayed`` object
     delayed = delayed_job()
@@ -105,14 +105,14 @@ The example below shows the pattern used to create Dask Jobs using the ``dask.di
 
 ::
 
-    from tethysapp.my_first_app.app import MyFirstApp as app
     from tethysapp.my_first_app.job_functions import distributed_job, convert_to_dollar_sign
+    from .app import App
 
     # 1. Get a Dask Scheduler
-    scheduler = app.get_scheduler(name='dask_primary')
+    scheduler = App.get_scheduler(name='dask_primary')
 
     # 2. Get job manager for this app
-    job_manager = app.get_job_manager()
+    job_manager = App.get_job_manager()
 
     # 3. Get the dask.distributed.Client instance from the scheduler
     try:
@@ -166,14 +166,14 @@ The following example shows how to create multiple Dask Jobs to tracke a multi-l
 
 ::
 
-    from tethysapp.my_first_app.app import MyFirstApp as app
     from tethysapp.my_first_app.job_functions import muliple_leaf_job
+    from .app import App
 
     # 1. Get a Dask Scheduler
-    scheduler = app.get_scheduler(name='dask_primary')
+    scheduler = App.get_scheduler(name='dask_primary')
 
     # 2. Get job manager for this app
-    job_manager = app.get_job_manager()
+    job_manager = App.get_job_manager()
 
     # 3. Get the dask.distributed.Client instance from the scheduler
     try:
@@ -182,7 +182,7 @@ The following example shows how to create multiple Dask Jobs to tracke a multi-l
         return redirect(reverse('dask_tutorial:error_message'))
 
     # 4. Call function that builds the dask.distributed job, returning multiple dask.distributed.Future objects
-    futures = muliple_leaf_job(client)
+    futures = multiple_leaf_job(client)
 
     # 5. Iterate through the list of futures, creating a new DaskJob for each one and calling DaskJob.execute on it.
     i = random.randint(1, 10000)

--- a/docs/tethys_sdk/static_resources.rst
+++ b/docs/tethys_sdk/static_resources.rst
@@ -136,15 +136,17 @@ Finally, include the following context variables in the controller for the page:
 
 .. code-block:: python
 
-    from django.shortcuts import reverse, render
+    from tethys_sdk.routing import controller
+    from .app import App
 
+    @controller
     def some_controller(request):
         context = {
             'nav_title': 'My Title',
             'nav_subtitle': 'My Subtitle',
-            'back_url': reverse('my_first_app:some_url')
+            'back_url': App.reverse('some_url')
         }
-        return render(request, 'my_first_app/some_template.html', context)
+        return App.render(request, 'some_template.html', context)
 
 nav_tabs.css
 ------------

--- a/docs/tethys_sdk/templating.rst
+++ b/docs/tethys_sdk/templating.rst
@@ -91,10 +91,18 @@ Examples:
 
     See the `Django Tag Reference <https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#ref-templates-builtins-tags>`_ for a complete list of tags that Django provides.
 
-Tethys Tags
-+++++++++++
+Tethys Filters
+++++++++++++++
 
-In addition to Django's library of template tags, Tethys also defines a few additional template tags that can be used in your templates.
+In addition to Django's library of template filters, Tethys also defines several additional template filters that can be used in your templates.
+
+.. note::
+
+    To load the Tethys template filters you will need to add a include ``tethys`` in the ``load`` tag:
+
+    .. code-block:: html+django
+
+        {% load tethys %}
 
 .. automodule:: tethys_apps.templatetags.tags
    :members: url, public

--- a/docs/tethys_sdk/templating.rst
+++ b/docs/tethys_sdk/templating.rst
@@ -96,6 +96,9 @@ Tethys Tags
 
 In addition to Django's library of template tags, Tethys also defines a few additional template tags that can be used in your templates.
 
+.. automodule:: tethys_apps.templatetags.tags
+   :members: url, public
+
 .. automodule:: tethys_apps.templatetags.humanize
    :members: human_duration
 
@@ -357,7 +360,7 @@ Use this block to add custom buttons to the app header. Use an anchor/link tag f
 
     {% block header_buttons %}
       <div class="header-button glyphicon-button">
-        <a href="{% url my_first_app:another_page %}"><i class="bi bi-boombox"></i></a>
+        <a href="{% url tethys_app|url:'another_page' %}"><i class="bi bi-boombox"></i></a>
       </div>
     {% endblock %}
 

--- a/docs/tethys_sdk/tethys_services/dataset_services.rst
+++ b/docs/tethys_sdk/tethys_services/dataset_services.rst
@@ -135,9 +135,9 @@ Call the ``get_dataset_service()`` method of the app class to get a ``DatasetEng
 
 .. code-block:: python
 
-    from my_first_app.app import MyFirstApp as app
+    from .app import App
 
-    ckan_engine = app.get_dataset_service('primary_ckan', as_engine=True)
+    ckan_engine = App.get_dataset_service('primary_ckan', as_engine=True)
 
 You can also create a ``DatasetEngine`` object directly. This can be useful if you want to vary the credentials for dataset access frequently (e.g.: using user specific credentials):
 
@@ -159,9 +159,9 @@ After you have a ``DatasetEngine``, simply call the desired method on it. All ``
 
 .. code-block:: python
 
-    from my_first_app.app import MyFirstApp as app
+    from .app import MyFirstApp as App
 
-    dataset_engine = app.get_dataset_service('primary_ckan', as_engine=True)
+    dataset_engine = App.get_dataset_service('primary_ckan', as_engine=True)
 
     result = dataset_engine.list_datasets()
 
@@ -183,18 +183,18 @@ Use the dataset service engines references above for descriptions of the methods
     .. code-block:: python
 
         from tethys_sdk.services import get_dataset_engine, ensure_oauth2
-        from .app import MyFirstApp as app
+        from .app import App
 
         @ensure_oauth2('hydroshare')
         def my_controller(request):
             """
             This is an example controller that uses the HydroShare API.
             """
-            engine = app.get_dataset_service('hydroshare', request=request)
+            engine = App.get_dataset_service('hydroshare', request=request)
 
             response = engine.list_datasets()
 
             context = {}
 
-            return render(request, 'my_first_app/home.html', context)
+            return App.render(request, 'home.html', context)
 

--- a/docs/tethys_sdk/tethys_services/spatial_dataset_service/geoserver_reference.rst
+++ b/docs/tethys_sdk/tethys_services/spatial_dataset_service/geoserver_reference.rst
@@ -45,10 +45,10 @@ Upload Shapefile
 
 ::
 
-    from my_first_app.app import MyFirstApp as app
+    from .app import App
 
     # First get an engine
-    engine = app.get_spatial_dataset_service('primary_geoserver', as_engine=True)
+    engine = App.get_spatial_dataset_service('primary_geoserver', as_engine=True)
 
     # Create a workspace named after our app
     engine.create_workspace(workspace_id='my_app', uri='http://www.example.com/apps/my-app')

--- a/docs/tethys_sdk/tethys_services/spatial_dataset_service/thredds_reference.rst
+++ b/docs/tethys_sdk/tethys_services/spatial_dataset_service/thredds_reference.rst
@@ -34,10 +34,10 @@ This example is adapted from the `Siphon NCSS Time Series Example <https://unida
 
     import datetime
     from netCDF4 import num2date
-    from my_first_app.app import MyFirstApp as app
+    from .app import App
 
     # This returns a siphon.catalog.TDSCatalog bound to the THREDDS service
-    catalog = app.get_spatial_dataset_service('primary_thredds', as_engine=True)
+    catalog = App.get_spatial_dataset_service('primary_thredds', as_engine=True)
 
     # Retrieve a dataset
     datasets = catalog.datasets

--- a/docs/tethys_sdk/tethys_services/spatial_dataset_services.rst
+++ b/docs/tethys_sdk/tethys_services/spatial_dataset_services.rst
@@ -139,9 +139,9 @@ Call the ``get_spatial_dataset_service()`` method of the app class to get the en
 
 .. code-block:: python
 
-    from my_first_app.app import MyFirstApp as app
+    from .app import App
 
-    geoserver_engine = app.get_spatial_dataset_service('primary_geoserver', as_engine=True)
+    geoserver_engine = App.get_spatial_dataset_service('primary_geoserver', as_engine=True)
 
 You can also create a ``SpatialDatasetEngine`` object directly. This can be useful if you want to vary the credentials for dataset access frequently (e.g.: using user specific credentials):
 
@@ -162,10 +162,10 @@ After you have an engine object, simply call the desired methods on it. Consider
 
 ::
 
-    from my_first_app.app import MyFirstApp as app
+    from .app import App
 
     # First get an engine
-    engine = app.get_spatial_dataset_service('primary_geoserver', as_engine=True)
+    engine = App.get_spatial_dataset_service('primary_geoserver', as_engine=True)
 
     # Create a workspace named after our app
     engine.create_workspace(workspace_id='my_app', uri='http://www.example.com/apps/my-app')

--- a/docs/tethys_sdk/tethys_services/web_processing_services.rst
+++ b/docs/tethys_sdk/tethys_services/web_processing_services.rst
@@ -108,9 +108,9 @@ Anytime you wish to use a WPS service in an app, you will need to obtain an ``ow
 
 ::
 
-    from my_first_app.app import MyFirstApp as app
+    from .app import App
 
-    wps_engine = app.get_web_processing_service('primary_52n', as_engine=True)
+    wps_engine = App.get_web_processing_service('primary_52n', as_engine=True)
 
 Alternatively, you can create an ``owslib.wps.WebProcessingService`` engine object directly without using the convenience function. This can be useful if you want to vary the credentials for WPS service access frequently (e.g.: to provide user specific credentials).
 

--- a/docs/tethys_sdk/workspaces.rst
+++ b/docs/tethys_sdk/workspaces.rst
@@ -67,13 +67,13 @@ In cases where it is not possible to use one of the decorators, the :term:`app c
 
 .. code-block:: python
 
-    from .app import MyFirstApp as app
+    from .app import App
+    from django.contrib.auth.models import User
 
-    @controller
-    def my_controller(request):
-        app_workspace = app.get_app_workspace()
-        user_workspace = app.get_user_workspace(request.user)
-        ...
+    user = User.objects.get(id=1)
+    app_workspace = App.get_app_workspace()
+    user_workspace = App.get_user_workspace(user)
+    ...
 
 For more details see :ref:`app_base_class_api`
 

--- a/docs/tutorials/bokeh.rst
+++ b/docs/tutorials/bokeh.rst
@@ -305,8 +305,8 @@ Note that in this case we are not using a custom template, but we add the ``app_
 .. code-block:: html+django
 
     {% block app_navigation_items %}
-      {% url 'bokeh_tutorial:home' as home_url %}
-      {% url 'bokeh_tutorial:shapes' as shapes_url %}
+      {% url tethys_app|url:'home' as home_url %}
+      {% url tethys_app|url:'shapes' as shapes_url %}
       <li class="title">Examples</li>
       <li class="{% if request.path == home_url %}active{% endif %}"><a href="{{ home_url }}">Sea Surface</a></li>
       <li class="{% if request.path == shapes_url %}active{% endif %}"><a href="{{ shapes_url }}">Shapes</a></li>

--- a/docs/tutorials/dask/dask_delayed.rst
+++ b/docs/tutorials/dask/dask_delayed.rst
@@ -31,6 +31,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
     .. code-block:: python
         :emphasize-lines: 6-15, 29
 
+
         @controller
         def home(request):
             """
@@ -55,7 +56,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
                     'data-bs-placement': 'top',
                     'title': 'Show All Jobs'
                 },
-                href=reverse('dask_tutorial:jobs_table')
+                href=App.reverse('jobs_table')
             )
 
             context = {
@@ -63,7 +64,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
                 'jobs_button': jobs_button
             }
 
-            return render(request, 'dask_tutorial/home.html', context)
+            return App.render(request, 'home.html', context)
 
 
 Add the ``run_job`` controller to the :file:`controller.py` module as well:

--- a/docs/tutorials/dask/dask_distributed.rst
+++ b/docs/tutorials/dask/dask_distributed.rst
@@ -68,7 +68,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
                     'data-bs-placement': 'top',
                     'title': 'Show All Jobs'
                 },
-                href=reverse('dask_tutorial:jobs_table')
+                href=App.reverse('jobs_table')
             )
 
             context = {
@@ -77,7 +77,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
                 'jobs_button': jobs_button,
             }
 
-            return render(request, 'dask_tutorial/home.html', context)
+            return App.render(request, 'home.html', context)
 
 Additionally update the ``run_job`` controller in :file:`controller.py` to look like:
 

--- a/docs/tutorials/dask/multiple_leaf_job.rst
+++ b/docs/tutorials/dask/multiple_leaf_job.rst
@@ -82,7 +82,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
                     'data-bs-placement': 'top',
                     'title': 'Show All Jobs'
                 },
-                href=reverse('dask_tutorial:jobs_table')
+                href=App.reverse('jobs_table')
             )
 
             context = {
@@ -92,7 +92,7 @@ Modify the ``home`` controller in the :file:`controller.py` module, adding a but
                 'jobs_button': jobs_button,
             }
 
-            return render(request, 'dask_tutorial/home.html', context)
+            return App.render(request, 'home.html', context)
 
 Update the ``run_job`` controller to call the Multi Leaf Job:
 

--- a/docs/tutorials/dask/setup_views.rst
+++ b/docs/tutorials/dask/setup_views.rst
@@ -58,17 +58,16 @@ Replacte the contents of :file:`controller.py` with the following:
     .. code-block:: python
 
         import random
-        from django.shortcuts import render, reverse, redirect
         from tethys_sdk.routing import controller
         from django.http.response import HttpResponseRedirect
         from django.contrib import messages
         from tethys_sdk.gizmos import Button
         from tethys_sdk.gizmos import JobsTable
         from tethys_compute.models.dask.dask_job_exception import DaskJobException
-        from tethysapp.dask_tutorial.app import DaskTutorial as app
+        from .app import App
 
         # get job manager for the app
-        job_manager = app.get_job_manager()
+        job_manager = App.get_job_manager()
 
 
         @controller
@@ -85,14 +84,14 @@ Replacte the contents of :file:`controller.py` with the following:
                     'data-bs-placement': 'top',
                     'title': 'Show All Jobs'
                 },
-                href=reverse('dask_tutorial:jobs_table')
+                href=App.reverse('jobs_table')
             )
 
             context = {
                 'jobs_button': jobs_button
             }
 
-            return render(request, 'dask_tutorial/home.html', context)
+            return App.render(request, 'home.html', context)
 
 
         @controller
@@ -108,7 +107,7 @@ Replacte the contents of :file:`controller.py` with the following:
                 striped=False,
                 bordered=False,
                 condensed=False,
-                results_url='dask_tutorial:result',
+                results_url=f'{App.package}:result',
                 refresh_interval=1000,
                 delete_btn=True,
                 show_detailed_status=True,
@@ -122,12 +121,12 @@ Replacte the contents of :file:`controller.py` with the following:
                     'data-bs-placement': 'top',
                     'title': 'Home'
                 },
-                href=reverse('dask_tutorial:home')
+                href=App.reverse('home')
             )
 
             context = {'jobs_table': jobs_table_options, 'home_button': home_button}
 
-            return render(request, 'dask_tutorial/jobs_table.html', context)
+            return App.render(request, 'jobs_table.html', context)
 
 
         @controller
@@ -147,7 +146,7 @@ Replacte the contents of :file:`controller.py` with the following:
                     'data-bs-placement': 'top',
                     'title': 'Home'
                 },
-                href=reverse('dask_tutorial:home')
+                href=App.reverse('home')
             )
 
             jobs_button = Button(
@@ -158,7 +157,7 @@ Replacte the contents of :file:`controller.py` with the following:
                     'data-bs-placement': 'top',
                     'title': 'Show All Jobs'
                 },
-                href=reverse('dask_tutorial:jobs_table')
+                href=App.reverse('jobs_table')
             )
 
             context = {
@@ -168,13 +167,13 @@ Replacte the contents of :file:`controller.py` with the following:
                 'jobs_button': jobs_button
             }
 
-            return render(request, 'dask_tutorial/results.html', context)
+            return App.render(request, 'results.html', context)
 
 
         @controller
         def error_message(request):
             messages.add_message(request, messages.ERROR, 'Invalid Scheduler!')
-            return redirect(reverse('dask_tutorial:home'))
+            return App.redirect(App.reverse('home'))
 
 
 
@@ -187,7 +186,7 @@ Remove the navigation menu from the app by using the ``app_no_nav.html`` base te
 
         {% extends "tethys_apps/app_no_nav.html" %}
 
-        {% load static tags %}
+        {% load static tethys %}
 
         {% block title %}{{ tethys_app.name }}{% endblock %}
 
@@ -220,8 +219,8 @@ Replace the contents of :file:`templates/dask_tutorial/home.html` with the follo
 
     .. code-block:: html+django
 
-        {% extends "dask_tutorial/base.html" %}
-        {% load tethys_gizmos %}
+        {% extends tethys_app.package|add:"/base.html" %}
+        {% load tethys %}
 
         {% block app_actions %}
         {% gizmo jobs_button %}
@@ -231,10 +230,8 @@ Create :file:`templates/dask_tutorial/jobs_table.html` with the following conten
 
     .. code-block:: html+django
 
-        {% extends "dask_tutorial/base.html" %}
-        {% load static tethys_gizmos %}
-
-        {% load tethys_gizmos %}
+        {% extends tethys_app.package|add:"/base.html" %}
+        {% load static tethys %}
 
         {% block global_scripts %}
             {{ block.super }}
@@ -273,10 +270,8 @@ Create :file:`templates/dask_tutorial/results.html` with the following contents:
 
     .. code-block:: html+django
 
-        {% extends "dask_tutorial/base.html" %}
-        {% load static tethys_gizmos %}
-
-        {% load tethys_gizmos %}
+        {% extends tethys_app.package|add:"/base.html" %}
+        {% load static tethys %}
 
         {% block title %}- Gizmos - Map View{% endblock %}
 
@@ -316,8 +311,8 @@ Create :file:`templates/dask_tutorial/error.html` with the following contents:
 
     .. code-block:: html+django
 
-        {% extends "dask_tutorial/base.html" %}
-        {% load tethys_gizmos %}
+        {% extends tethys_app.package|add:"/base.html" %}
+        {% load tethys %}
 
         {% block app_content %}
         <div class="error-message">

--- a/docs/tutorials/dask/setup_views.rst
+++ b/docs/tutorials/dask/setup_views.rst
@@ -187,7 +187,7 @@ Remove the navigation menu from the app by using the ``app_no_nav.html`` base te
 
         {% extends "tethys_apps/app_no_nav.html" %}
 
-        {% load static %}
+        {% load static tags %}
 
         {% block title %}{{ tethys_app.name }}{% endblock %}
 
@@ -207,12 +207,12 @@ Remove the navigation menu from the app by using the ``app_no_nav.html`` base te
 
         {% block content_dependent_styles %}
         {{ block.super }}
-        <link href="{% static 'dask_tutorial/css/main.css' %}" rel="stylesheet"/>
+        <link href="{% static tethys_app|public:'css/main.css' %}" rel="stylesheet"/>
         {% endblock %}
 
         {% block scripts %}
         {{ block.super }}
-        <script src="{% static 'dask_tutorial/js/main.js' %}" type="text/javascript"></script>
+        <script src="{% static tethys_app|public:'js/main.js' %}" type="text/javascript"></script>
         {% endblock %}
 
 

--- a/docs/tutorials/geoserver/draw.rst
+++ b/docs/tutorials/geoserver/draw.rst
@@ -42,7 +42,7 @@ Create a new :file:`draw.html` template in your template directory and add the f
 
 .. code-block:: python
 
-    {% extends "geoserver_app/base.html" %}
+    {% extends tethys_app.package|add:"/base.html" %}
     {% load tethys_gizmos %}
 
     {% block app_content %}
@@ -68,9 +68,9 @@ Replace the ``app_navigation_items`` block of the :file:`base.html` template wit
 .. code-block:: html+django
 
     {% block app_navigation_items %}
-      {% url 'geoserver_app:home' as home_url %}
-      {% url 'geoserver_app:map' as map_url %}
-      {% url 'geoserver_app:draw' as draw_url %}
+      {% url tethys_app|url:'home' as home_url %}
+      {% url tethys_app|url:'map' as map_url %}
+      {% url tethys_app|url:'draw' as draw_url %}
       <li class="nav-item title">App Navigation</li>
       <li class="nav-item"><a href="{{ home_url }}" class="nav-link{% if request.path == home_url %} active{% endif %}">Upload Shapefile</a></li>
       <li class="nav-item"><a href="{{ map_url }}" class="nav-link{% if request.path == map_url %} active{% endif %}">GeoServer Layers</a></li>

--- a/docs/tutorials/geoserver/draw.rst
+++ b/docs/tutorials/geoserver/draw.rst
@@ -11,6 +11,8 @@ Add a new controller to the :file:`controller.py` module:
 
 .. code-block:: python
 
+    from .app import App
+
     @controller
     def draw(request):
         drawing_options = MVDraw(
@@ -33,7 +35,7 @@ Add a new controller to the :file:`controller.py` module:
         context = {'map_options': map_options,
                    'geometry': geometry}
 
-        return render(request, 'geoserver_app/draw.html', context)
+        return App.render(request, 'draw.html', context)
 
 2. Spatial Input Template
 =========================
@@ -43,7 +45,7 @@ Create a new :file:`draw.html` template in your template directory and add the f
 .. code-block:: python
 
     {% extends tethys_app.package|add:"/base.html" %}
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% block app_content %}
         <h1>Draw on the Map</h1>

--- a/docs/tutorials/geoserver/map_geoserver.rst
+++ b/docs/tutorials/geoserver/map_geoserver.rst
@@ -76,7 +76,7 @@ Add a new controller to the :file:`controller.py` module:
             'select_options': select_options
         }
 
-        return render(request, 'geoserver_app/map.html', context)
+        return App.render(request, 'map.html', context)
 
 2. Map Page Template
 ====================
@@ -85,8 +85,8 @@ Create a new :file:`map.html` template in your template directory and add the fo
 
 .. code-block:: html+django
 
-    {% extends "geoserver_app/base.html" %}
-    {% load tethys_gizmos %}
+    {% extends tethys_app.package|add:"/base.html" %}
+    {% load tethys %}
 
     {% block app_content %}
         <h1>GeoServer Layers</h1>

--- a/docs/tutorials/geoserver/upload_shp.rst
+++ b/docs/tutorials/geoserver/upload_shp.rst
@@ -36,11 +36,10 @@ Replace the contents of :file:`controllers.py` module with the following:
     import random
     import string
 
-    from django.shortcuts import render
     from tethys_sdk.routing import controller
 
     from tethys_sdk.gizmos import *
-    from .app import GeoserverApp as app
+    from .app import App
 
 
     WORKSPACE = 'geoserver_app'
@@ -53,7 +52,7 @@ Replace the contents of :file:`controllers.py` module with the following:
         Controller for the app home page.
         """
         # Retrieve a geoserver engine
-        geoserver_engine = app.get_spatial_dataset_service(name='main_geoserver', as_engine=True)
+        geoserver_engine = App.get_spatial_dataset_service(name='main_geoserver', as_engine=True)
 
         # Check for workspace and create workspace for app if it doesn't exist
         response = geoserver_engine.list_workspaces()
@@ -82,7 +81,7 @@ Replace the contents of :file:`controllers.py` module with the following:
 
         context = {}
 
-        return render(request, 'geoserver_app/home.html', context)
+        return App.render(request, 'home.html', context)
 
 
 3. Test Shapefile Upload

--- a/docs/tutorials/google_earth_engine/part_1/dataset_controls.rst
+++ b/docs/tutorials/google_earth_engine/part_1/dataset_controls.rst
@@ -398,7 +398,7 @@ In this step, you'll create controls using Tethys Gizmos with their initial valu
 
 .. code-block:: html+django
 
-    {% extends "earth_engine/base.html" %}
+    {% extends tethys_app.package|add:"/base.html" %}
     {% load tethys_gizmos static %}
 
     {% block app_navigation_items %}

--- a/docs/tutorials/google_earth_engine/part_1/dataset_controls.rst
+++ b/docs/tutorials/google_earth_engine/part_1/dataset_controls.rst
@@ -264,7 +264,6 @@ In this step, you'll create controls using Tethys Gizmos with their initial valu
 .. code-block:: python
 
     import datetime as dt
-    from django.shortcuts import render
     from tethys_sdk.routing import controller
     from tethys_sdk.gizmos import SelectInput, DatePicker, Button
     from .gee.products import EE_PRODUCTS
@@ -392,14 +391,14 @@ In this step, you'll create controls using Tethys Gizmos with their initial valu
             'load_button': load_button,
         }
 
-        return render(request, 'earth_engine/home.html', context)
+        return App.render(request, 'home.html', context)
 
 2. Replace the contents of the `templates/earth_engine/home.html` template with the following:
 
 .. code-block:: html+django
 
     {% extends tethys_app.package|add:"/base.html" %}
-    {% load tethys_gizmos static %}
+    {% load static tethys %}
 
     {% block app_navigation_items %}
       <li class="title">Select Dataset</li>

--- a/docs/tutorials/google_earth_engine/part_1/dataset_controls_js.rst
+++ b/docs/tutorials/google_earth_engine/part_1/dataset_controls_js.rst
@@ -117,7 +117,7 @@ In this step you'll learn how to create a JavaScript module using the closure me
 
     {% block scripts %}
       {{ block.super }}
-      <script src="{% static 'earth_engine/js/gee_datasets.js' %}" type="text/javascript"></script>
+      <script src="{% static tethys_app|public:'js/gee_datasets.js' %}" type="text/javascript"></script>
     {% endblock %}
 
 2. Implement Methods

--- a/docs/tutorials/google_earth_engine/part_1/map_view.rst
+++ b/docs/tutorials/google_earth_engine/part_1/map_view.rst
@@ -141,7 +141,7 @@ In this step you'll add the ``MapView`` to the home view. You'll also add a cust
 
     {% block content_dependent_styles %}
         {{ block.super }}
-        <link rel="stylesheet" href="{% static 'earth_engine/css/map.css' %}" />
+        <link rel="stylesheet" href="{% static tethys_app|public:'css/map.css' %}" />
     {% endblock %}
 
 3. Test and Verify

--- a/docs/tutorials/google_earth_engine/part_1/plot_data.rst
+++ b/docs/tutorials/google_earth_engine/part_1/plot_data.rst
@@ -279,13 +279,13 @@ The technique that will be demonstrated in this step will leverage the `jQuery.l
             context['error'] = f'An unexpected error has occurred. Please try again.'
             log.exception('An unexpected error occurred.')
 
-        return render(request, 'earth_engine/plot.html', context)
+        return App.render(request, 'plot.html', context)
 
 3. Create a new template called :file:`templates/earth_engine/plot.html` with the following contents:
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% if plot_view %}
       {% gizmo plot_view %}

--- a/docs/tutorials/google_earth_engine/part_1/plot_data.rst
+++ b/docs/tutorials/google_earth_engine/part_1/plot_data.rst
@@ -374,7 +374,7 @@ In this step you'll add a Plot button and the modal for the plot to the controll
       <!-- End Plot Modal -->
       <div id="ee-products" data-ee-products="{{ ee_products|jsonify }}"></div>
       <div id="loader">
-        <img src="{% static 'earth_engine/images/map-loader.gif' %}">
+        <img src="{% static tethys_app|public:'images/map-loader.gif' %}">
       </div>
     {% endblock %}
 
@@ -449,9 +449,9 @@ In this step you'll add a loading image to the modal whenever it is shown, repla
 
     {% block content_dependent_styles %}
         {{ block.super }}
-        <link rel="stylesheet" href="{% static 'earth_engine/css/map.css' %}" />
-        <link rel="stylesheet" href="{% static 'earth_engine/css/loader.css' %}" />
-        <link rel="stylesheet" href="{% static 'earth_engine/css/plot.css' %}" />
+        <link rel="stylesheet" href="{% static tethys_app|public:'css/map.css' %}" />
+        <link rel="stylesheet" href="{% static tethys_app|public:'css/loader.css' %}" />
+        <link rel="stylesheet" href="{% static tethys_app|public:'css/plot.css' %}" />
     {% endblock %}
 
 .. tip::

--- a/docs/tutorials/google_earth_engine/part_1/vis_gee_layers.rst
+++ b/docs/tutorials/google_earth_engine/part_1/vis_gee_layers.rst
@@ -564,8 +564,8 @@ You may have noticed while testing the app, that it can take some time for a lay
 
     {% block content_dependent_styles %}
         {{ block.super }}
-        <link rel="stylesheet" href="{% static 'earth_engine/css/map.css' %}" />
-        <link rel="stylesheet" href="{% static 'earth_engine/css/loader.css' %}" />
+        <link rel="stylesheet" href="{% static tethys_app|public:'css/map.css' %}" />
+        <link rel="stylesheet" href="{% static tethys_app|public:'css/loader.css' %}" />
     {% endblock %}
 
 .. code-block:: html+django
@@ -573,7 +573,7 @@ You may have noticed while testing the app, that it can take some time for a lay
     {% block after_app_content %}
       <div id="ee-products" data-ee-products="{{ ee_products|jsonify }}"></div>
       <div id="loader">
-        <img src="{% static 'earth_engine/images/map-loader.gif' %}">
+        <img src="{% static tethys_app|public:'images/map-loader.gif' %}">
       </div>
     {% endblock %}
 

--- a/docs/tutorials/google_earth_engine/part_2/about_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/about_page.rst
@@ -56,7 +56,7 @@ The first step to adding a new page to the app is to create a new controller and
         Controller for the app about page.
         """
         context = {}
-        return app.render(request, 'about.html', context)
+        return App.render(request, 'about.html', context)
 
 3. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify that the new page loads. You should see the "This is the About Page" text.
 

--- a/docs/tutorials/google_earth_engine/part_2/about_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/about_page.rst
@@ -56,7 +56,7 @@ The first step to adding a new page to the app is to create a new controller and
         Controller for the app about page.
         """
         context = {}
-        return render(request, 'earth_engine/about.html', context)
+        return app.render(request, 'about.html', context)
 
 3. Navigate to `<http://localhost:8000/apps/earth-engine/about/>`_ and verify that the new page loads. You should see the "This is the About Page" text.
 
@@ -71,11 +71,13 @@ To minimize the amount of code that is duplicated, you will create a new :file:`
 
 .. code-block:: html+django
 
+    {% load tags %}
+
     <div class="header-button glyphicon-button">
-      <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
+      <a href="{% url tethys_app|url:'home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
     </div>
     <div class="header-button glyphicon-button">
-      <a href="{% url 'earth_engine:about' %}" title="About"><i class="bi bi-info-circle-fill"></i></a>
+      <a href="{% url tethys_app|url:'about' %}" title="About"><i class="bi bi-info-circle-fill"></i></a>
     </div>
 
 2. Add the following lines to the :file:`templates/earth_engine/base.html`, :file:`templates/earth_engine/home.html`, and :file:`templates/earth_engine/about.html` templates:
@@ -83,7 +85,7 @@ To minimize the amount of code that is duplicated, you will create a new :file:`
 .. code-block:: html+django
 
     {% block header_buttons %}
-      {% include "earth_engine/header_buttons.html" %}
+      {% include tethys_app.package|add:"header_buttons.html" %}
     {% endblock %}
 
 3. The Home button is included in :file:`header_buttons.html` and provided by :file:`base.html`, so it will be removed from :file:`viewer.html`. Delete the ``header_buttons`` block in :file:`templates/earth_engine/viewer.html`:
@@ -92,7 +94,7 @@ To minimize the amount of code that is duplicated, you will create a new :file:`
 
     -{% block header_buttons %}
     -  <div class="header-button glyphicon-button">
-    -    <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
+    -    <a href="{% url tethys_app|url:'home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
     -  </div>
     -{% endblock %}
 
@@ -224,13 +226,17 @@ As with the Home page, the Bootstrap Grid System does a good job providing the b
 
 1. Create a new :file:`public/earth_engine/about.css` stylesheet.
 
-2. Include the new :file:`about.css` by adding the ``styles`` block to the :file:`templates/earth_engine/about.html`:
+2. Include the new :file:`about.css` by adding the ``styles`` block to the :file:`templates/earth_engine/about.html`. Be sure to add the ``tags`` argument to the ``loads`` template tag at the top:
 
 .. code-block:: html+django
 
+    {% load static tags %}
+
+    ...
+
     {% block styles %}
       {{ block.super }}
-      <link rel="stylesheet" href="{% static 'earth_engine/css/about.css' %}" />
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/about.css' %}" />
     {% endblock %}
 
 3. Add the following contents to :file:`public/earth_engine/about.css` to customize the style of the page header:
@@ -347,7 +353,7 @@ In this step you will create a new modal that will contain a disclaimer for the 
       <!-- End Plot Modal -->
       <div id="ee-products" data-ee-products="{{ ee_products|jsonify }}"></div>
       <div id="loader">
-        <img src="{% static 'earth_engine/images/map-loader.gif' %}">
+        <img src="{% static tethys_app|public:'images/map-loader.gif' %}">
       </div>
     {% endblock %}
 

--- a/docs/tutorials/google_earth_engine/part_2/about_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/about_page.rst
@@ -71,7 +71,7 @@ To minimize the amount of code that is duplicated, you will create a new :file:`
 
 .. code-block:: html+django
 
-    {% load tags %}
+    {% load tethys %}
 
     <div class="header-button glyphicon-button">
       <a href="{% url tethys_app|url:'home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
@@ -230,7 +230,7 @@ As with the Home page, the Bootstrap Grid System does a good job providing the b
 
 .. code-block:: html+django
 
-    {% load static tags %}
+    {% load static tethys %}
 
     ...
 

--- a/docs/tutorials/google_earth_engine/part_2/file_upload.rst
+++ b/docs/tutorials/google_earth_engine/part_2/file_upload.rst
@@ -63,7 +63,7 @@ Create a new `Bootstrap Modal <https://getbootstrap.com/docs/5.2/components/moda
         'map_view': map_view
     }
 
-    return render(request, 'earth_engine/viewer.html', context)
+    return App.render(request, 'viewer.html', context)
 
 2. Add the new button with help text to the ``app_navigation_items`` block in :file:`templates/earth_engine/viewer.html`:
 
@@ -246,7 +246,7 @@ The ``action`` attribute of the HTML ``form`` element dictates endpoint to which
         'map_view': map_view
     }
 
-    return render(request, 'earth_engine/viewer.html', context)
+    return App.render(request, 'viewer.html', context)
 
 3. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_. Press the **Set Boundary** button to open the Set Boundary form. Choose a file and press the **Set Boundary** button in the modal to upload it. Verify that the name of the file is printed to the console.
 

--- a/docs/tutorials/google_earth_engine/part_2/home_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/home_page.rst
@@ -50,7 +50,7 @@ Currently, the map viewer page is the "home" page of the app as evidenced by it 
 
 .. code-block:: python
 
-    return render(request, 'earth_engine/viewer.html', context)
+    return App.render(request, 'viewer.html', context)
 
 4. Set custom URLs for the ``get_image_collection`` and  ``get_time_series_plot`` controllers in :file:`controllers.py`: so that their URLs are relative to the ``viewer`` url:
 
@@ -76,7 +76,7 @@ In this step you will create a new ``home`` controller and :file:`home.html` tem
 .. code-block:: html+django
 
     {% extends tethys_app.package|add:"/base.html" %}
-    {% load tethys_gizmos static %}
+    {% load static tethys %}
 
     {% block app_content %}
     <h1>Home Page</h1>
@@ -92,7 +92,7 @@ In this step you will create a new ``home`` controller and :file:`home.html` tem
         Controller for the app home page.
         """
         context = {}
-        return render(request, 'earth_engine/home.html', context)
+        return App.render(request, 'home.html', context)
 
 3. Navigate to `<http://localhost:8000/apps/earth-engine/>`_ and verify that the new home page loads with text "Home Page".
 
@@ -112,7 +112,7 @@ As the app is not very complex (i.e. it only has two pages), the navigation menu
 
    -{% extends tethys_app.package|add:"/base.html" %}
    +{% extends "tethys_apps/app_header_content.html" %}
-    {% load tethys_gizmos static %}
+    {% load static tethys %}
 
     {% block app_content %}
     <h1>Home Page</h1>

--- a/docs/tutorials/google_earth_engine/part_2/home_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/home_page.rst
@@ -75,7 +75,7 @@ In this step you will create a new ``home`` controller and :file:`home.html` tem
 
 .. code-block:: html+django
 
-    {% extends "earth_engine/base.html" %}
+    {% extends tethys_app.package|add:"/base.html" %}
     {% load tethys_gizmos static %}
 
     {% block app_content %}
@@ -110,7 +110,7 @@ As the app is not very complex (i.e. it only has two pages), the navigation menu
 
 .. code-block:: diff
 
-   -{% extends "earth_engine/base.html" %}
+   -{% extends tethys_app.package|add:"/base.html" %}
    +{% extends "tethys_apps/app_header_content.html" %}
     {% load tethys_gizmos static %}
 
@@ -256,7 +256,7 @@ In this step we'll add a the title and some filler content to the About panel of
       <h2 class="info-title">About</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eget est lorem ipsum dolor sit amet. Morbi tincidunt augue interdum velit euismod in pellentesque.</p>
       <p>Ac felis donec et odio pellentesque. Quis ipsum suspendisse ultrices gravida dictum fusce ut. Curabitur gravida arcu ac tortor dignissim convallis aenean et tortor. Sed euismod nisi porta lorem mollis. Nisi scelerisque eu ultrices vitae. Sit amet consectetur adipiscing elit duis. At in tellus integer feugiat scelerisque varius morbi enim.</p>
-      <img id="feature-image" src="{% static 'earth_engine/images/earth-engine-viewer.png' %}">
+      <img id="feature-image" src="{% static tethys_app|public:'images/earth-engine-viewer.png' %}">
     </div>
 
 4. Navigate to `<http://localhost:8000/apps/earth-engine/>`_ and verify that the title "About", filler paragraphs, and screenshot appear in the panel on the left.
@@ -296,7 +296,7 @@ In this step we'll add the content to the Resources panel of the home page. The 
       <div class="d-flex align-items-center">
         <div class="flex-shrink-0">
           <a href="#coast">
-            <img class="media-object" src="{% static 'earth_engine/images/coast_80_80.jpg' %}" alt="coast">
+            <img class="media-object" src="{% static tethys_app|public:'images/coast_80_80.jpg' %}" alt="coast">
           </a>
         </div>
         <div class="media-body flex-grow-1 ms-3">
@@ -308,7 +308,7 @@ In this step we'll add the content to the Resources panel of the home page. The 
       <div class="d-flex align-items-center mt-2">
         <div class="flex-shrink-0">
           <a href="#condensation">
-            <img class="media-object" src="{% static 'earth_engine/images/condensation_80_80.jpg' %}" alt="condensation">
+            <img class="media-object" src="{% static tethys_app|public:'images/condensation_80_80.jpg' %}" alt="condensation">
           </a>
         </div>
         <div class="media-body flex-grow-1 ms-3">
@@ -320,7 +320,7 @@ In this step we'll add the content to the Resources panel of the home page. The 
       <div class="d-flex align-items-center mt-2">
         <div class="flex-shrink-0">
           <a href="#waterfall">
-            <img class="media-object" src="{% static 'earth_engine/images/waterfall_80_80.jpg' %}" alt="waterfall">
+            <img class="media-object" src="{% static tethys_app|public:'images/waterfall_80_80.jpg' %}" alt="waterfall">
           </a>
         </div>
         <div class="media-body flex-grow-1 ms-3">
@@ -346,7 +346,7 @@ In this step you will add the content to the Get Started panel. This panel is ar
     <div class="info-container">
       <h2 class="info-title">Get Started</h2>
       <p>Press the button below to launch the viewer</p>
-      <a id="get-started-btn" href="{% url 'earth_engine:viewer' %}">Launch Viewer</a>
+      <a id="get-started-btn" href="{% url tethys_app|url:'viewer' %}">Launch Viewer</a>
     </div>
 
 2. Navigate to `<http://localhost:8000/apps/earth-engine/>`_ and verify that the title "Get Started", paragraph, and Launch Viewer link appear in the panel on the bottom right. Click on the Launch Viewer link to verify that it directs the user to the map view page.
@@ -364,7 +364,7 @@ The Bootstrap CSS framework provides a good base for styling pages in the apps. 
 
     {% block styles %}
       {{ block.super }}
-      <link rel="stylesheet" href="{% static 'earth_engine/css/home.css' %}" />
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/home.css' %}" />
     {% endblock %}
 
 3. Add the following lines to :file:`public/css/home.css` to customize the appearance of the ``info-container`` panels:
@@ -483,7 +483,7 @@ In this step you will add a Home button to the Viewer page so that users can eas
 
     {% block header_buttons %}
       <div class="header-button glyphicon-button">
-        <a href="{% url 'earth_engine:home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
+        <a href="{% url tethys_app|url:'home' %}" title="Home"><i class="bi bi-house-door-fill"></i></a>
       </div>
     {% endblock %}
 

--- a/docs/tutorials/google_earth_engine/part_2/rest_api.rst
+++ b/docs/tutorials/google_earth_engine/part_2/rest_api.rst
@@ -98,7 +98,6 @@ The :file:`controllers.py` file is beginning to get quite long. To make the cont
 .. code-block:: python
 
     import logging
-    from django.shortcuts import render
     from tethys_sdk.routing import controller
 
     log = logging.getLogger(f'tethys.apps.{__name__}')
@@ -110,7 +109,7 @@ The :file:`controllers.py` file is beginning to get quite long. To make the cont
         Controller for the app home page.
         """
         context = {}
-        return render(request, 'earth_engine/home.html', context)
+        return App.render(request, 'home.html', context)
 
 
     @controller
@@ -119,7 +118,7 @@ The :file:`controllers.py` file is beginning to get quite long. To make the cont
         Controller for the app about page.
         """
         context = {}
-        return render(request, 'earth_engine/about.html', context)
+        return App.render(request, 'about.html', context)
 
 3. Copy the ``viewer``, ``get_image_collection``, and ``get_time_series_plot`` controller functions with any imports they need into the new :file:`controllers/viewer.py` module:
 
@@ -152,7 +151,7 @@ The :file:`controllers.py` file is beginning to get quite long. To make the cont
 
         ...  # Code not shown for brevity
 
-        return render(request, 'earth_engine/viewer.html', context)
+        return App.render(request, 'viewer.html', context)
 
 
     @controller(url='viewer/get-image-collection')
@@ -171,7 +170,7 @@ The :file:`controllers.py` file is beginning to get quite long. To make the cont
 
         ...  # Code not shown for brevity
 
-        return render(request, 'earth_engine/plot.html', context)
+        return App.render(request, 'plot.html', context)
 
 5. Delete the old :file:`controllers.py` file.
 

--- a/docs/tutorials/google_earth_engine/part_3/prepare.rst
+++ b/docs/tutorials/google_earth_engine/part_3/prepare.rst
@@ -70,12 +70,12 @@ Although using the :file:`gee/params.py` file to store our service account crede
 
 .. code-block:: python
 
-    from ..app import EarthEngine as app
+    from ..app import App
 
 .. code-block:: python
 
-    service_account = app.get_custom_setting('service_account_email')
-    private_key_path = app.get_custom_setting('private_key_file')
+    service_account = App.get_custom_setting('service_account_email')
+    private_key_path = App.get_custom_setting('private_key_file')
 
     if service_account and private_key_path and os.path.isfile(private_key_path):
         try:

--- a/docs/tutorials/key_concepts/advanced.rst
+++ b/docs/tutorials/key_concepts/advanced.rst
@@ -585,11 +585,11 @@ c. Open ``/templates/dam_inventory/home.html``, add a new ``div`` element to the
     .. code-block:: html+django
 
         {% extends "dam_inventory/base.html" %}
-        {% load tethys_gizmos static %}
+        {% load tethys_gizmos static tags %}
 
         {% block styles %}
             {{ block.super }}
-            <link href="{% static 'dam_inventory/css/map.css' %}" rel="stylesheet"/>
+            <link href="{% static tethys_app|public:'css/map.css' %}" rel="stylesheet"/>
         {% endblock %}
 
         {% block app_content %}
@@ -603,7 +603,7 @@ c. Open ``/templates/dam_inventory/home.html``, add a new ``div`` element to the
 
         {% block scripts %}
             {{ block.super }}
-            <script src="{% static 'dam_inventory/js/map.js' %}" type="text/javascript"></script>
+            <script src="{% static tethys_app|public:'js/map.js' %}" type="text/javascript"></script>
         {% endblock %}
 
 
@@ -728,9 +728,9 @@ d. Use the ``can_add_dams`` variable to determine whether to show or hide the na
         :emphasize-lines: 8, 10
 
         {% block app_navigation_items %}
-        {% url 'dam_inventory:home' as home_url %}
-        {% url 'dam_inventory:add_dam' as add_dam_url %}
-        {% url 'dam_inventory:dams' as list_dam_url %}
+        {% url tethys_app|url:'home' as home_url %}
+        {% url tethys_app|url:'add_dam' as add_dam_url %}
+        {% url tethys_app|url:'dams' as list_dam_url %}
         <li class="nav-item title">Navigation</li>
         <li class="nav-item"><a class="nav-link{% if request.path == home_url %} active{% endif %}" href="{{ home_url }}">Home</a></li>
         <li class="nav-item"><a class="nav-link{% if request.path == list_dam_url %} active{% endif %}" href="{{ list_dam_url }}">Dams</a></li>
@@ -898,7 +898,7 @@ b. New Template: ``assign_hydrograph.html``
 
     .. code-block:: html+django
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos %}
 
         {% block app_content %}
@@ -1021,10 +1021,10 @@ d. Update navigation
     .. code-block:: html+django
 
         {% block app_navigation_items %}
-        {% url 'dam_inventory:home' as home_url %}
-        {% url 'dam_inventory:add_dam' as add_dam_url %}
-        {% url 'dam_inventory:dams' as list_dam_url %}
-        {% url 'dam_inventory:assign_hydrograph' as assign_hydrograph_url %}
+        {% url tethys_app|url:'home' as home_url %}
+        {% url tethys_app|url:'add_dam' as add_dam_url %}
+        {% url tethys_app|url:'dams' as list_dam_url %}
+        {% url tethys_app|url:'assign_hydrograph' as assign_hydrograph_url %}
         <li class="nav-item title">Navigation</li>
         <li class="nav-item"><a class="nav-link{% if request.path == home_url %} active{% endif %}" href="{{ home_url }}">Home</a></li>
         <li class="nav-item"><a class="nav-link{% if request.path == list_dam_url %} active{% endif %}" href="{{ list_dam_url }}">Dams</a></li>
@@ -1049,12 +1049,12 @@ a. Create Template ``hydrograph.html``
 
     .. code-block:: html+django
 
-        {% extends "dam_inventory/base.html" %}
-        {% load tethys_gizmos %}
+        {% extends tethys_app.package|add:"/base.html" %}
+        {% load tethys_gizmos tags %}
 
         {% block app_navigation_items %}
         <li class="nav-item title">App Navigation</li>
-        <li class="nav-item "><a class="nav-link" href="{% url 'dam_inventory:dams' %}">Back</a></li>
+        <li class="nav-item "><a class="nav-link" href="{% url tethys_app|url:'dams' %}">Back</a></li>
         {% endblock %}
 
         {% block app_content %}
@@ -1210,7 +1210,7 @@ a. Add Plotly Gizmo dependency to ``home.html``:
     .. code-block:: html+django
         :emphasize-lines: 4-6
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos static %}
 
         {% block import_gizmos %}

--- a/docs/tutorials/key_concepts/beginner.rst
+++ b/docs/tutorials/key_concepts/beginner.rst
@@ -109,7 +109,7 @@ a. Open ``/templates/dam_inventory/home.html`` and replace it's contents with th
 
     .. code-block:: html+django
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos %}
 
         {% block app_content %}
@@ -205,13 +205,13 @@ b. Load the styles on the ``/templates/dam_inventory/home.html`` template by add
 
     .. code-block:: html+django
 
-        {% load tethys_gizmos static %}
+        {% load tethys_gizmos static tags %}
 
         ...
 
         {% block styles %}
             {{ block.super }}
-            <link href="{% static 'dam_inventory/css/map.css' %}" rel="stylesheet"/>
+            <link href="{% static tethys_app|public:'css/map.css' %}" rel="stylesheet"/>
         {% endblock %}
 
 c. Save your changes to ``map.css`` and ``home.html`` and refresh the page to view the changes. The map should fill the content area now. Notice how the map dynamically resizes if the screen size changes.
@@ -292,7 +292,7 @@ a. Modify the ``template/dam_inventory/add_dam.html`` with a title in the app co
 
     .. code-block:: html+django
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos %}
 
         {% block app_content %}
@@ -345,8 +345,8 @@ a. Open ``/templates/dam_inventory/base.html`` and replace the ``app_navigation_
 
         {% block app_navigation_items %}
         <li class="nav-item title">Navigation</li>
-        <li class="nav-item"><a class="nav-link active" href="{% url 'dam_inventory:home' %}">Home</a></li>
-        <li class="nav-item"><a class="nav-link" href="{% url 'dam_inventory:add_dam' %}">Add Dam</a></li>
+        <li class="nav-item"><a class="nav-link active" href="{% url tethys_app|url:'home' %}">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url tethys_app|url:'add_dam' %}">Add Dam</a></li>
         {% endblock %}
 
     Notice that the **Home** link in the app navigation is always highlighed, even if you are on the **Add Dam** page. The highlight is controlled by adding the ``active`` class to the appropriate navigation link. We can get the navigation to highlight appropriately using the following pattern.
@@ -356,8 +356,8 @@ b. Modify ``app_navigation_items`` block in ``/templates/dam_inventory/base.html
     .. code-block:: html+django
 
         {% block app_navigation_items %}
-        {% url 'dam_inventory:home' as home_url %}
-        {% url 'dam_inventory:add_dam' as add_dam_url %}
+        {% url tethys_app|url:'home' as home_url %}
+        {% url tethys_app|url:'add_dam' as add_dam_url %}
         <li class="nav-item title">Navigation</li>
         <li class="nav-item"><a class="nav-link{% if request.path == home_url %} active{% endif %}" href="{{ home_url }}">Home</a></li>
         <li class="nav-item"><a class="nav-link{% if request.path == add_dam_url %} active{% endif %}" href="{{ add_dam_url }}">Add Dam</a></li>

--- a/docs/tutorials/key_concepts/beginner.rst
+++ b/docs/tutorials/key_concepts/beginner.rst
@@ -110,7 +110,7 @@ a. Open ``/templates/dam_inventory/home.html`` and replace it's contents with th
     .. code-block:: html+django
 
         {% extends tethys_app.package|add:"/base.html" %}
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% block app_content %}
         {% gizmo dam_inventory_map %}
@@ -143,9 +143,9 @@ a. Open ``controllers.py`` define the ``dam_inventory_map`` and ``add_dam_button
 
     .. code-block:: python
 
-        from django.shortcuts import render
         from tethys_sdk.gizmos import MapView, Button
         from tethys_sdk.routing import controller
+        from .app import App
 
 
         @controller
@@ -174,7 +174,7 @@ a. Open ``controllers.py`` define the ``dam_inventory_map`` and ``add_dam_button
                 'add_dam_button': add_dam_button
             }
 
-            return render(request, 'dam_inventory/home.html', context)
+            return App.render(request, 'home.html', context)
 
 b. Save your changes to ``controllers.py`` and ``home.html`` and refresh the page to view the map.
 
@@ -205,7 +205,7 @@ b. Load the styles on the ``/templates/dam_inventory/home.html`` template by add
 
     .. code-block:: html+django
 
-        {% load tethys_gizmos static tags %}
+        {% load static tethys %}
 
         ...
 
@@ -244,7 +244,7 @@ b. Create a new controller function called ``add_dam`` at the bottom of the ``co
             Controller for the Add Dam page.
             """
             context = {}
-            return render(request, 'dam_inventory/add_dam.html', context)
+            return App.render(request, 'add_dam.html', context)
 
     This is the most basic controller function you can write: a function that accepts an argument called ``request`` and a return value that is the result of the ``render`` function. The ``render`` function renders the Django template into valid HTML using the ``request`` and ``context`` provided.
 
@@ -269,7 +269,7 @@ a. Modify the ``add_dam_button`` on the Home page to link to the newly created p
 
     .. code-block:: python
 
-        from django.shortcuts import reverse
+        from .app import App
 
         ...
 
@@ -282,7 +282,7 @@ a. Modify the ``add_dam_button`` on the Home page to link to the newly created p
                 name='add-dam-button',
                 icon='plus-square',
                 style='success',
-                href=reverse('dam_inventory:add_dam')
+                href=App.reverse('add_dam')
             )
 
 9. Build Out New Page
@@ -293,7 +293,7 @@ a. Modify the ``template/dam_inventory/add_dam.html`` with a title in the app co
     .. code-block:: html+django
 
         {% extends tethys_app.package|add:"/base.html" %}
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% block app_content %}
         <h1>Add Dam</h1>
@@ -331,7 +331,7 @@ b. Define the options for the ``Add`` and ``Cancel`` button gizmos in the ``add_
                 'cancel_button': cancel_button,
             }
 
-            return render(request, 'dam_inventory/add_dam.html', context)
+            return App.render(request, 'add_dam.html', context)
 
 
 10. Customize Navigation

--- a/docs/tutorials/key_concepts/intermediate.rst
+++ b/docs/tutorials/key_concepts/intermediate.rst
@@ -39,7 +39,7 @@ HTML forms are the primary mechanism for obtaining input from users of your app.
     .. code-block:: html+django
 
         {% extends tethys_app.package|add:"/base.html" %}
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% block app_content %}
         <h1>Add Dam</h1>
@@ -117,7 +117,7 @@ b. Define the options for the form gizmos in the controller and change the ``add
             cancel_button = Button(
                 display_text='Cancel',
                 name='cancel-button',
-                href=reverse('dam_inventory:home')
+                href=App.reverse('home')
             )
 
             context = {
@@ -129,7 +129,7 @@ b. Define the options for the form gizmos in the controller and change the ``add
                 'cancel_button': cancel_button,
             }
 
-            return render(request, 'dam_inventory/add_dam.html', context)
+            return App.render(request, 'add_dam.html', context)
 
 2. Handle Form Submission
 =========================
@@ -141,7 +141,6 @@ a. Change the ``add_dam`` controller to handle the form data using the form vali
     .. code-block:: python
         :emphasize-lines: 1-2, 11-53, 59-60, 68-69, 76-77, 87-88
 
-        from django.shortcuts import redirect
         from django.contrib import messages
 
         ...
@@ -243,7 +242,7 @@ a. Change the ``add_dam`` controller to handle the form data using the form vali
             cancel_button = Button(
                 display_text='Cancel',
                 name='cancel-button',
-                href=reverse('dam_inventory:home')
+                href=App.reverse('home')
             )
 
             context = {
@@ -255,7 +254,7 @@ a. Change the ``add_dam`` controller to handle the form data using the form vali
                 'cancel_button': cancel_button,
             }
 
-            return render(request, 'dam_inventory/add_dam.html', context)
+            return App.render(request, 'add_dam.html', context)
 
 .. tip::
 
@@ -452,7 +451,7 @@ b. Modify ``add_dam`` controller to use the new ``add_new_dam`` model function t
             cancel_button = Button(
                 display_text='Cancel',
                 name='cancel-button',
-                href=reverse('dam_inventory:home')
+                href=App.reverse('home')
             )
 
             context = {
@@ -464,7 +463,7 @@ b. Modify ``add_dam`` controller to use the new ``add_new_dam`` model function t
                 'cancel_button': cancel_button,
             }
 
-            return render(request, 'dam_inventory/add_dam.html', context)
+            return App.render(request, 'add_dam.html', context)
 
 c. Use the Add Dam page to add several dams for the Dam Inventory app.
 
@@ -509,7 +508,7 @@ b. Add a new template ``/templates/dam_inventory/list_dams.html`` with the follo
     .. code-block:: html+django
 
         {% extends tethys_app.package|add:"/base.html" %}
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% block app_content %}
         <h1>Dams</h1>
@@ -553,7 +552,7 @@ c. Create a new controller function in ``controllers.py`` called ``list_dams``:
                 'dams_table': dams_table
             }
 
-            return render(request, 'dam_inventory/list_dams.html', context)
+            return App.render(request, 'list_dams.html', context)
         
     .. note::
 
@@ -586,7 +585,7 @@ a. Open ``/templates/dam_inventory/add_dam.html`` and add the ``location_input``
         :emphasize-lines: 8-12
 
         {% extends tethys_app.package|add:"/base.html" %}
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% block app_content %}
         <h1>Add Dam</h1>
@@ -743,7 +742,7 @@ b. Add the definition of the ``location_input`` gizmo and validation code to the
             cancel_button = Button(
                 display_text='Cancel',
                 name='cancel-button',
-                href=reverse('dam_inventory:home')
+                href=App.reverse('home')
             )
 
             context = {
@@ -757,7 +756,7 @@ b. Add the definition of the ``location_input`` gizmo and validation code to the
                 'cancel_button': cancel_button,
             }
 
-            return render(request, 'dam_inventory/add_dam.html', context)
+            return App.render(request, 'add_dam.html', context)
 
 c. Modify the ``add_new_dam`` Model Method to store spatial data:
 
@@ -903,7 +902,7 @@ a. Modify the ``home`` controller in ``controllers.py`` to map the list of dams:
                 name='add-dam-button',
                 icon='plus-square',
                 style='success',
-                href=reverse('dam_inventory:add_dam')
+                href=App.reverse('add_dam')
             )
 
             context = {
@@ -911,7 +910,7 @@ a. Modify the ``home`` controller in ``controllers.py`` to map the list of dams:
                 'add_dam_button': add_dam_button
             }
 
-            return render(request, 'dam_inventory/home.html', context)
+            return App.render(request, 'home.html', context)
 
 7. Solution
 ===========

--- a/docs/tutorials/key_concepts/intermediate.rst
+++ b/docs/tutorials/key_concepts/intermediate.rst
@@ -38,7 +38,7 @@ HTML forms are the primary mechanism for obtaining input from users of your app.
 
     .. code-block:: html+django
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos %}
 
         {% block app_content %}
@@ -508,7 +508,7 @@ b. Add a new template ``/templates/dam_inventory/list_dams.html`` with the follo
 
     .. code-block:: html+django
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos %}
 
         {% block app_content %}
@@ -565,9 +565,9 @@ d. Open ``/templates/dam_inventory/base.html`` and add navigation links for the 
         :emphasize-lines: 4, 7
 
         {% block app_navigation_items %}
-        {% url 'dam_inventory:home' as home_url %}
-        {% url 'dam_inventory:add_dam' as add_dam_url %}
-        {% url 'dam_inventory:dams' as list_dam_url %}
+        {% url tethys_app|url:'home' as home_url %}
+        {% url tethys_app|url:'add_dam' as add_dam_url %}
+        {% url tethys_app|url:'dams' as list_dam_url %}
         <li class="nav-item title">Navigation</li>
         <li class="nav-item"><a class="nav-link{% if request.path == home_url %} active{% endif %}" href="{{ home_url }}">Home</a></li>
         <li class="nav-item"><a class="nav-link{% if request.path == list_dam_url %} active{% endif %}" href="{{ list_dam_url }}">Dams</a></li>
@@ -585,7 +585,7 @@ a. Open ``/templates/dam_inventory/add_dam.html`` and add the ``location_input``
     .. code-block:: html+django
         :emphasize-lines: 8-12
 
-        {% extends "dam_inventory/base.html" %}
+        {% extends tethys_app.package|add:"/base.html" %}
         {% load tethys_gizmos %}
 
         {% block app_content %}

--- a/docs/tutorials/map_layout/add_spatial_data.rst
+++ b/docs/tutorials/map_layout/add_spatial_data.rst
@@ -42,12 +42,12 @@ Replace :file:`controller.py` with the following:
     from pathlib import Path
     from tethys_sdk.layouts import MapLayout
     from tethys_sdk.routing import controller
-    from .app import MapLayoutTutorial as app
+    from .app import App
 
 
     @controller(name="home", app_workspace=True)
     class MapLayoutTutorialMap(MapLayout):
-        app = app
+        app = App
         base_template = 'map_layout_tutorial/base.html'
         map_title = 'Map Layout Tutorial'
         map_subtitle = 'NOAA-OWP NextGen Model Outputs'
@@ -248,12 +248,12 @@ Replace your :file:`controllers.py` with the following:
     from pathlib import Path
     from tethys_sdk.layouts import MapLayout
     from tethys_sdk.routing import controller
-    from .app import MapLayoutTutorial as app
+    from .app import App
 
 
     @controller(name="home", app_workspace=True)
     class MapLayoutTutorialMap(MapLayout):
-        app = app
+        app = App
         base_template = 'map_layout_tutorial/base.html'
         map_title = 'Map Layout Tutorial'
         map_subtitle = 'NOAA-OWP NextGen Model Outputs'

--- a/docs/tutorials/map_layout/configure_data_plotting.rst
+++ b/docs/tutorials/map_layout/configure_data_plotting.rst
@@ -45,14 +45,14 @@ Replace :file:`controller.py` with the following:
     import pandas as pd
     from tethys_sdk.layouts import MapLayout
     from tethys_sdk.routing import controller
-    from .app import MapLayoutTutorial as app
+    from .app import App
 
 
     MODEL_OUTPUT_FOLDER_NAME = 'sample_nextgen_data'
 
     @controller(name="home", app_workspace=True)
     class MapLayoutTutorialMap(MapLayout):
-        app = app
+        app = App
         base_template = 'map_layout_tutorial/base.html'
         map_title = 'Map Layout Tutorial'
         map_subtitle = 'NOAA-OWP NextGen Model Outputs'

--- a/docs/tutorials/map_layout/configure_map_layout.rst
+++ b/docs/tutorials/map_layout/configure_map_layout.rst
@@ -33,13 +33,13 @@ This can be done by replacing the entire :file:`controller.py` with the followin
 
     from tethys_sdk.layouts import MapLayout
     from tethys_sdk.routing import controller
-    from .app import MapLayoutTutorial as app
+    from .app import App
 
 
     @controller(name="home", app_workspace=True)
     class MapLayoutTutorialMap(MapLayout):
-        app = app
-        base_template = 'map_layout_tutorial/base.html'
+        app = App
+        base_template = f'{App.package}/base.html'
         map_title = 'Map Layout Tutorial'
         map_subtitle = 'NOAA-OWP NextGen Model Outputs'
 

--- a/docs/tutorials/quotas.rst
+++ b/docs/tutorials/quotas.rst
@@ -98,7 +98,7 @@ a. Add the :ref:`user_workspace` argument to the ``controller`` decorator and a 
                         messages.info(request, 'Successfully assigned hydrograph.')
                     else:
                         messages.info(request, 'Unable to assign hydrograph. Please try again.')
-                    return redirect(reverse('dam_inventory:home'))
+                    return App.redirect(reverse('home'))
 
                 messages.error(request, "Please fix errors.")
 
@@ -348,7 +348,7 @@ a. Creating a custom quota is pretty simple. Create a new file called ``dam_quot
 
         from tethys_quotas.handlers.base import ResourceQuotaHandler
         from .model import Dam
-        from .app import DamInventory as app
+        from .app import App
 
 
         class DamQuotaHandler(ResourceQuotaHandler):
@@ -457,7 +457,7 @@ a. Create the ``delete_dam`` function in ``controllers.py``:
 
             messages.success(request, "{} Dam has been successfully deleted.".format(dam.name))
 
-            return redirect(reverse('dam_inventory:dams'))
+            return App.redirect(reverse('dams'))
 
 d. Refactor the ``list_dams`` controller to add a `Delete` button for each dam. The code will restrict user's to deleting only dams that they created.
 
@@ -475,14 +475,14 @@ d. Refactor the ``list_dams`` controller to add a `Delete` button for each dam. 
             for dam in dams:
                 hydrograph_id = get_hydrograph(dam.id)
                 if hydrograph_id:
-                    url = reverse('dam_inventory:hydrograph', kwargs={'hydrograph_id': hydrograph_id})
+                    url = App.reverse('hydrograph', kwargs={'hydrograph_id': hydrograph_id})
                     dam_hydrograph = format_html('<a class="btn btn-primary" href="{}">Hydrograph Plot</a>'.format(url))
                 else:
                     dam_hydrograph = format_html('<a class="btn btn-primary disabled" title="No hydrograph assigned" '
                                                  'style="pointer-events: auto;">Hydrograph Plot</a>')
 
                 if dam.user_id == request.user.id:
-                    url = reverse('dam_inventory:delete_dam', kwargs={'dam_id': dam.id})
+                    url = App.reverse('delete_dam', kwargs={'dam_id': dam.id})
                     dam_delete = format_html('<a class="btn btn-danger" href="{}">Delete Dam</a>'.format(url))
                 else:
                     dam_delete = format_html('<a class="btn btn-danger disabled" title="You are not the creator of this dam" '
@@ -509,7 +509,7 @@ d. Refactor the ``list_dams`` controller to add a `Delete` button for each dam. 
                 'can_add_dams': has_permission(request, 'add_dams')
             }
 
-            return render(request, 'dam_inventory/list_dams.html', context)
+            return App.render(request, 'list_dams.html', context)
 
 e. Test by deleting a dam or two (while logged in as the non-administrator) and trying to add new dams. This time you shouldn't be redirected to the error page, but should be able to add a dam like normal because you brought the number of dams created by the current user below the quota's default value.
 

--- a/docs/tutorials/quotas.rst
+++ b/docs/tutorials/quotas.rst
@@ -318,10 +318,10 @@ h. Finally, remove the permissions restrictions on adding dams so that any user 
     .. code-block:: html+django
 
         {% block app_navigation_items %}
-        {% url 'dam_inventory:home' as home_url %}
-        {% url 'dam_inventory:add_dam' as add_dam_url %}
-        {% url 'dam_inventory:dams' as list_dam_url %}
-        {% url 'dam_inventory:assign_hydrograph' as assign_hydrograph_url %}
+        {% url tethys_app|url:'home' as home_url %}
+        {% url tethys_app|url:'add_dam' as add_dam_url %}
+        {% url tethys_app|url:'dams' as list_dam_url %}
+        {% url tethys_app|url:'assign_hydrograph' as assign_hydrograph_url %}
         <li class="nav-item title">Navigation</li>
         <li class="nav-item"><a class="nav-link{% if request.path == home_url %} active{% endif %}" href="{{ home_url }}">Home</a></li>
         <li class="nav-item"><a class="nav-link{% if request.path == list_dam_url %} active{% endif %}" href="{{ list_dam_url }}">Dams</a></li>

--- a/docs/tutorials/thredds/plot_at_location.rst
+++ b/docs/tutorials/thredds/plot_at_location.rst
@@ -43,8 +43,8 @@ In this step you'll learn to use another Leaflet plugin: `Leaflet.Draw <http://l
        crossorigin=""/>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.min.css" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css"/>
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/leaflet_map.css' %}"/>
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/loader.css' %}" />
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/leaflet_map.css' %}"/>
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/loader.css' %}" />
     {% endblock %}
 
     {% block global_scripts %}
@@ -446,9 +446,9 @@ The `JQuery.load() <https://api.jquery.com/load/>`_ method is used to call a URL
        crossorigin=""/>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.min.css" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css"/>
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/leaflet_map.css' %}"/>
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/loader.css' %}" />
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/plot.css' %}" />
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/leaflet_map.css' %}"/>
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/loader.css' %}" />
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/plot.css' %}" />
     {% endblock %}
 
 4. Add a modal to :file:`templates/thredds_tutorial/home.html` for displaying the plot:
@@ -457,7 +457,7 @@ The `JQuery.load() <https://api.jquery.com/load/>`_ method is used to call a URL
 
     {% block after_app_content %}
       <div id="loader">
-        <img src="{% static 'thredds_tutorial/images/map-loader.gif' %}">
+        <img src="{% static tethys_app|public:'images/map-loader.gif' %}">
       </div>
       <!-- Plot Modal -->
       <div class="modal fade" id="plot-modal" tabindex="-1" role="dialog" aria-labelledby="plot-modal-label">

--- a/docs/tutorials/thredds/plot_at_location.rst
+++ b/docs/tutorials/thredds/plot_at_location.rst
@@ -390,13 +390,13 @@ In this step you will create a new controller that will query the dataset at the
             context['error'] = f'An unexpected error has occurred. Please try again.'
             log.exception('An unexpected error occurred.')
 
-        return render(request, 'thredds_tutorial/plot.html', context)
+        return App.render(request, 'plot.html', context)
 
 4. Create a new template for the ``get_time_series_plot`` controller, :file:`templates/thredds_tutorial/plot.html`, with the following contents:
 
 .. code-block:: html+django
 
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% if plot_view %}
       {% gizmo plot_view %}

--- a/docs/tutorials/thredds/visualize_leaflet.rst
+++ b/docs/tutorials/thredds/visualize_leaflet.rst
@@ -41,7 +41,7 @@ Leaflet is not officially supported by Tethys Platform as a Gizmo, but it can ea
 
 .. code-block:: html+django
 
-    {% extends "thredds_tutorial/base.html" %}
+    {% extends tethys_app.package|add:"/base.html" %}
     {% load tethys_gizmos %}
 
     {% block styles %}
@@ -169,15 +169,15 @@ Leaflet is not officially supported by Tethys Platform as a Gizmo, but it can ea
 
 .. code-block:: html+django
 
-    {% extends "thredds_tutorial/base.html" %}
-    {% load tethys_gizmos static %}
+    {% extends tethys_app.package|add:"/base.html" %}
+    {% load tethys_gizmos static tags %}
 
     {% block styles %}
       {{ block.super }}
       <link rel="stylesheet" href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css"
        integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ=="
        crossorigin=""/>
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/leaflet_map.css' %}"/>
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/leaflet_map.css' %}"/>
     {% endblock %}
 
     {% block global_scripts %}
@@ -189,7 +189,7 @@ Leaflet is not officially supported by Tethys Platform as a Gizmo, but it can ea
 
     {% block scripts %}
       {{ block.super }}
-      <script src="{% static 'thredds_tutorial/js/leaflet_map.js' %}" type="text/javascript"></script>
+      <script src="{% static tethys_app|public:'js/leaflet_map.js' %}" type="text/javascript"></script>
     {% endblock %}
 
 .. tip::
@@ -710,7 +710,7 @@ Many of the datasets hosted on THREDDS servers have time as a dimension. In this
        integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ=="
        crossorigin=""/>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.min.css" />
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/leaflet_map.css' %}"/>
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/leaflet_map.css' %}"/>
     {% endblock %}
 
     {% block global_scripts %}
@@ -947,15 +947,15 @@ Depending on the speed of the THREDDS server and the user's internet connection,
        integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ=="
        crossorigin=""/>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.1/dist/leaflet.timedimension.control.min.css" />
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/leaflet_map.css' %}"/>
-      <link rel="stylesheet" href="{% static 'thredds_tutorial/css/loader.css' %}" />
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/leaflet_map.css' %}"/>
+      <link rel="stylesheet" href="{% static tethys_app|public:'css/loader.css' %}" />
     {% endblock %}
 
 .. code-block:: html+django
 
     {% block after_app_content %}
       <div id="loader">
-        <img src="{% static 'thredds_tutorial/images/map-loader.gif' %}">
+        <img src="{% static tethys_app|public:'images/map-loader.gif' %}">
       </div>
     {% endblock %}
 

--- a/docs/tutorials/thredds/visualize_leaflet.rst
+++ b/docs/tutorials/thredds/visualize_leaflet.rst
@@ -42,7 +42,7 @@ Leaflet is not officially supported by Tethys Platform as a Gizmo, but it can ea
 .. code-block:: html+django
 
     {% extends tethys_app.package|add:"/base.html" %}
-    {% load tethys_gizmos %}
+    {% load tethys %}
 
     {% block styles %}
       {{ block.super }}
@@ -170,7 +170,7 @@ Leaflet is not officially supported by Tethys Platform as a Gizmo, but it can ea
 .. code-block:: html+django
 
     {% extends tethys_app.package|add:"/base.html" %}
-    {% load tethys_gizmos static tags %}
+    {% load static tethys %}
 
     {% block styles %}
       {{ block.super }}
@@ -214,7 +214,6 @@ In this step, you'll create controls to allow the user to search for and select 
 
 .. code-block:: python
 
-    from django.shortcuts import render
     from tethys_sdk.routing import controller
     from tethys_sdk.gizmos import SelectInput
 
@@ -266,7 +265,7 @@ In this step, you'll create controls to allow the user to search for and select 
             'variable_select': variable_select,
             'style_select': style_select,
         }
-        return render(request, 'thredds_tutorial/home.html', context)
+        return App.render(request, 'home.html', context)
 
 2. Add the controls to the ``app_navigation_items`` block in :file:`templates/thredds_tutorial/home.html`:
 
@@ -387,7 +386,7 @@ At this point the select controls are empty and don't do anything. In this step,
     from django.shortcuts import render
     from tethys_sdk.routing import controller
     from tethys_sdk.gizmos import SelectInput
-    from .app import ThreddsTutorial as app
+    from .app import App
     from .thredds_methods import parse_datasets
 
 .. code-block:: python
@@ -397,7 +396,7 @@ At this point the select controls are empty and don't do anything. In this step,
         """
         Controller for the app home page.
         """
-        catalog = app.get_spatial_dataset_service(app.THREDDS_SERVICE_NAME, as_engine=True)
+        catalog = App.get_spatial_dataset_service(app.THREDDS_SERVICE_NAME, as_engine=True)
 
         # Retrieve dataset options from the THREDDS service
         print('Retrieving Datasets...')
@@ -429,7 +428,7 @@ At this point the select controls are empty and don't do anything. In this step,
 
         from siphon.http_util import session_manager
         session_manager.set_session_options(verify=False)
-        catalog = app.get_spatial_dataset_service('my_thredds_service', as_engine=True)
+        catalog = App.get_spatial_dataset_service('my_thredds_service', as_engine=True)
 
     .. warning::
 

--- a/docs/tutorials/websockets.rst
+++ b/docs/tutorials/websockets.rst
@@ -259,6 +259,7 @@ b. Let's create a message box to display our notification when a new app is adde
     .. code-block:: python
 
         from tethys_sdk.gizmos import MessageBox
+        from .app import App
 
         ...
 
@@ -281,7 +282,7 @@ b. Let's create a message box to display our notification when a new app is adde
                 'can_add_dams': has_permission(request, 'add_dams')
             }
 
-            return render(request, 'dam_inventory/home.html', context)
+            return App.render(request, 'home.html', context)
 
         ...
 

--- a/docs/whats_new/app_migration.rst
+++ b/docs/whats_new/app_migration.rst
@@ -79,12 +79,12 @@ For example, the following controllers:
 .. code-block:: python
 
     from tethys_sdk.workspaces import app_workspace
-    from .app import MyFirstApp as app
+    from .app import App
 
 
     def controller_a(request):
         """Gets user workspace from old app class method."""
-        user_workspace = app.get_user_workspace(request.user)
+        user_workspace = App.get_user_workspace(request.user)
         uw_path = user_workspace.path
         ...
  

--- a/scripts/install_tethys.sh
+++ b/scripts/install_tethys.sh
@@ -371,7 +371,8 @@ then
           --set DATABASES.default.USER ${TETHYS_DB_SUPER_USERNAME} \
           --set DATABASES.default.PASSWORD ${TETHYS_DB_PASSWORD} \
           --set DATABASES.default.PORT ${TETHYS_DB_PORT} \
-          --set DATABASES.default.DIR ${TETHYS_DB_DIR}
+          --set DATABASES.default.DIR ${TETHYS_DB_DIR} \
+          --set DATABASES.default.ENGINE django.db.backends.postgresql
     fi
 
     if [ -n "${SETUP_DB}" ]

--- a/tests/apps/tethysapp-test_app/tethysapp/test_app/app.py
+++ b/tests/apps/tethysapp-test_app/tethysapp/test_app/app.py
@@ -14,7 +14,7 @@ from tethys_sdk.app_settings import (
 from tethys_sdk.handoff import HandoffHandler
 
 
-class TestApp(TethysAppBase):
+class App(TethysAppBase):
     """
     Tethys app class for Test App.
     """

--- a/tests/apps/tethysapp-test_app/tethysapp/test_app/app.py
+++ b/tests/apps/tethysapp-test_app/tethysapp/test_app/app.py
@@ -20,12 +20,12 @@ class TestApp(TethysAppBase):
     """
 
     name = "Test App"
+    description = "Place a brief description of your app here."
     index = "home"
-    icon = "test_app/images/icon.gif"
     package = "test_app"
+    icon = f"{package}/images/icon.gif"
     root_url = "test-app"
     color = "#2c3e50"
-    description = "Place a brief description of your app here."
     tags = ""
     enable_feedback = False
     feedback_emails = []

--- a/tests/apps/tethysapp-test_app/tethysapp/test_app/controllers.py
+++ b/tests/apps/tethysapp-test_app/tethysapp/test_app/controllers.py
@@ -1,6 +1,6 @@
 from tethys_sdk.routing import handler, consumer
 from tethys_sdk.gizmos import Button
-from .app import TestApp as app
+from .app import App
 
 from channels.generic.websocket import WebsocketConsumer
 import json
@@ -72,7 +72,7 @@ def home_controller(request):
         "script": script,
     }
 
-    return app.render(request, "home.html", context)
+    return App.render(request, "home.html", context)
 
 
 @handler(

--- a/tests/apps/tethysapp-test_app/tethysapp/test_app/controllers.py
+++ b/tests/apps/tethysapp-test_app/tethysapp/test_app/controllers.py
@@ -1,6 +1,6 @@
-from django.shortcuts import render
 from tethys_sdk.routing import handler, consumer
 from tethys_sdk.gizmos import Button
+from .app import TestApp as app
 
 from channels.generic.websocket import WebsocketConsumer
 import json
@@ -72,7 +72,7 @@ def home_controller(request):
         "script": script,
     }
 
-    return render(request, "test_app/home.html", context)
+    return app.render(request, "home.html", context)
 
 
 @handler(

--- a/tests/apps/tethysapp-test_app/tethysapp/test_app/templates/test_app/home.html
+++ b/tests/apps/tethysapp-test_app/tethysapp/test_app/templates/test_app/home.html
@@ -1,5 +1,5 @@
-{% extends "test_app/base.html" %}
-{% load tethys_gizmos %}
+{% extends tethys_app.package|add:"/base.html" %}
+{% load tethys %}
 
 {% block header_buttons %}
   <div class="header-button glyphicon-button" data-toggle="tooltip" data-placement="bottom" title="Help">

--- a/tests/extensions/tethysext-test_extension/tethysext/test_extension/controllers.py
+++ b/tests/extensions/tethysext-test_extension/tethysext/test_extension/controllers.py
@@ -1,5 +1,5 @@
-from django.shortcuts import render
 from tethys_sdk.routing import controller
+from .ext import Extension
 
 
 @controller(
@@ -14,4 +14,4 @@ def home(request, var1, var2):
         "var2": var2,
     }
 
-    return render(request, "test_extension/home.html", context)
+    return Extension.render(request, "home.html", context)

--- a/tests/extensions/tethysext-test_extension/tethysext/test_extension/ext.py
+++ b/tests/extensions/tethysext-test_extension/tethysext/test_extension/ext.py
@@ -1,7 +1,7 @@
 from tethys_sdk.base import TethysExtensionBase
 
 
-class TestExtension(TethysExtensionBase):
+class Extension(TethysExtensionBase):
     """
     Tethys extension class for Test Extension.
     """

--- a/tests/unit_tests/test_tethys_apps/test_base/test_app_base.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_app_base.py
@@ -409,6 +409,13 @@ class TestTethysBase(unittest.TestCase):
             mock_reverse.call_args.args, (f"{TethysBaseChild.package}:test",)
         )
 
+    @mock.patch("tethys_apps.base.app_base.render_to_string")
+    def test_render_to_string(self, mock_render):
+        TethysBaseChild.render_to_string("test")
+        self.assertEqual(
+            mock_render.call_args.args, (f"{TethysBaseChild.package}/test",)
+        )
+
 
 class TestTethysExtensionBase(unittest.TestCase):
     def setUp(self):

--- a/tests/unit_tests/test_tethys_apps/test_harvester.py
+++ b/tests/unit_tests/test_tethys_apps/test_harvester.py
@@ -226,7 +226,7 @@ class HarvesterTest(unittest.TestCase):
     @mock.patch("sys.stdout", new_callable=io.StringIO)
     @mock.patch("tethys_apps.harvester.tethys_log.exception")
     @mock.patch(
-        "tethysapp.test_app.app.TestApp.registered_url_maps",
+        "tethysapp.test_app.app.App.registered_url_maps",
         new_callable=mock.PropertyMock,
     )
     def test_harvest_app_instances_load_url_patterns_exception(
@@ -254,7 +254,7 @@ class HarvesterTest(unittest.TestCase):
     @mock.patch("sys.stdout", new_callable=io.StringIO)
     @mock.patch("tethys_apps.harvester.tethys_log.exception")
     @mock.patch(
-        "tethysapp.test_app.app.TestApp.registered_url_maps",
+        "tethysapp.test_app.app.App.registered_url_maps",
         new_callable=mock.PropertyMock,
     )
     def test_harvest_app_instances_load_handler_patterns_exception(
@@ -282,7 +282,7 @@ class HarvesterTest(unittest.TestCase):
 
     @mock.patch("sys.stdout", new_callable=io.StringIO)
     @mock.patch("tethys_apps.harvester.tethys_log.warning")
-    @mock.patch("tethysapp.test_app.app.TestApp.register_app_permissions")
+    @mock.patch("tethysapp.test_app.app.App.register_app_permissions")
     def test_harvest_app_instances_programming_error(
         self, mock_permissions, mock_logwarning, mock_stdout
     ):
@@ -309,7 +309,7 @@ class HarvesterTest(unittest.TestCase):
 
     @mock.patch("sys.stdout", new_callable=io.StringIO)
     @mock.patch("tethys_apps.harvester.tethys_log.warning")
-    @mock.patch("tethysapp.test_app.app.TestApp.register_app_permissions")
+    @mock.patch("tethysapp.test_app.app.App.register_app_permissions")
     def test_harvest_app_instances_object_does_not_exist(
         self, mock_permissions, mock_logwarning, mock_stdout
     ):

--- a/tests/unit_tests/test_tethys_apps/test_templatetags/test_tags.py
+++ b/tests/unit_tests/test_tethys_apps/test_templatetags/test_tags.py
@@ -78,3 +78,15 @@ class TestTags(unittest.TestCase):
         )
         ret_tag_list = t.get_tags_from_apps(self.mock_dict_apps)
         self.assertNotIn("disabled", ret_tag_list)
+
+    def test_url(self):
+        app = {"package": "test"}
+        controller_name = "controller"
+        ret = t.url(app, controller_name)
+        self.assertEqual(ret, f"{app['package']}:{controller_name}")
+
+    def test_public(self):
+        app = {"package": "test"}
+        static_path = "path/to/static"
+        ret = t.public(app, static_path)
+        self.assertEqual(ret, f"{app['package']}/{static_path}")

--- a/tests/unit_tests/test_tethys_apps/test_utilities.py
+++ b/tests/unit_tests/test_tethys_apps/test_utilities.py
@@ -767,14 +767,14 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
     @mock.patch("tethys_apps.utilities.SingletonHarvester")
     def test_get_app_class(self, mock_harvester):
         """"""
-        from tethysapp.test_app.app import TestApp
+        from tethysapp.test_app.app import App
 
-        test_app = TestApp()
+        test_app = App()
         mock_harvester().apps = [test_app]
 
         mock_db_app = mock.MagicMock()
-        mock_db_app.name = TestApp.name  # This should match the name of TestApp
-        mock_db_app.package = "test_app"  # This should match the package of TestApp
+        mock_db_app.name = App.name  # This should match the name of App
+        mock_db_app.package = App.package  # This should match the package of App
 
         ret = utilities.get_app_class(mock_db_app)
 
@@ -784,14 +784,14 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
     @mock.patch("tethys_apps.utilities.SingletonHarvester")
     def test_get_app_class__different_name(self, mock_harvester):
         """Test case when user changes name of app in DB (from app settings)."""
-        from tethysapp.test_app.app import TestApp
+        from tethysapp.test_app.app import App
 
-        test_app = TestApp()
+        test_app = App()
         mock_harvester().apps = [test_app]
 
         mock_db_app = mock.MagicMock()
-        mock_db_app.name = "Different Name"  # This shouldn't match the name of TestApp
-        mock_db_app.package = "test_app"  # This should match the package of TestApp
+        mock_db_app.name = "Different Name"  # This shouldn't match the name of App
+        mock_db_app.package = "test_app"  # This should match the package of App
 
         ret = utilities.get_app_class(mock_db_app)
 
@@ -801,14 +801,14 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
     @mock.patch("tethys_apps.utilities.SingletonHarvester")
     def test_get_app_class__no_matching_class(self, mock_harvester):
         """Test case when no app class can be found for the app."""
-        from tethysapp.test_app.app import TestApp
+        from tethysapp.test_app.app import App
 
-        mock_harvester().apps = [TestApp()]
+        mock_harvester().apps = [App()]
 
         mock_db_app = mock.MagicMock()
-        mock_db_app.name = TestApp.name  # This should match the name of TestApp
+        mock_db_app.name = App.name  # This should match the name of App
         mock_db_app.package = (
-            "does_not_exist"  # This shouldn't match the package of TestApp
+            "does_not_exist"  # This shouldn't match the package of App
         )
 
         ret = utilities.get_app_class(mock_db_app)

--- a/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmos/test_jobs_table.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmos/test_jobs_table.py
@@ -33,7 +33,7 @@ class TestJobsTable(unittest.TestCase):
 
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_execute_exception(self, mock_tj, mock_log):
         tj = mock_tj.objects.get_subclass()
@@ -56,7 +56,7 @@ class TestJobsTable(unittest.TestCase):
 
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_terminate_exception(self, mock_tj, mock_log):
         tj = mock_tj.objects.get_subclass()
@@ -77,7 +77,7 @@ class TestJobsTable(unittest.TestCase):
 
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_delete_exception(self, mock_tj, mock_log):
         tj = mock_tj.objects.get_subclass()
@@ -98,7 +98,7 @@ class TestJobsTable(unittest.TestCase):
 
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_resubmit_exception(self, mock_tj, mock_log):
         tj = mock_tj.objects.get_subclass()
@@ -120,7 +120,7 @@ class TestJobsTable(unittest.TestCase):
         result = gizmo_jobs_table.show_log(request="", job_id="1")
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_show_log_exception(self, mock_tj, mock_log):
         tj = mock_tj.objects.get_subclass()
@@ -156,7 +156,7 @@ class TestJobsTable(unittest.TestCase):
         )
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_get_log_content_exception(self, mock_tj, mock_log):
         tj = mock_tj.objects.get_subclass()
@@ -330,7 +330,7 @@ class TestJobsTable(unittest.TestCase):
         self.assertEqual("Submitted", rts_call_args[0][0][1]["job_status"])
         self.assertEqual(200, result.status_code)
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_update_row_exception(self, mock_tj, mock_log):
         mock_tj.objects.get_subclass.side_effect = Exception("error")
@@ -466,7 +466,7 @@ class TestJobsTable(unittest.TestCase):
             data["dag"],
         )
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_update_workflow_nodes_row_exception(self, mock_tj, mock_log):
         mock_tj.objects.get_subclass.side_effect = Exception
@@ -508,7 +508,7 @@ class TestJobsTable(unittest.TestCase):
         self.assertIn('"html": "test_html"', ret.content.decode("utf-8"))
         mock_bokeh.assert_called_with("http://test_dashboard/individual-graph")
 
-    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.log")
+    @mock.patch("tethys_gizmos.views.gizmos.jobs_table.logger")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.server_document")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.DaskScheduler")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")

--- a/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmos/test_jobs_table.py
+++ b/tests/unit_tests/test_tethys_gizmos/test_views/test_gizmos/test_jobs_table.py
@@ -176,7 +176,7 @@ class TestJobsTable(unittest.TestCase):
     def test_update_row_showcase(self, mock_tj, mock_rts):
         mock_rts.return_value = '{"job_statuses":[]}'
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
-            spec=TethysJob, status="Various", label="gizmos_showcase"
+            spec=TethysJob, status="Various", label="gizmo_showcase"
         )
         rows = [("1", "30")]
         request = RequestFactory().post(
@@ -199,7 +199,7 @@ class TestJobsTable(unittest.TestCase):
     def test_update_row_showcase_various_complete(self, mock_tj, mock_rts):
         mock_rts.return_value = '{"job_statuses":[]}'
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
-            spec=TethysJob, status="Various-Complete", label="gizmos_showcase"
+            spec=TethysJob, status="Various-Complete", label="gizmo_showcase"
         )
         rows = [("1", "30")]
         request = RequestFactory().post(
@@ -222,7 +222,7 @@ class TestJobsTable(unittest.TestCase):
     def test_update_row_showcase_condor_workflow(self, mock_tj, mock_rts):
         mock_rts.return_value = '{"job_statuses":[]}'
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
-            spec=CondorWorkflow, status="Various", label="gizmos_showcase"
+            spec=CondorWorkflow, status="Various", label="gizmo_showcase"
         )
         rows = [("1", "30")]
         request = RequestFactory().post(
@@ -243,7 +243,7 @@ class TestJobsTable(unittest.TestCase):
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.render_to_string")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_update_row(self, mock_tj, mock_rts):
-        # Another Case where job.label is not gizmos_showcase
+        # Another Case where job.label is not gizmo_showcase
         mock_rts.return_value = '{"job_statuses":[]}'
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
             spec=CondorWorkflow,
@@ -283,7 +283,7 @@ class TestJobsTable(unittest.TestCase):
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.render_to_string")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_update_row_dask_job_results_ready(self, mock_tj, mock_rts):
-        # Another Case where job.label is not gizmos_showcase
+        # Another Case where job.label is not gizmo_showcase
         mock_rts.return_value = '{"job_statuses":[]}'
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
             spec=DaskJob,
@@ -304,7 +304,7 @@ class TestJobsTable(unittest.TestCase):
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.render_to_string")
     @mock.patch("tethys_gizmos.views.gizmos.jobs_table.TethysJob")
     def test_update_row_condor_workflow_no_statuses(self, mock_tj, mock_rts):
-        # Another Case where job.label is not gizmos_showcase
+        # Another Case where job.label is not gizmo_showcase
         mock_rts.return_value = '{"job_statuses":[]}'
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
             spec=CondorWorkflow,
@@ -411,7 +411,7 @@ class TestJobsTable(unittest.TestCase):
         mock_tj.objects.get_subclass.return_value = mock.MagicMock(
             spec=CondorWorkflow,
             status="Various",
-            label="gizmos_showcase",
+            label="gizmo_showcase",
         )
 
         request = RequestFactory().post("/jobs")

--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -341,7 +341,7 @@ class TethysBase(TethysBaseMixin):
             .. code-block:: python
 
                 # controllers.py
-                from .app import MyFirstApp as app  # note importing the TethysBaseApp object as ``app`` is a convention
+                from .app import App
 
                 @controller
                 def home(request):
@@ -351,7 +351,7 @@ class TethysBase(TethysBaseMixin):
 
                     context = {}
 
-                    return app.render(request, 'home.html', context)
+                    return App.render(request, 'home.html', context)
         """
         return render(
             request,
@@ -372,7 +372,7 @@ class TethysBase(TethysBaseMixin):
             .. code-block:: python
 
                 # controllers.py
-                from .app import MyFirstApp as app  # note importing the TethysBaseApp object as ``app`` is a convention
+                from .app import App
 
                 @controller
                 def do_something_and_redirect_home(request):
@@ -380,7 +380,7 @@ class TethysBase(TethysBaseMixin):
                     Controller to do something before redirecting to the app homepage.
                     \"""
 
-                    return app.redirect(app.reverse("jobs_table"))
+                    return App.redirect(App.reverse("jobs_table"))
 
         """
         to = to if to.startswith("/") else f"{cls.package}:{to}"
@@ -397,7 +397,7 @@ class TethysBase(TethysBaseMixin):
 
                 # controllers.py
                 from tethys_sdk.gizmos import Button
-                from .app import MyFirstApp as app  # note importing the TethysBaseApp object as ``app`` is a convention
+                from .app import App
 
                 @controller
                 def home(request):
@@ -408,12 +408,12 @@ class TethysBase(TethysBaseMixin):
                     cancel_button = Button(
                         display_text='Cancel',
                         name='cancel-button',
-                        href=app.reverse('home')
+                        href=App.reverse('home')
                     )
 
                     context = {'cancel_button': cancel_button}
 
-                    return app.render(request, 'home.html', context)
+                    return App.render(request, 'home.html', context)
         """
         return reverse(
             f"{cls.package}:{viewname}",
@@ -1049,11 +1049,11 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
             @controller
             def my_controller(request):
-                user_workspace = app.get_user_workspace(request.user)
+                user_workspace = App.get_user_workspace(request.user)
                 ...
         """  # noqa: E501
         return get_user_workspace(cls, user_or_request)
@@ -1073,11 +1073,11 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
             @controller
             def my_controller(request):
-                app_workspace = app.get_app_workspace()
+                app_workspace = App.get_app_workspace()
                 ...
         """
         return get_app_workspace(cls)
@@ -1097,10 +1097,10 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
             scheduler = app.get_scheduler('primary_condor')
-            job_manager = app.get_job_manager()
+            job_manager = App.get_job_manager()
             job_manager.create_job(
                 name='do_the_thing',
                 job_type='CONDORJOB',
@@ -1137,9 +1137,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            max_count = app.get_custom_setting('max_count')
+            max_count = App.get_custom_setting('max_count')
 
         """
         from tethys_apps.models import TethysApp
@@ -1166,9 +1166,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            max_count = app.set_custom_setting('max_count', 5)
+            max_count = App.set_custom_setting('max_count', 5)
 
         """
         from tethys_apps.models import TethysApp
@@ -1248,9 +1248,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            ckan_engine = app.get_dataset_service('primary_ckan', as_engine=True)
+            ckan_engine = App.get_dataset_service('primary_ckan', as_engine=True)
 
         """
         from tethys_apps.models import TethysApp
@@ -1297,9 +1297,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            geoserver_engine = app.get_spatial_dataset_service('primary_geoserver', as_engine=True)
+            geoserver_engine = App.get_spatial_dataset_service('primary_geoserver', as_engine=True)
 
 
         """
@@ -1345,9 +1345,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            wps_engine = app.get_web_processing_service('primary_52n')
+            wps_engine = App.get_web_processing_service('primary_52n')
 
         """
         from tethys_apps.models import TethysApp
@@ -1384,11 +1384,11 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            conn_engine = app.get_persistent_store_connection('primary')
-            conn_url = app.get_persistent_store_connection('primary', as_url=True)
-            SessionMaker = app.get_persistent_store_database('primary', as_sessionmaker=True)
+            conn_engine = App.get_persistent_store_connection('primary')
+            conn_url = App.get_persistent_store_connection('primary', as_url=True)
+            SessionMaker = App.get_persistent_store_database('primary', as_sessionmaker=True)
             session = SessionMaker()
 
         """
@@ -1430,11 +1430,11 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            db_engine = app.get_persistent_store_database('example_db')
-            db_url = app.get_persistent_store_database('example_db', as_url=True)
-            SessionMaker = app.get_persistent_store_database('example_db', as_sessionmaker=True)
+            db_engine = App.get_persistent_store_database('example_db')
+            db_url = App.get_persistent_store_database('example_db', as_url=True)
+            SessionMaker = App.get_persistent_store_database('example_db', as_sessionmaker=True)
             session = SessionMaker()
 
         """
@@ -1493,12 +1493,12 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            result = app.create_persistent_store('example_db', 'primary')
+            result = App.create_persistent_store('example_db', 'primary')
 
             if result:
-                engine = app.get_persistent_store_engine('example_db')
+                engine = App.get_persistent_store_engine('example_db')
 
         """  # noqa: E501
         # Get named persistent store service connection
@@ -1589,9 +1589,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            result = app.drop_persistent_store('example_db')
+            result = App.drop_persistent_store('example_db')
 
             if result:
                 # App database 'example_db' was successfully destroyed and no longer exists
@@ -1634,9 +1634,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            ps_databases = app.list_persistent_store_databases()
+            ps_databases = App.list_persistent_store_databases()
 
         """
         from tethys_apps.models import TethysApp
@@ -1671,9 +1671,9 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            ps_connections = app.list_persistent_store_connections()
+            ps_connections = App.list_persistent_store_connections()
 
         """
         from tethys_apps.models import TethysApp
@@ -1702,12 +1702,12 @@ class TethysAppBase(TethysBase):
 
         ::
 
-            from .app import MyFirstApp as app
+            from .app import App
 
-            result = app.persistent_store_exists('example_db')
+            result = App.persistent_store_exists('example_db')
 
             if result:
-                engine = app.get_persistent_store_engine('example_db')
+                engine = App.get_persistent_store_engine('example_db')
 
         """
         from tethys_apps.models import TethysApp

--- a/tethys_apps/base/app_base.py
+++ b/tethys_apps/base/app_base.py
@@ -15,6 +15,7 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.urls import re_path
 from django.utils.functional import classproperty
 from django.shortcuts import render, redirect, reverse
+from django.template.loader import render_to_string
 
 from .testing.environment import (
     is_testing_environment,
@@ -421,6 +422,42 @@ class TethysBase(TethysBaseMixin):
             args=args,
             kwargs=kwargs,
             current_app=current_app,
+        )
+
+    @classmethod
+    def render_to_string(cls, template_name, context=None, request=None, using=None):
+        """Shortcut for Django render_to_string function with app package inserted.
+
+        Usage:
+            Use in place of the ``django.template.loader.render_to_string`` function to avoid hard-coding the namespace for the Tethys app/extension
+
+             .. code-block:: python
+
+                # controllers.py
+                from tethys_sdk.gizmos import Button
+                from .app import App
+
+                @controller
+                def home(request):
+                    \"""
+                    Controller for the app home page.
+                    \"""
+
+                    cancel_button = Button(
+                        display_text='Cancel',
+                        name='cancel-button',
+                        href=App.reverse('home')
+                    )
+
+                    context = {'cancel_button': cancel_button}
+
+                    html = App.render_to_string('home.html', context)
+        """
+        return render_to_string(
+            f"{cls.package}/{template_name}",
+            context=context,
+            request=request,
+            using=using,
         )
 
 

--- a/tethys_apps/base/controller.py
+++ b/tethys_apps/base/controller.py
@@ -457,7 +457,7 @@ def handler(
         ------------
 
         from bokeh.embed import server_document
-        from django.shortcuts import render
+        from .app import App
 
         def home_controller(request):
             # custom logic here
@@ -468,7 +468,7 @@ def handler(
                 'script': script,
                 'custom_key': custom_value,
             }
-            return render(request, 'my_app/home.html', context)
+            return App.render(request, 'home.html', context)
 
         @handler(
             name='home',

--- a/tethys_apps/base/workspace.py
+++ b/tethys_apps/base/workspace.py
@@ -288,10 +288,10 @@ def get_user_workspace(app_class_or_request, user_or_request) -> TethysWorkspace
 
         import os
         from tethys_sdk.workspaces import get_user_workspace
-        from .app import MyFirstApp as app
+        from .app import App
 
         def some_function(user):
-            user_workspace = get_user_workspace(app, user)
+            user_workspace = get_user_workspace(App, user)
             ...
     """  # noqa: E501
     from tethys_apps.base.app_base import TethysAppBase
@@ -342,7 +342,7 @@ def user_workspace(controller):
     ::
 
         import os
-        from my_first_app.app import MyFirstApp as app
+        from .app import App
         from tethys_sdk.workspaces import user_workspace
 
         @user_workspace
@@ -357,7 +357,7 @@ def user_workspace(controller):
 
             context = {}
 
-            return render(request, 'my_first_app/template.html', context)
+            return App.render(request, 'template.html', context)
 
     """  # noqa:E501
 
@@ -416,10 +416,10 @@ def get_app_workspace(app_or_request) -> TethysWorkspace:
 
         import os
         from tethys_sdk.workspaces import get_app_workspace
-        from .app import MyFirstApp as app
+        from .app import App
 
         def some_function():
-            app_workspace = get_app_workspace(app)
+            app_workspace = get_app_workspace(App)
             ...
     """
     from tethys_apps.base.app_base import TethysAppBase
@@ -455,7 +455,7 @@ def app_workspace(controller):
     ::
 
         import os
-        from my_first_app.app import MyFirstApp as app
+        from .app import App
         from tethys_sdk.workspaces import app_workspace
 
         @app_workspace
@@ -470,7 +470,7 @@ def app_workspace(controller):
 
             context = {}
 
-            return render(request, 'my_first_app/template.html', context)
+            return App.render(request, 'template.html', context)
 
     """  # noqa:E501
 

--- a/tethys_apps/context_processors.py
+++ b/tethys_apps/context_processors.py
@@ -29,6 +29,7 @@ def tethys_apps_context(request):
         context["tethys_app"] = {
             "id": app.id,
             "name": app.name,
+            "package": app.package,
             "index": app.index,
             "icon": app.icon,
             "color": app.color,

--- a/tethys_apps/templates/tethys_apps/app_base.html
+++ b/tethys_apps/templates/tethys_apps/app_base.html
@@ -1,4 +1,4 @@
-{% load static app_theme tethys_gizmos %}
+{% load static tethys %}
 <!DOCTYPE html>
 
 {# Allows custom attributes to be added to the html tag #}

--- a/tethys_apps/templates/tethys_apps/app_card.html
+++ b/tethys_apps/templates/tethys_apps/app_card.html
@@ -1,4 +1,4 @@
-{% load static tags site_settings %}
+{% load static tethys %}
 <div class="app-card-container position-relative" data-tags="{{ app|get_tag_class }}">
     {% if not unconfigured %}
     <a class="app-link-wrapper rounded d-block mt-4 {% if not app.show_in_apps_library or not app.enabled %} veiled{% endif %}"

--- a/tethys_apps/templates/tethys_apps/app_content_only.html
+++ b/tethys_apps/templates/tethys_apps/app_content_only.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_base.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block app_base_styles %}
   <link href="{% static 'tethys_apps/css/app_content_only.css' %}" rel="stylesheet" />

--- a/tethys_apps/templates/tethys_apps/app_header_content.html
+++ b/tethys_apps/templates/tethys_apps/app_header_content.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_no_actions.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block styles %}
   {{ block.super }}

--- a/tethys_apps/templates/tethys_apps/app_left_actions.html
+++ b/tethys_apps/templates/tethys_apps/app_left_actions.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_right_actions.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block styles %}
   {{ block.super }}

--- a/tethys_apps/templates/tethys_apps/app_library.html
+++ b/tethys_apps/templates/tethys_apps/app_library.html
@@ -1,7 +1,6 @@
-
 {% extends "base.html" %}
 
-{% load static tags site_settings %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - {% if site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}{% endblock %}
 

--- a/tethys_apps/templates/tethys_apps/app_no_actions.html
+++ b/tethys_apps/templates/tethys_apps/app_no_actions.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_base.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block styles %}
   {{ block.super }}

--- a/tethys_apps/templates/tethys_apps/app_no_nav.html
+++ b/tethys_apps/templates/tethys_apps/app_no_nav.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_base.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block styles %}
   {{ block.super }}

--- a/tethys_apps/templates/tethys_apps/app_quad_split.html
+++ b/tethys_apps/templates/tethys_apps/app_quad_split.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_header_content.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block inner_app_content %}
 	<div id="inner-app-content" class="container-fluid">

--- a/tethys_apps/templates/tethys_apps/app_right_actions.html
+++ b/tethys_apps/templates/tethys_apps/app_right_actions.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_base.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block styles %}
   {{ block.super }}

--- a/tethys_apps/templates/tethys_apps/app_three_columns.html
+++ b/tethys_apps/templates/tethys_apps/app_three_columns.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_header_content.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block inner_app_content %}
 <div id="inner-app-content" class="container-fluid">

--- a/tethys_apps/templates/tethys_apps/app_two_columns.html
+++ b/tethys_apps/templates/tethys_apps/app_two_columns.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_header_content.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block inner_app_content %}
   <div id="inner-app-content" class="container-fluid">

--- a/tethys_apps/templatetags/app_theme.py
+++ b/tethys_apps/templatetags/app_theme.py
@@ -17,6 +17,15 @@ def lighten(hex_color, percentage):
 
     Returns: A hex color value in the format "#2d3436"
 
+    Usage:
+        Be sure to include the ``app_theme`` argument to the ``load`` template tag.
+
+        .. code-block:: html+django
+
+            {% loads app_theme %}
+
+            {{ tethys_app.color|lighten:20 }}
+
     """
     if not re.search(hex_regex_pattern, hex_color):
         raise ValueError(

--- a/tethys_apps/templatetags/app_theme.py
+++ b/tethys_apps/templatetags/app_theme.py
@@ -18,11 +18,11 @@ def lighten(hex_color, percentage):
     Returns: A hex color value in the format "#2d3436"
 
     Usage:
-        Be sure to include the ``app_theme`` argument to the ``load`` template tag.
+        Be sure to include the ``tethys`` argument to the ``load`` template tag.
 
         .. code-block:: html+django
 
-            {% loads app_theme %}
+            {% loads tethys %}
 
             {{ tethys_app.color|lighten:20 }}
 

--- a/tethys_apps/templatetags/humanize.py
+++ b/tethys_apps/templatetags/humanize.py
@@ -35,9 +35,13 @@ def human_duration(iso_duration_str):
         str: humanized string representing the amount of time from now (e.g.: "in 30 minutes").
 
     Usage:
-        {% load static humanize %}
+        Be sure to include the ``humanize`` argument to the ``load`` template tag.
 
-        {{ P1DT3H6M|human_duration }}
+        .. code-block:: html+django
+
+            {% load static humanize %}
+
+            {{ P1DT3H6M|human_duration }}
     """
     time_change = isodate.parse_duration(iso_duration_str)
     now = arrow.utcnow()

--- a/tethys_apps/templatetags/humanize.py
+++ b/tethys_apps/templatetags/humanize.py
@@ -35,11 +35,11 @@ def human_duration(iso_duration_str):
         str: humanized string representing the amount of time from now (e.g.: "in 30 minutes").
 
     Usage:
-        Be sure to include the ``humanize`` argument to the ``load`` template tag.
+        Be sure to include the ``tethys`` argument to the ``load`` template tag.
 
         .. code-block:: html+django
 
-            {% load static humanize %}
+            {% load tethys %}
 
             {{ P1DT3H6M|human_duration }}
     """

--- a/tethys_apps/templatetags/tags.py
+++ b/tethys_apps/templatetags/tags.py
@@ -83,11 +83,11 @@ def url(app, controller_name):
         str: A controller name with the namespace from the active Tethys app prepended
 
     Usage:
-        Be sure to include the ``tags`` argument to the ``load`` template tag.
+        Be sure to include the ``tethys`` argument to the ``load`` template tag.
 
         .. code-block:: html+django
 
-            {% load tags %}
+            {% load tethys %}
 
             {% url tethys_app|url:'home' %}
 
@@ -98,7 +98,7 @@ def url(app, controller_name):
 
         .. code-block:: html+django
 
-            {% load tags %}
+            {% load tethys %}
 
             {% url tethys_app|url:'home' %}
 
@@ -126,11 +126,11 @@ def public(app, static_path):
         str: The path to the static file with the active Tethys app's namespace prepended
 
     Usage:
-        Be sure to include the ``tags`` argument to the ``load`` template tag.
+        Be sure to include the ``tethys`` argument to the ``load`` template tag.
 
         .. code-block:: html+django
 
-            {% load tags %}
+            {% load static tethys %}
 
             {% static tethys_app|public:'css/main.css' %}
 
@@ -141,13 +141,15 @@ def public(app, static_path):
 
         .. code-block:: html+django
 
-            {% load tags %}
+            {% load static tethys %}
 
             {% static tethys_app|public:'css/main.css' %}
 
         Equivalent (but not recommended):
 
         .. code-block:: html+django
+
+            {% load static %}
 
             {% static 'my_first_app/css/main.css' %}
 

--- a/tethys_apps/templatetags/tags.py
+++ b/tethys_apps/templatetags/tags.py
@@ -68,3 +68,89 @@ def get_tag_class(app):
     # Join tags into a single space delimited string
     tags_list = " ".join(tags)
     return tags_list
+
+
+@register.filter
+def url(app, controller_name):
+    """
+    A shortcut to add the active Tethys app namespace to a controller name.
+
+    Args:
+        app: the active Tethys app loaded in the context
+        controller_name: the name of the controller from the active Tethys app to get the URL for
+
+    Returns:
+        str: A controller name with the namespace from the active Tethys app prepended
+
+    Usage:
+        Be sure to include the ``tags`` argument to the ``load`` template tag.
+
+        .. code-block:: html+django
+
+            {% load tags %}
+
+            {% url tethys_app|url:'home' %}
+
+    Note:
+        This filter allows you to avoid having the app package hardcoded in your templates. If the active app package is ``my_first_app``, then the following would be equivalent:
+
+        Recommended Usage:
+
+        .. code-block:: html+django
+
+            {% load tags %}
+
+            {% url tethys_app|url:'home' %}
+
+        Equivalent (but not recommended):
+
+        .. code-block:: html+django
+
+            {% url 'my_first_app:home' %}
+
+    """
+    app_package = app["package"] if isinstance(app, dict) else app.package
+    return f"{app_package}:{controller_name}"
+
+
+@register.filter
+def public(app, static_path):
+    """
+    Add the active Tethys app namespace to a public filepath.
+
+    Args:
+        app: the active Tethys app loaded in the context
+        static_path: the relative path to a static file in the active Tethys app's ``public`` directory
+
+    Returns:
+        str: The path to the static file with the active Tethys app's namespace prepended
+
+    Usage:
+        Be sure to include the ``tags`` argument to the ``load`` template tag.
+
+        .. code-block:: html+django
+
+            {% load tags %}
+
+            {% static tethys_app|public:'css/main.css' %}
+
+    Note:
+        This filter allows you to avoid having the app package hardcoded in your templates. If the active app package is ``my_first_app``, then the following would be equivalent:
+
+        Recommended Usage:
+
+        .. code-block:: html+django
+
+            {% load tags %}
+
+            {% static tethys_app|public:'css/main.css' %}
+
+        Equivalent (but not recommended):
+
+        .. code-block:: html+django
+
+            {% static 'my_first_app/css/main.css' %}
+
+    """
+    app_package = app["package"] if isinstance(app, dict) else app.package
+    return f"{app_package}/{static_path}"

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -47,7 +47,6 @@ handler_url_patterns = harvester.get_handler_patterns(url_namespaces=url_namespa
 # configure handler HTTP routes
 http_handler_patterns = []
 for namespace, urls in handler_url_patterns["http_handler_patterns"].items():
-
     if settings.MULTIPLE_APP_MODE:
         root_pattern = f'apps/{namespace.replace("_", "-")}/'
     else:

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/app.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/app.py_tmpl
@@ -1,7 +1,7 @@
 from tethys_sdk.base import TethysAppBase
 
 
-class {{class_name}}(TethysAppBase):
+class App(TethysAppBase):
     """
     Tethys app class for {{proper_name}}.
     """

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/controllers.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/controllers.py_tmpl
@@ -1,6 +1,6 @@
-from django.shortcuts import render
 from tethys_sdk.routing import controller
 from tethys_sdk.gizmos import Button
+from .app import {{class_name}} as app
 
 @controller
 def home(request):
@@ -71,4 +71,4 @@ def home(request):
         'next_button': next_button
     }
 
-    return render(request, '{{project}}/home.html', context)
+    return app.render(request, 'home.html', context)

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/controllers.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/controllers.py_tmpl
@@ -1,6 +1,6 @@
 from tethys_sdk.routing import controller
 from tethys_sdk.gizmos import Button
-from .app import {{class_name}} as app
+from .app import App
 
 @controller
 def home(request):
@@ -71,4 +71,4 @@ def home(request):
         'next_button': next_button
     }
 
-    return app.render(request, 'home.html', context)
+    return App.render(request, 'home.html', context)

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/base.html_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/base.html_tmpl
@@ -1,6 +1,6 @@
 {{ '{%' }} extends "tethys_apps/app_base.html" {{ '%}' }}
 
-{{ '{%' }} load static {{ '%}' }}
+{{ '{%' }} load static tags {{ '%}' }}
 
 {{ '{%' }} block title {{ '%}' }}{{ '{{' }} tethys_app.name {{ '}}' }}{{ '{%' }} endblock {{ '%}' }}
 
@@ -33,10 +33,10 @@
 
 {{ '{%' }} block content_dependent_styles {{ '%}' }}
   {{ '{{' }} block.super }{{ "}" }}
-  <link href="{{ '{%' }} static '{{project}}/css/main.css' {{ '%}' }}" rel="stylesheet"/>
+  <link href="{{ '{%' }} static tethys_app|public:'css/main.css' {{ '%}' }}" rel="stylesheet"/>
 {{ '{%' }} endblock {{ '%}' }}
 
 {{ '{%' }} block scripts {{ '%}' }}
   {{ '{{' }} block.super }{{ "}" }}
-  <script src="{{ '{%' }} static '{{project}}/js/main.js' {{ '%}' }}" type="text/javascript"></script>
+  <script src="{{ '{%' }} static tethys_app|public:'js/main.js' {{ '%}' }}" type="text/javascript"></script>
 {{ '{%' }} endblock {{ '%}' }}

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/base.html_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/base.html_tmpl
@@ -1,6 +1,6 @@
 {{ '{%' }} extends "tethys_apps/app_base.html" {{ '%}' }}
 
-{{ '{%' }} load static tags {{ '%}' }}
+{{ '{%' }} load static tethys {{ '%}' }}
 
 {{ '{%' }} block title {{ '%}' }}{{ '{{' }} tethys_app.name {{ '}}' }}{{ '{%' }} endblock {{ '%}' }}
 

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/home.html_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/home.html_tmpl
@@ -1,4 +1,4 @@
-{{ '{%' }} extends "{{project}}/base.html" {{ '%}' }}
+{{ '{%' }} extends tethys_app.package|add:"/base.html" {{ '%}' }}
 {{ '{%' }} load tethys_gizmos {{ '%}' }}
 
 {{ '{%' }} block header_buttons {{ '%}' }}

--- a/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/home.html_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/default/tethysapp/+project+/templates/+project+/home.html_tmpl
@@ -1,5 +1,5 @@
 {{ '{%' }} extends tethys_app.package|add:"/base.html" {{ '%}' }}
-{{ '{%' }} load tethys_gizmos {{ '%}' }}
+{{ '{%' }} load tethys {{ '%}' }}
 
 {{ '{%' }} block header_buttons {{ '%}' }}
   <div class="header-button glyphicon-button" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Help">

--- a/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/app.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/app.py_tmpl
@@ -1,7 +1,7 @@
 from tethys_sdk.base import TethysAppBase
 
 
-class {{class_name}}(TethysAppBase):
+class App(TethysAppBase):
     """
     Tethys app class for {{proper_name}}.
     """

--- a/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/controllers.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/controllers.py_tmpl
@@ -1,15 +1,15 @@
-from django.shortcuts import render
 from django.http import JsonResponse
 import pandas as pd
 
 from tethys_sdk.routing import controller
+from .app import App
 
 
 @controller
 def home(request):
     """Controller for the app home page."""
     # The index.html template loads the React frontend
-    return app.render(request, 'index.html')
+    return App.render(request, 'index.html')
 
 
 @controller

--- a/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/controllers.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/controllers.py_tmpl
@@ -9,7 +9,7 @@ from tethys_sdk.routing import controller
 def home(request):
     """Controller for the app home page."""
     # The index.html template loads the React frontend
-    return render(request, '{{project}}/index.html')
+    return app.render(request, 'index.html')
 
 
 @controller

--- a/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/templates/+project+/index.html_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/templates/+project+/index.html_tmpl
@@ -1,4 +1,4 @@
-{{ '{%' }} load static {{ '%}' }}
+{{ '{%' }} load static tags {{ '%}' }}
 <!DOCTYPE html>
 <html>
 	<head>
@@ -11,6 +11,6 @@
 	<body style="margin: 0;">
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
-		<script src="{{ '{%' }} static '{{project}}/frontend/main.js' {{ '%}' }}"></script>
+		<script src="{{ '{%' }} static tethys_app|public:'frontend/main.js' {{ '%}' }}"></script>
 	</body>
 </html>

--- a/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/templates/+project+/index.html_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/react/tethysapp/+project+/templates/+project+/index.html_tmpl
@@ -1,4 +1,4 @@
-{{ '{%' }} load static tags {{ '%}' }}
+{{ '{%' }} load static tethys {{ '%}' }}
 <!DOCTYPE html>
 <html>
 	<head>

--- a/tethys_cli/scaffold_templates/extension_templates/default/tethysext/+project+/ext.py_tmpl
+++ b/tethys_cli/scaffold_templates/extension_templates/default/tethysext/+project+/ext.py_tmpl
@@ -1,7 +1,7 @@
 from tethys_sdk.base import TethysExtensionBase
 
 
-class {{class_name}}(TethysExtensionBase):
+class Extension(TethysExtensionBase):
     """
     Tethys extension class for {{proper_name}}.
     """

--- a/tethys_compute/job_manager.py
+++ b/tethys_compute/job_manager.py
@@ -40,9 +40,9 @@ class JobManager:
 
         ::
 
-            from app import MyApp as app
+            from .app import App
 
-            job_manager = app.get_job_manager()
+            job_manager = App.get_job_manager()
     """
 
     def __init__(self, app):

--- a/tethys_compute/templates/tethys_compute/dask_scheduler_dashboard.html
+++ b/tethys_compute/templates/tethys_compute/dask_scheduler_dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - Dask Scheduler{% endblock %}
 

--- a/tethys_gizmos/gizmo_options/bokeh_view.py
+++ b/tethys_gizmos/gizmo_options/bokeh_view.py
@@ -42,7 +42,7 @@ class BokehView(TethysGizmoOptions):
 
     Template Code Example::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% gizmo bokeh_view_input %}
 
@@ -214,7 +214,7 @@ class BokehView(TethysGizmoOptions):
 
     Template Code::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% gizmo scatter_plot %}
         {% gizmo line_plot %}

--- a/tethys_gizmos/gizmo_options/jobs_table.py
+++ b/tethys_gizmos/gizmo_options/jobs_table.py
@@ -305,7 +305,7 @@ class JobsTable(TethysGizmoOptions):
         # Initialize super class
         super().__init__(attributes=attributes, classes=classes)
 
-        self.jobs = jobs
+        self.jobs = list(jobs)
         if sort:
             key = sort if callable(sort) else lambda j: j.creation_time
             self.jobs.sort(key=key, reverse=reverse_sort)

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -316,7 +316,7 @@ class MapView(TethysGizmoOptions):
 
     ::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% gizmo map_view_options %}
 

--- a/tethys_gizmos/gizmo_options/table_view.py
+++ b/tethys_gizmos/gizmo_options/table_view.py
@@ -69,7 +69,7 @@ class TableView(TethysGizmoOptions):
 
     ::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% gizmo table_view %}
         {% gizmo table_view_edit %}

--- a/tethys_gizmos/static/tethys_gizmos/js/jobs_table.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/jobs_table.js
@@ -366,6 +366,11 @@ function bind_jobs_table_actions(table_elem){
     else if(action.data('modal-url')){
       bind_modal_url(action);
     }
+    else if(action.hasClass('job-action-refresh-status')){
+        action.on('click', function(){
+            update_row(table_elem);
+        });
+    }
     else{
       bind_action(action);
     }

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/bokeh_application.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/bokeh_application.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 <div id='bokeh-application' style="width: 100%; height:250px;">
   {{ the_script|safe}}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/bokeh_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/bokeh_view.html
@@ -1,4 +1,4 @@
-{% load tethys_gizmos %}
+{% load tethys %}
 
 <div class="{% if classes %} {{ classes }} {% endif %} {% if hidden %} hidden {% endif %}" 
   {% if divid %} id="{{ divid }}"{% endif %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/cesium_map_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/cesium_map_view.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 
 <div id="cesium_map_view_outer_container" style="height: 100%;">

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/datatable_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/datatable_view.html
@@ -1,4 +1,4 @@
-{% load tethys_gizmos %}
+{% load tethys %}
 
 <table class="data_table_gizmo_view table{% if bordered %} table-bordered{% endif %}{% if hover %} table-hover{% endif %}{% if striped %} table-striped{% endif %}{% if condensed %} table-condensed{% endif %}{% if dark %} table-dark{% endif %}{% if classes %} {{ classes }}{% endif %}" width="100%"
   {% if attributes %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/date_picker.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/date_picker.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% if display_text %}
 <label class="form-label" for="{{ name }}">{{ display_text }}</label>

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/esri_map.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/esri_map.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 
 <div id="esri_map_view_outer_container">

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/job_logs.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/job_logs.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% gizmo sub_job_select %}
 {% for log, options in log_options.items %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {% for column_value in row.columns %}
   {% with col_idx=forloop.counter0 %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row_error.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row_error.html
@@ -1,4 +1,4 @@
-{% load static tethys %}
+{% load static %}
 
 <td id="error-{{ job_id }}" colspan="{{ num_cols }}">
     <img src="{% static 'tethys_gizmos/images/job_error.png' %}" height="20px" width="20px" style="margin-right: 5px;"/>

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row_error.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row_error.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 <td id="error-{{ job_id }}" colspan="{{ num_cols }}">
     <img src="{% static 'tethys_gizmos/images/job_error.png' %}" height="20px" width="20px" style="margin-right: 5px;"/>

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/jobs_table.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/jobs_table.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 <div id="jobs-table-messages"></div>
 <table class="table jobs-table{% if bordered %} table-bordered{% endif %}{% if hover %} table-hover{% endif %}{% if striped %} table-striped{% endif %}{% if condensed %} table-condensed{% endif %}{% if classes %} {{ classes }}{% endif %}"

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/map_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/map_view.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
   <!-- the style for 
 
     - .tethys-map-view-draw-control

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/message_box.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/message_box.html
@@ -1,4 +1,4 @@
-{% load tethys_gizmos %}
+{% load tethys %}
 
 <div id="{{ name }}" class="modal fade{% if classes %} {{ classes }}{% endif %}" tabindex="-1" role="dialog" aria-labelledby="{{ name|add:'Label' }}" aria-hidden="true"
         {% if attributes %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/plot_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/plot_view.html
@@ -1,4 +1,4 @@
-{% load tethys_gizmos %}
+{% load tethys %}
 
 <div class="{% if engine == 'd3' %}d3-plot{% else %}highcharts-plot{% endif %}{% if classes %} {{ classes }}{% endif %}"
   {% if plot_object|isstring %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/plotly_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/plotly_view.html
@@ -1,4 +1,4 @@
-{% load tethys_gizmos %}
+{% load tethys %}
 
 <div class="{% if classes %} {{ classes }} {% endif %} {% if hidden %} hidden {% endif %}" 
   {% if divid %} id="{{ divid }}"{% endif %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/select_input.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/select_input.html
@@ -1,5 +1,5 @@
 {% if not original %}
-  {% load static tethys_gizmos %}
+  {% load static tethys %}
 {% endif %}
 {% if display_text %}
 <label class="form-label" for="{{ name }}">{{ display_text }}</label>

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/table_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/table_view.html
@@ -1,4 +1,4 @@
-{% load tethys_gizmos %}
+{% load tethys %}
 
 <table class="table{% if bordered %} table-bordered{% endif %}{% if hover %} table-hover{% endif %}{% if striped %} table-striped{% endif %}{% if condensed %} table-condensed{% endif %}{% if dark %} table-dark{% endif %}{% if classes %} {{ classes }}{% endif %}"
         {% if attributes %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/workflow_nodes_row.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/workflow_nodes_row.html
@@ -1,4 +1,4 @@
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 <td colspan="{{ num_cols }}">
   <div class="workflow-nodes-graph">

--- a/tethys_gizmos/templatetags/tethys_gizmos.py
+++ b/tethys_gizmos/templatetags/tethys_gizmos.py
@@ -295,7 +295,7 @@ def gizmo(parser, token):
 
     Example::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% gizmo options %}
 
@@ -303,7 +303,7 @@ def gizmo(parser, token):
 
     Example::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% gizmo gizmo_name options %}
 
@@ -337,7 +337,7 @@ def import_gizmo_dependency(parser, token):
 
     Example::
 
-        {% load tethys_gizmos %}
+        {% load tethys %}
 
         {% block import_gizmos %}
             {% import_gizmo_dependency example_gizmo %}

--- a/tethys_gizmos/views/gizmos/jobs_table.py
+++ b/tethys_gizmos/views/gizmos/jobs_table.py
@@ -11,7 +11,7 @@ from tethys_portal.optional_dependencies import optional_import
 # optional imports
 server_document = optional_import("server_document", from_module="bokeh.embed")
 
-log = logging.getLogger("tethys.tethys_gizmos.views.jobs_table")
+logger = logging.getLogger(f"tethys.{__name__}")
 
 
 def perform_action(request, job_id, action, success_message="", error_message=None):
@@ -22,8 +22,8 @@ def perform_action(request, job_id, action, success_message="", error_message=No
         message = success_message
     except Exception as e:
         success = False
-        log.exception(e)
-        log.error(
+        logger.exception(e)
+        logger.error(
             f'The following error occurred when running "{action}" on job {job_id}: {str(e)}'
         )
         message = error_message or f"Unable to {action} job {job_id}."
@@ -46,7 +46,7 @@ def delete(request, job_id):
     except Exception as e:
         success = False
         message = str(e)
-        log.error(f"The following error occurred when deleting job {job_id}: {message}")
+        logger.error(f"The following error occurred when deleting job {job_id}: {message}")
     return JsonResponse({"success": success, "message": message})
 
 
@@ -93,8 +93,9 @@ def show_log(request, job_id):
             {"success": True, "html": html, "log_contents": log_contents}
         )
     except Exception as e:
+        logger.exception(e)
         message = str(e)
-        log.error(
+        logger.error(
             "The following error occurred when retrieving logs for job %s: %s",
             job_id,
             message,
@@ -124,7 +125,7 @@ def get_log_content(request, job_id, key1, key2=None):
         if key2 is None:
             key2 = ""  # for error message formatting
         message = str(e)
-        log.error(
+        logger.error(
             "The following error occurred when retrieving log content for log %s in job %s: %s",
             job_id,
             f"{key1} {key2}",
@@ -202,7 +203,7 @@ def update_row(request, job_id):
         html = render_to_string("tethys_gizmos/gizmos/job_row.html", data)
     except Exception as e:
         error_msg = "Updating row for job {} failed: {}".format(job_id, str(e))
-        log.warning(error_msg)
+        logger.warning(error_msg)
         user_friendly_error = (
             'An unexpected error occurred while updating this row. Press the "Refresh Status" '
             "button to update the row manually."
@@ -289,7 +290,7 @@ def update_workflow_nodes_row(request, job_id):
 
         success = True
     except Exception as e:
-        log.error(
+        logger.error(
             "The following error occurred when updating details row for job %s: %s",
             job_id,
             str(e),
@@ -329,7 +330,7 @@ def bokeh_row(request, job_id, type="individual-graph"):
         success = True
 
     except Exception as e:
-        log.error(
+        logger.error(
             "The following error occurred when getting bokeh chart "
             "from scheduler {} for job {}: {}".format(
                 dask_scheduler.name, job_id, str(e)

--- a/tethys_gizmos/views/gizmos/jobs_table.py
+++ b/tethys_gizmos/views/gizmos/jobs_table.py
@@ -147,7 +147,7 @@ def update_row(request, job_id):
         statuses = None
         if status in ["Various", "Various-Complete"]:
             # Hard code statues for the gizmo showcase
-            if job.label == "gizmos_showcase":
+            if job.label == "gizmo_showcase":
                 if isinstance(job, CondorWorkflow):
                     statuses = {
                         "Completed": 20,
@@ -227,8 +227,8 @@ def update_workflow_nodes_row(request, job_id):
         job = TethysJob.objects.get_subclass(id=job_id)
         status = job.status
 
-        # Hard code example for gizmos_showcase
-        if job.label == "gizmos_showcase":
+        # Hard code example for gizmo_showcase
+        if job.label == "gizmo_showcase":
             dag = {
                 "a": {
                     "status": "com",

--- a/tethys_gizmos/views/gizmos/jobs_table.py
+++ b/tethys_gizmos/views/gizmos/jobs_table.py
@@ -22,7 +22,6 @@ def perform_action(request, job_id, action, success_message="", error_message=No
         message = success_message
     except Exception as e:
         success = False
-        logger.exception(e)
         logger.error(
             f'The following error occurred when running "{action}" on job {job_id}: {str(e)}'
         )
@@ -46,7 +45,9 @@ def delete(request, job_id):
     except Exception as e:
         success = False
         message = str(e)
-        logger.error(f"The following error occurred when deleting job {job_id}: {message}")
+        logger.error(
+            f"The following error occurred when deleting job {job_id}: {message}"
+        )
     return JsonResponse({"success": success, "message": message})
 
 

--- a/tethys_layouts/templates/tethys_layouts/map_layout/map_layout.html
+++ b/tethys_layouts/templates/tethys_layouts/map_layout/map_layout.html
@@ -1,5 +1,5 @@
 {% extends base_template %}
-{% load tethys_gizmos static %}
+{% load static tethys %}
 
 {% block import_gizmos %}
   {% import_gizmo_dependency select_input %}

--- a/tethys_layouts/templates/tethys_layouts/tethys_layout.html
+++ b/tethys_layouts/templates/tethys_layouts/tethys_layout.html
@@ -1,6 +1,6 @@
 {% extends "tethys_apps/app_base.html" %}
 
-{% load static tethys_gizmos %}
+{% load static tethys %}
 
 {# import tethys_gizmos.css for centering of loading gif #}
 {% block import_gizmos %}

--- a/tethys_portal/templates/base.html
+++ b/tethys_portal/templates/base.html
@@ -1,4 +1,4 @@
-{% load static site_settings %}
+{% load static tethys %}
 <!DOCTYPE html>
 
 {# Allows custom attributes to be added to the html tag #}

--- a/tethys_portal/templates/tethys_portal/accounts/base.html
+++ b/tethys_portal/templates/tethys_portal/accounts/base.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static site_settings %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - Log In{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/accounts/lockout.html
+++ b/tethys_portal/templates/tethys_portal/accounts/lockout.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static humanize %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - Locked Out!{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/accounts/login.html
+++ b/tethys_portal/templates/tethys_portal/accounts/login.html
@@ -1,6 +1,6 @@
 {% extends "tethys_portal/accounts/base.html" %}
 
-{% load django_bootstrap5 site_settings %}
+{% load django_bootstrap5 tethys %}
 
 {% block title %}{{ block.super }} - Log In{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/accounts/register.html
+++ b/tethys_portal/templates/tethys_portal/accounts/register.html
@@ -1,6 +1,6 @@
 {% extends "tethys_portal/accounts/base.html" %}
 
-{% load django_bootstrap5 site_settings %}
+{% load django_bootstrap5 tethys %}
 
 {% block title %}{{ block.super }} - Sign Up{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/home.html
+++ b/tethys_portal/templates/tethys_portal/home.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static site_settings %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - Welcome!{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/user/base.html
+++ b/tethys_portal/templates/tethys_portal/user/base.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load static site_settings %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - Profile{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/user/confirm.html
+++ b/tethys_portal/templates/tethys_portal/user/confirm.html
@@ -1,8 +1,6 @@
 {% extends "tethys_portal/user/base.html" %}
 
-{% load static django_bootstrap5 %}
-
-{% load static site_settings %}
+{% load static django_bootstrap5 tethys %}
 
 {% block title %}{{ block.super }} - Confirmation{% endblock %}
 

--- a/tethys_portal/templates/tethys_portal/user/profile.html
+++ b/tethys_portal/templates/tethys_portal/user/profile.html
@@ -1,6 +1,6 @@
 {% extends "tethys_portal/user/base.html" %}
 
-{% load static site_settings %}
+{% load static tethys %}
 
 {% block title %}{{ block.super }} - Profile{% endblock %}
 

--- a/tethys_sdk/templatetags/tethys.py
+++ b/tethys_sdk/templatetags/tethys.py
@@ -1,0 +1,29 @@
+"""
+********************************************************************************
+* Name: tethys.py
+* Author: Scott Christensen
+* Created On: April 2024
+* Copyright:
+* License: BSD 2-Clause
+********************************************************************************
+"""
+
+from tethys_apps.templatetags.app_theme import register as app_theme_library
+from tethys_apps.templatetags.humanize import register as humanize_library
+from tethys_apps.templatetags.site_settings import register as site_settings_library
+from tethys_apps.templatetags.tags import register as tags_library
+from tethys_gizmos.templatetags.tethys_gizmos import register as gizmos_library
+
+from django import template
+
+libraries = (
+    app_theme_library,
+    humanize_library,
+    site_settings_library,
+    tags_library,
+    gizmos_library,
+)
+
+register = template.Library()
+register.tags = {k: v for lib in libraries for k, v in lib.tags.items()}
+register.filters = {k: v for lib in libraries for k, v in lib.filters.items()}


### PR DESCRIPTION
Fixes #997 

Compiles all Tethys template tags/filters into a single ``tethys`` namespace templatetag library.

Add template filters and TethysBase classmethods to use inplace of ``django.shortcuts`` functions to avoid using the ``app.package`` as a magic string

Add the following template filters:

 ```html+django
{% load static tethys %}

{% static tethys_app|public:'css/main.css' %}
```

```html+django
{% load tethys %}

{% url tethys_app|url:'home' %}
```

Changes the scaffold to extend the ``base.html`` without using the ``project``:

```html+django
{% extends tethys_app.package|add:"/base.html" %}
```

Changes scaffolds to name app/ext classes as ``App`` and ``Extension``.

Adds ``render``, ``redirect``, ``reverse``, and ``render_to_string`` methods to ``tethys_apps.base.app_base.TethysBase`` to replace the ``django.shortcuts`` functions:

```python
from tethys_sdk.gizmos import Button
from .app import App

@controller
def home(request):
    """
    Controller for the app home page.
    """

    cancel_button = Button(
        display_text='Cancel',
        name='cancel-button',
        href=app.reverse('home')
    )

    context = {'cancel_button': cancel_button}

    return App.render(request, 'home.html', context)
```

```python
from .app import App

@controller
def do_something_and_redirect_home(request):
    """
    Controller to do something before redirecting to the app homepage.
    """

    return App.redirect(App.reverse("jobs_table"))
```