### PR TITLE
Fixed and pulled healthcheck into docker/liveness-probe.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,6 +207,7 @@ EXPOSE 80
 ###############*
 ADD docker/salt/ /srv/salt/
 ADD docker/run.sh ${TETHYS_HOME}/
+ADD docker/liveness-probe.sh ${TETHYS_HOME}/
 
 ########
 # RUN! #
@@ -215,7 +216,4 @@ WORKDIR ${TETHYS_HOME}
 # Create Salt configuration based on ENVs
 CMD bash run.sh
 HEALTHCHECK --start-period=240s \
-  CMD  function check_process_is_running(){ if [ "$(ps $1 | wc -l)" -ne 2 ]; then echo The $2 process \($1\) is  not running. 1>&2; return 1; fi }; \
-  check_process_is_running $(cat $(grep 'pidfile=.*' /etc/supervisor/supervisord.conf | awk -F'=' '{print $2}' | awk '{print $1}')) supervisor; \
-  check_process_is_running $(cat $(grep 'pid .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}')) nginx; \
-  check_process_is_running $(ls -l /run/tethys_asgi0.sock.lock | awk -F'-> ' '{print $2}') asgi;
+  CMD ./liveness-probe.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       TETHYS_DB_SUPERUSER: "tethys_super"
       TETHYS_DB_SUPERUSER_PASS: "pass"
       CLIENT_MAX_BODY_SIZE: "75M"
+    healthcheck:
+      test: ["CMD", "./liveness-probe.sh"]
+      interval: 10s
+      timeout: 6s
+      retries: 2
     links:
       - db
     depends_on:

--- a/docker/liveness-probe.sh
+++ b/docker/liveness-probe.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+check_process_is_running() { 
+	if [ "$(ps $1 | wc -l)" -ne 2 ]; then 
+		echo The $2 process \($1\) is  not running. 1>&2; 
+	else
+		echo "ok"
+	fi 
+}
+
+ret1=$(check_process_is_running $(cat $(grep 'pidfile=.*' /etc/supervisor/supervisord.conf | awk -F'=' '{print $2}' | awk '{print $1}')) supervisor)
+ret2=$(check_process_is_running $(cat $(grep 'pid .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}')) nginx)
+ret3=$(check_process_is_running $(ls -l /run/tethys_asgi0.sock.lock | awk -F'-> ' '{print $2}') asgi)
+
+if [ "$ret1" != "ok" ] || [ "$ret2" != "ok" ] || [ "$ret3" != "ok" ]; then
+	echo "liveness-probe.sh: at least 1 test failed"
+	exit 1
+else
+	echo "liveness-probe.sh: all tests passed"
+	exit 0
+fi


### PR DESCRIPTION
Continuing this discussion:
https://github.com/tethysplatform/tethys/discussions/1018

3 goals here:

1. Kubernetes doesn't apply HEALTHCHECK from a Dockerfile, so I pulled the logic into a script called liveness-probe.sh which is copied into the container, and then can be implemented directly by any container manager (docker, docker-compose, kubernetes, etc).

2. I don't get into the weeds of bash nor docker HEALTHCHECK often. I think this implementation is a bit easier to read and maintain.

3. If I'm not making a mistake, the current implementation of HEALTHCHECK as executed by docker-compose fails to a syntax error:
```
            "Health": {
                "Status": "unhealthy",
                "FailingStreak": 5,
                "Log": [
                    {
                        "Start": "2024-04-17T16:17:10.194952618-05:00",
                        "End": "2024-04-17T16:17:10.236757633-05:00",
                        "ExitCode": 2,
                        "Output": "/bin/sh: 1: Syntax error: \"(\" unexpected\n"
                    },
                    {
--
            "Healthcheck": {
                "Test": [
                    "CMD-SHELL",
                    "function check_process_is_running(){ if [ \"$(ps $1 | wc -l)\" -ne 2 ]; then echo The $2 process \\($1\\) is  not running. 1>&2; return 1; fi };   check_process_is_running $(cat $(grep 'pidfile=.*' /etc/supervisor/supervisord.conf | awk -F'=' '{print $2}' | awk '{print $1}')) supervisor;   check_process_is_running $(cat $(grep 'pid .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}')) nginx;   check_process_is_running $(ls -l /run/tethys_asgi0.sock.lock | awk -F'-> ' '{print $2}') asgi;"
                ],
                "StartPeriod": 240000000000
            },
            "Image": "tethysplatform/tethys-core",
```