### PR TITLE
Standalone App Non-Home Index Fixes

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_decorators.py
+++ b/tests/unit_tests/test_tethys_apps/test_decorators.py
@@ -1,8 +1,8 @@
-import unittest
 from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase
+from tethys_sdk.testing import TethysTestCase
 from django.test.utils import override_settings
 from django.http import HttpResponseRedirect
 
@@ -11,10 +11,28 @@ from tethys_sdk.permissions import login_required
 from .. import UserFactory
 
 
-class DecoratorsTest(unittest.TestCase):
+@override_settings(MULTIPLE_APP_MODE=True)
+class DecoratorsTest(TethysTestCase):
+    import sys
+    from importlib import reload, import_module
+    from django.conf import settings
+    from django.urls import clear_url_caches
+
+    @classmethod
+    def reload_urlconf(self, urlconf=None):
+        self.clear_url_caches()
+        if urlconf is None:
+            urlconf = self.settings.ROOT_URLCONF
+        if urlconf in self.sys.modules:
+            self.reload(self.sys.modules["tethys_apps.urls"])
+            self.reload(self.sys.modules[urlconf])
+        else:
+            self.import_module(urlconf)
+
     def setUp(self):
         self.request_factory = RequestFactory()
         self.user = UserFactory()
+        self.reload_urlconf()
 
     def tearDown(self):
         pass
@@ -229,6 +247,7 @@ class DecoratorsTest(unittest.TestCase):
         self.assertEqual(f.method(request), "expected_result")
 
 
+@override_settings(MULTIPLE_APP_MODE=True)
 @override_settings(PREFIX_URL="test/prefix")
 @override_settings(LOGIN_URL="/test/prefix/test/login/")
 class DecoratorsWithPrefixTest(TestCase):
@@ -243,6 +262,7 @@ class DecoratorsWithPrefixTest(TestCase):
         if urlconf is None:
             urlconf = self.settings.ROOT_URLCONF
         if urlconf in self.sys.modules:
+            self.reload(self.sys.modules["tethys_apps.urls"])
             self.reload(self.sys.modules[urlconf])
         else:
             self.import_module(urlconf)
@@ -257,6 +277,7 @@ class DecoratorsWithPrefixTest(TestCase):
         self.reload_urlconf()
         pass
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.decorators.messages")
     @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
     def test_permission_required_message(self, _, mock_messages):
@@ -290,6 +311,7 @@ class DecoratorsWithPrefixTest(TestCase):
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertIn("test/prefix/test/login/", ret.url)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.decorators.messages")
     @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
     def test_permission_required_no_pass_authenticated(self, _, mock_messages):

--- a/tests/unit_tests/test_tethys_apps/test_decorators.py
+++ b/tests/unit_tests/test_tethys_apps/test_decorators.py
@@ -79,7 +79,9 @@ class DecoratorsTest(unittest.TestCase):
     @override_settings(MULTIPLE_APP_MODE=False)
     @mock.patch("tethys_apps.decorators.messages")
     @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
-    def test_permission_required_no_pass_authenticated_single_app_mode(self, _, mock_messages):
+    def test_permission_required_no_pass_authenticated_single_app_mode(
+        self, _, mock_messages
+    ):
         request = self.request_factory.get("/apps/test-app")
         request.user = self.user
 
@@ -303,11 +305,13 @@ class DecoratorsWithPrefixTest(TestCase):
         mock_messages.add_message.assert_called()
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual("/test/prefix/apps/", ret.url)
-    
+
     @override_settings(MULTIPLE_APP_MODE=False)
     @mock.patch("tethys_apps.decorators.messages")
     @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
-    def test_permission_required_no_pass_authenticated_single_app_mode(self, _, mock_messages):
+    def test_permission_required_no_pass_authenticated_single_app_mode(
+        self, _, mock_messages
+    ):
         request = self.request_factory.get("/apps/test-app")
         request.user = self.user
 

--- a/tests/unit_tests/test_tethys_apps/test_decorators.py
+++ b/tests/unit_tests/test_tethys_apps/test_decorators.py
@@ -76,6 +76,23 @@ class DecoratorsTest(unittest.TestCase):
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual("/apps/", ret.url)
 
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_apps.decorators.messages")
+    @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
+    def test_permission_required_no_pass_authenticated_single_app_mode(self, _, mock_messages):
+        request = self.request_factory.get("/apps/test-app")
+        request.user = self.user
+
+        @permission_required("create_projects")
+        def create_projects(request, *args, **kwargs):
+            return "expected_result"
+
+        ret = create_projects(request)
+
+        mock_messages.add_message.assert_called()
+        self.assertIsInstance(ret, HttpResponseRedirect)
+        self.assertEqual("/user/", ret.url)
+
     @mock.patch("tethys_apps.decorators.messages")
     @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
     def test_permission_required_no_pass_authenticated_with_referrer(
@@ -286,6 +303,23 @@ class DecoratorsWithPrefixTest(TestCase):
         mock_messages.add_message.assert_called()
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual("/test/prefix/apps/", ret.url)
+    
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_apps.decorators.messages")
+    @mock.patch("tethys_apps.decorators.has_permission", return_value=False)
+    def test_permission_required_no_pass_authenticated_single_app_mode(self, _, mock_messages):
+        request = self.request_factory.get("/apps/test-app")
+        request.user = self.user
+
+        @permission_required("create_projects")
+        def create_projects(request, *args, **kwargs):
+            return "expected_result"
+
+        ret = create_projects(request)
+
+        mock_messages.add_message.assert_called()
+        self.assertIsInstance(ret, HttpResponseRedirect)
+        self.assertEqual("/test/prefix/user/", ret.url)
 
     @mock.patch("tethys_apps.decorators.messages")
     @mock.patch("tethys_apps.decorators.has_permission", return_value=False)

--- a/tests/unit_tests/test_tethys_apps/test_urls.py
+++ b/tests/unit_tests/test_tethys_apps/test_urls.py
@@ -2,6 +2,8 @@ from django.urls import reverse, resolve
 from tethys_sdk.testing import TethysTestCase
 from django.test import override_settings
 from django.urls.exceptions import NoReverseMatch
+from unittest import mock
+from django.views.generic.base import RedirectView
 
 
 class TestUrls(TethysTestCase):
@@ -151,6 +153,67 @@ class TestUrlsWithStandaloneApp(TethysTestCase):
         self.assertEqual("/", url)
         self.assertEqual("home", resolver.func.__name__)
         self.assertEqual("tethysapp.test_app.controllers", resolver.func.__module__)
+
+        url = reverse("test_extension:home", kwargs={"var1": "foo", "var2": "bar"})
+        resolver = resolve(url)
+        self.assertEqual("/extensions/foo/bar/", url)
+        self.assertEqual("home", resolver.func.__name__)
+        self.assertEqual(
+            "tethysext.test_extension.controllers", resolver.func.__module__
+        )
+
+
+@override_settings(MULTIPLE_APP_MODE=False)
+class TestUrlsWithStandaloneAppNoApp(TethysTestCase):
+    import sys
+    from importlib import reload, import_module
+    from django.conf import settings
+    from django.urls import clear_url_caches
+
+    @classmethod
+    def reload_urlconf(self, urlconf=None):
+        self.clear_url_caches()
+        if urlconf is None:
+            urlconf = self.settings.ROOT_URLCONF
+        if urlconf in self.sys.modules:
+            self.reload(self.sys.modules["tethys_apps.urls"])
+            self.reload(self.sys.modules[urlconf])
+        else:
+            self.import_module(urlconf)
+
+    @mock.patch("tethys_apps.utilities.get_configured_standalone_app")
+    def set_up(self, mock_get_configured_standalone_app):
+        mock_get_configured_standalone_app.return_value = []
+        self.reload_urlconf()
+        pass
+
+    @override_settings(MULTIPLE_APP_MODE=True)
+    def tearDown(self):
+        self.reload_urlconf()
+        pass
+
+    def test_urls(self):
+        # This executes the code at the module level
+        with self.assertRaises(NoReverseMatch):
+            reverse("app_library")
+
+        url = reverse("home")
+        resolver = resolve(url)
+        self.assertEqual("/", url)
+        self.assertEqual(resolver.func.view_class, RedirectView)
+        self.assertEqual("user:profile", resolver.func.view_initkwargs["pattern_name"])
+
+        url = reverse("send_beta_feedback")
+        resolver = resolve(url)
+        self.assertEqual("/send-beta-feedback/", url)
+        self.assertEqual("send_beta_feedback_email", resolver.func.__name__)
+        self.assertEqual("tethys_apps.views", resolver.func.__module__)
+
+        url = reverse("test_app:home")
+        resolver = resolve(url)
+        self.assertEqual("/", url)
+        self.assertEqual(resolver.func.view_class, RedirectView)
+        self.assertEqual("user:profile", resolver.func.view_initkwargs["pattern_name"])
 
         url = reverse("test_extension:home", kwargs={"var1": "foo", "var2": "bar"})
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_apps/test_urls.py
+++ b/tests/unit_tests/test_tethys_apps/test_urls.py
@@ -6,13 +6,34 @@ from unittest import mock
 from django.views.generic.base import RedirectView
 
 
+@override_settings(MULTIPLE_APP_MODE=True)
 class TestUrls(TethysTestCase):
+    import sys
+    from importlib import reload, import_module
+    from django.conf import settings
+    from django.urls import clear_url_caches
+
+    @classmethod
+    def reload_urlconf(self, urlconf=None):
+        self.clear_url_caches()
+        if urlconf is None:
+            urlconf = self.settings.ROOT_URLCONF
+        if urlconf in self.sys.modules:
+            self.reload(self.sys.modules["tethys_apps.urls"])
+            self.reload(self.sys.modules[urlconf])
+        else:
+            self.import_module(urlconf)
+
     def set_up(self):
+        self.reload_urlconf()
         pass
 
-    def tear_down(self):
+    @override_settings(PREFIX_URL="/")
+    def tearDown(self):
+        self.reload_urlconf()
         pass
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     def test_urls(self):
         # This executes the code at the module level
         url = reverse("app_library")
@@ -48,6 +69,7 @@ class TestUrls(TethysTestCase):
 
 
 # probably need to test for extensions manually
+@override_settings(MULTIPLE_APP_MODE=True)
 @override_settings(PREFIX_URL="test/prefix")
 class TestUrlsWithPrefix(TethysTestCase):
     import sys

--- a/tests/unit_tests/test_tethys_apps/test_urls.py
+++ b/tests/unit_tests/test_tethys_apps/test_urls.py
@@ -2,6 +2,8 @@ from django.urls import reverse, resolve
 from tethys_sdk.testing import TethysTestCase
 from django.test import override_settings
 from django.urls.exceptions import NoReverseMatch
+from unittest import mock
+from django.views.generic.base import RedirectView
 
 
 class TestUrls(TethysTestCase):
@@ -151,6 +153,67 @@ class TestUrlsWithStandaloneApp(TethysTestCase):
         self.assertEqual("/", url)
         self.assertEqual("home", resolver.func.__name__)
         self.assertEqual("tethysapp.test_app.controllers", resolver.func.__module__)
+
+        url = reverse("test_extension:home", kwargs={"var1": "foo", "var2": "bar"})
+        resolver = resolve(url)
+        self.assertEqual("/extensions/foo/bar/", url)
+        self.assertEqual("home", resolver.func.__name__)
+        self.assertEqual(
+            "tethysext.test_extension.controllers", resolver.func.__module__
+        )
+
+
+@override_settings(MULTIPLE_APP_MODE=False)
+class TestUrlsWithStandaloneAppNoApp(TethysTestCase):
+    import sys
+    from importlib import reload, import_module
+    from django.conf import settings
+    from django.urls import clear_url_caches
+
+    @classmethod
+    def reload_urlconf(self, urlconf=None):
+        self.clear_url_caches()
+        if urlconf is None:
+            urlconf = self.settings.ROOT_URLCONF
+        if urlconf in self.sys.modules:
+            self.reload(self.sys.modules["tethys_apps.urls"])
+            self.reload(self.sys.modules[urlconf])
+        else:
+            self.import_module(urlconf)
+
+    @mock.patch("tethys_apps.utilities.get_configured_standalone_app")
+    def set_up(self, mock_get_configured_standalone_app):
+        mock_get_configured_standalone_app.return_value = []
+        self.reload_urlconf()
+        pass
+
+    @override_settings(MULTIPLE_APP_MODE=True)
+    def tearDown(self):
+        self.reload_urlconf()
+        pass
+
+    def test_urls(self):
+        # This executes the code at the module level
+        with self.assertRaises(NoReverseMatch):
+            reverse("app_library")
+
+        url = reverse("home")
+        resolver = resolve(url)
+        self.assertEqual("/", url)
+        self.assertEqual(resolver.func.view_class, RedirectView)
+        self.assertEqual('user:profile', resolver.func.view_initkwargs['pattern_name'])
+
+        url = reverse("send_beta_feedback")
+        resolver = resolve(url)
+        self.assertEqual("/send-beta-feedback/", url)
+        self.assertEqual("send_beta_feedback_email", resolver.func.__name__)
+        self.assertEqual("tethys_apps.views", resolver.func.__module__)
+
+        url = reverse("test_app:home")
+        resolver = resolve(url)
+        self.assertEqual("/", url)
+        self.assertEqual(resolver.func.view_class, RedirectView)
+        self.assertEqual('user:profile', resolver.func.view_initkwargs['pattern_name'])
 
         url = reverse("test_extension:home", kwargs={"var1": "foo", "var2": "bar"})
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_apps/test_urls.py
+++ b/tests/unit_tests/test_tethys_apps/test_urls.py
@@ -2,8 +2,6 @@ from django.urls import reverse, resolve
 from tethys_sdk.testing import TethysTestCase
 from django.test import override_settings
 from django.urls.exceptions import NoReverseMatch
-from unittest import mock
-from django.views.generic.base import RedirectView
 
 
 class TestUrls(TethysTestCase):
@@ -153,67 +151,6 @@ class TestUrlsWithStandaloneApp(TethysTestCase):
         self.assertEqual("/", url)
         self.assertEqual("home", resolver.func.__name__)
         self.assertEqual("tethysapp.test_app.controllers", resolver.func.__module__)
-
-        url = reverse("test_extension:home", kwargs={"var1": "foo", "var2": "bar"})
-        resolver = resolve(url)
-        self.assertEqual("/extensions/foo/bar/", url)
-        self.assertEqual("home", resolver.func.__name__)
-        self.assertEqual(
-            "tethysext.test_extension.controllers", resolver.func.__module__
-        )
-
-
-@override_settings(MULTIPLE_APP_MODE=False)
-class TestUrlsWithStandaloneAppNoApp(TethysTestCase):
-    import sys
-    from importlib import reload, import_module
-    from django.conf import settings
-    from django.urls import clear_url_caches
-
-    @classmethod
-    def reload_urlconf(self, urlconf=None):
-        self.clear_url_caches()
-        if urlconf is None:
-            urlconf = self.settings.ROOT_URLCONF
-        if urlconf in self.sys.modules:
-            self.reload(self.sys.modules["tethys_apps.urls"])
-            self.reload(self.sys.modules[urlconf])
-        else:
-            self.import_module(urlconf)
-
-    @mock.patch("tethys_apps.utilities.get_configured_standalone_app")
-    def set_up(self, mock_get_configured_standalone_app):
-        mock_get_configured_standalone_app.return_value = []
-        self.reload_urlconf()
-        pass
-
-    @override_settings(MULTIPLE_APP_MODE=True)
-    def tearDown(self):
-        self.reload_urlconf()
-        pass
-
-    def test_urls(self):
-        # This executes the code at the module level
-        with self.assertRaises(NoReverseMatch):
-            reverse("app_library")
-
-        url = reverse("home")
-        resolver = resolve(url)
-        self.assertEqual("/", url)
-        self.assertEqual(resolver.func.view_class, RedirectView)
-        self.assertEqual('user:profile', resolver.func.view_initkwargs['pattern_name'])
-
-        url = reverse("send_beta_feedback")
-        resolver = resolve(url)
-        self.assertEqual("/send-beta-feedback/", url)
-        self.assertEqual("send_beta_feedback_email", resolver.func.__name__)
-        self.assertEqual("tethys_apps.views", resolver.func.__module__)
-
-        url = reverse("test_app:home")
-        resolver = resolve(url)
-        self.assertEqual("/", url)
-        self.assertEqual(resolver.func.view_class, RedirectView)
-        self.assertEqual('user:profile', resolver.func.view_initkwargs['pattern_name'])
 
         url = reverse("test_extension:home", kwargs={"var1": "foo", "var2": "bar"})
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_apps/test_urls.py
+++ b/tests/unit_tests/test_tethys_apps/test_urls.py
@@ -145,7 +145,7 @@ class TestUrlsWithStandaloneApp(TethysTestCase):
         resolver = resolve(url)
         self.assertEqual("/apps/", url)
         self.assertEqual("django.views.generic.base.RedirectView", resolver._func_path)
-        self.assertEqual("home", resolver.func.view_initkwargs["pattern_name"])
+        self.assertEqual("test_app:home", resolver.func.view_initkwargs["pattern_name"])
 
         url = reverse("send_beta_feedback")
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_apps/test_urls.py
+++ b/tests/unit_tests/test_tethys_apps/test_urls.py
@@ -1,6 +1,7 @@
 from django.urls import reverse, resolve
 from tethys_sdk.testing import TethysTestCase
 from django.test import override_settings
+from django.urls.exceptions import NoReverseMatch
 
 
 class TestUrls(TethysTestCase):
@@ -135,17 +136,9 @@ class TestUrlsWithStandaloneApp(TethysTestCase):
 
     def test_urls(self):
         # This executes the code at the module level
-        url = reverse("home")
-        resolver = resolve(url)
-        self.assertEqual("/", url)
-        self.assertEqual("home", resolver.func.__name__)
-        self.assertEqual("tethysapp.test_app.controllers", resolver.func.__module__)
-
-        url = reverse("app_library")
-        resolver = resolve(url)
-        self.assertEqual("/apps/", url)
-        self.assertEqual("django.views.generic.base.RedirectView", resolver._func_path)
-        self.assertEqual("test_app:home", resolver.func.view_initkwargs["pattern_name"])
+        with self.assertRaises(NoReverseMatch):
+            reverse("home")
+            reverse("app_library")
 
         url = reverse("send_beta_feedback")
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_apps/test_utilities.py
+++ b/tests/unit_tests/test_tethys_apps/test_utilities.py
@@ -1067,14 +1067,28 @@ class TestTethysAppsUtilitiesTethysTestCase(TethysTestCase):
     @override_settings(MULTIPLE_APP_MODE=False)
     def test_get_configured_standalone_app_no_app_name_no_installed(self):
         from tethys_apps.models import TethysApp
-        from django.core.exceptions import ObjectDoesNotExist
 
         with mock.patch(
             "tethys_apps.models.TethysApp", wraps=TethysApp
         ) as mock_tethysapp:
             mock_tethysapp.objects.first.return_value = []
-            with self.assertRaises(ObjectDoesNotExist):
-                utilities.get_configured_standalone_app()
+            app = utilities.get_configured_standalone_app()
+            
+            self.assertTrue(app == [])
+            mock_tethysapp.objects.first.assert_called_once()
+
+    @override_settings(MULTIPLE_APP_MODE=False)
+    def test_get_configured_standalone_app_db_not_ready(self):
+        from tethys_apps.models import TethysApp
+        from django.db.utils import ProgrammingError
+
+        with mock.patch(
+            "tethys_apps.models.TethysApp", wraps=TethysApp
+        ) as mock_tethysapp:
+            mock_tethysapp.objects.first.side_effect = [ProgrammingError]
+            app = utilities.get_configured_standalone_app()
+            
+            self.assertIsNone(app)
 
             mock_tethysapp.objects.first.assert_called_once()
 

--- a/tests/unit_tests/test_tethys_apps/test_utilities.py
+++ b/tests/unit_tests/test_tethys_apps/test_utilities.py
@@ -1073,7 +1073,7 @@ class TestTethysAppsUtilitiesTethysTestCase(TethysTestCase):
         ) as mock_tethysapp:
             mock_tethysapp.objects.first.return_value = []
             app = utilities.get_configured_standalone_app()
-            
+
             self.assertTrue(app == [])
             mock_tethysapp.objects.first.assert_called_once()
 
@@ -1087,7 +1087,7 @@ class TestTethysAppsUtilitiesTethysTestCase(TethysTestCase):
         ) as mock_tethysapp:
             mock_tethysapp.objects.first.side_effect = [ProgrammingError]
             app = utilities.get_configured_standalone_app()
-            
+
             self.assertIsNone(app)
 
             mock_tethysapp.objects.first.assert_called_once()

--- a/tests/unit_tests/test_tethys_apps/test_utilities.py
+++ b/tests/unit_tests/test_tethys_apps/test_utilities.py
@@ -1085,6 +1085,7 @@ class TestTethysAppsUtilitiesTethysTestCase(TethysTestCase):
         with mock.patch(
             "tethys_apps.models.TethysApp", wraps=TethysApp
         ) as mock_tethysapp:
+            mock_tethysapp.DoesNotExist = TethysApp.DoesNotExist
             mock_tethysapp.objects.first.side_effect = [ProgrammingError]
             app = utilities.get_configured_standalone_app()
 

--- a/tests/unit_tests/test_tethys_apps/test_utilities.py
+++ b/tests/unit_tests/test_tethys_apps/test_utilities.py
@@ -123,6 +123,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         self.assertTrue(test_app)
         self.assertTrue(test_ext)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     def test_get_active_app_none_none(self):
         # Get the active TethysApp object, with a request of None and url of None
         result = utilities.get_active_app(request=None, url=None)
@@ -132,6 +133,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         result = utilities.get_active_app()
         self.assertEqual(None, result)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_request(self, mock_app):
         # Mock up for TethysApp, and request
@@ -155,6 +157,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         result = utilities.get_active_app(request=mock_request)
         self.assertEqual(mock_tethysapp, result)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_url(self, mock_app):
         # Mock up for TethysApp
@@ -164,6 +167,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         result = utilities.get_active_app(url="/apps/foo/bar")
         self.assertEqual(mock_app.objects.get(), result)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.utilities.SingletonHarvester")
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_class(self, mock_app, mock_harvester):
@@ -177,6 +181,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         result = utilities.get_active_app(url="/apps/foo/bar", get_class=True)
         self.assertEqual(mock_app.objects.get(), result)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_request_bad_path(self, mock_app):
         # Mock up for TethysApp
@@ -189,6 +194,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         result = utilities.get_active_app(request=mock_request)
         self.assertEqual(None, result)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.utilities.tethys_log.warning")
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_request_exception1(self, mock_app, mock_log_warning):
@@ -206,6 +212,7 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
             'Could not locate app with root url "foo".'
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.utilities.tethys_log.warning")
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_request_exception2(self, mock_app, mock_log_warning):

--- a/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
+++ b/tests/unit_tests/test_tethys_cli/test_app_settings_command.py
@@ -2,6 +2,7 @@ import unittest
 import json
 from unittest import mock
 from django.core.exceptions import ObjectDoesNotExist
+from django.test import override_settings
 import tethys_cli.app_settings_commands as cli_app_settings_command
 from tethys_sdk.testing import TethysTestCase
 
@@ -1113,6 +1114,7 @@ class TestCliAppSettingsCommandTethysTestCase(TethysTestCase):
         self.assertEqual(mock_write_success.call_count, 1)
         mock_exit.assert_called_with(1)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_cli.app_settings_commands.Path.exists")
     @mock.patch("tethys_cli.app_settings_commands.call")
     @mock.patch("tethys_cli.app_settings_commands.gen_salt_string_for_setting")

--- a/tests/unit_tests/test_tethys_cli/test_list_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_list_commands.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+from django.test.utils import override_settings
 
 from tethys_cli.list_command import list_command
 
@@ -83,6 +84,7 @@ class ListCommandTests(unittest.TestCase):
         self.assertIn("  bar", check_list)
         self.assertIn("  baz", check_list)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_cli.list_command.write_msg")
     def test_list_command_urls(self, mock_msg):
         mock_args = mock.MagicMock(urls=True)

--- a/tests/unit_tests/test_tethys_config/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_config/test_context_processors.py
@@ -76,6 +76,42 @@ class TestTethysConfigContextProcessors(unittest.TestCase):
                 "secondary_text_hover_color": "#aaaaaa",
                 "brand_image": "test_app/images/icon.gif",
                 "brand_text": "Test App",
+                "site_title": "Test App",
+            },
+        }
+        self.assertDictEqual(expected_context, ret)
+
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("termsandconditions.models.TermsAndConditions")
+    @mock.patch("tethys_config.models.Setting")
+    @mock.patch("tethys_config.context_processors.get_configured_standalone_app")
+    def test_tethys_global_settings_context_single_app_mode_no_app(
+        self, mock_get_configured_standalone_app, mock_setting, mock_terms
+    ):
+        mock_request = mock.MagicMock()
+        mock_setting.as_dict.return_value = dict()
+        mock_terms.get_active_terms_list.return_value = ["active_terms"]
+        mock_terms.get_active_list.return_value = ["active_list"]
+        mock_get_configured_standalone_app.return_value = None
+
+        ret = tethys_global_settings_context(mock_request)
+
+        mock_setting.as_dict.assert_called_once()
+        mock_terms.get_active_terms_list.assert_called_once()
+        mock_terms.get_active_list.assert_not_called()
+        now = dt.datetime.now(dt.UTC)
+
+        expected_context = {
+            "site_defaults": {"copyright": f"Copyright © {now:%Y} Your Organization"},
+            "site_globals": {
+                "background_color": "#fefefe",
+                "documents": ["active_terms"],
+                "primary_color": "#0a62a9",
+                "primary_text_color": "#ffffff",
+                "primary_text_hover_color": "#eeeeee",
+                "secondary_color": "#a2d6f9",
+                "secondary_text_color": "#212529",
+                "secondary_text_hover_color": "#aaaaaa",
             },
         }
         self.assertDictEqual(expected_context, ret)

--- a/tests/unit_tests/test_tethys_config/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_config/test_context_processors.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import unittest
 from unittest import mock
+from django.test.utils import override_settings
 
 from tethys_config.context_processors import tethys_global_settings_context
 
@@ -41,4 +42,39 @@ class TestTethysConfigContextProcessors(unittest.TestCase):
             },
         }
 
+        self.assertDictEqual(expected_context, ret)
+
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("termsandconditions.models.TermsAndConditions")
+    @mock.patch("tethys_config.models.Setting")
+    def test_tethys_global_settings_context_single_app_mode(
+        self, mock_setting, mock_terms
+    ):
+        mock_request = mock.MagicMock()
+        mock_setting.as_dict.return_value = dict()
+        mock_terms.get_active_terms_list.return_value = ["active_terms"]
+        mock_terms.get_active_list.return_value = ["active_list"]
+
+        ret = tethys_global_settings_context(mock_request)
+
+        mock_setting.as_dict.assert_called_once()
+        mock_terms.get_active_terms_list.assert_called_once()
+        mock_terms.get_active_list.assert_not_called()
+        now = dt.datetime.now(dt.UTC)
+
+        expected_context = {
+            "site_defaults": {"copyright": f"Copyright © {now:%Y} Your Organization"},
+            "site_globals": {
+                "background_color": "#fefefe",
+                "documents": ["active_terms"],
+                "primary_color": "#0a62a9",
+                "primary_text_color": "#ffffff",
+                "primary_text_hover_color": "#eeeeee",
+                "secondary_color": "#a2d6f9",
+                "secondary_text_color": "#212529",
+                "secondary_text_hover_color": "#aaaaaa",
+                'brand_image': 'test_app/images/icon.gif',
+                'brand_text': 'Test App'
+            },
+        }
         self.assertDictEqual(expected_context, ret)

--- a/tests/unit_tests/test_tethys_config/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_config/test_context_processors.py
@@ -13,6 +13,7 @@ class TestTethysConfigContextProcessors(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("termsandconditions.models.TermsAndConditions")
     @mock.patch("tethys_config.models.Setting")
     def test_tethys_global_settings_context(self, mock_setting, mock_terms):

--- a/tests/unit_tests/test_tethys_config/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_config/test_context_processors.py
@@ -73,8 +73,8 @@ class TestTethysConfigContextProcessors(unittest.TestCase):
                 "secondary_color": "#a2d6f9",
                 "secondary_text_color": "#212529",
                 "secondary_text_hover_color": "#aaaaaa",
-                'brand_image': 'test_app/images/icon.gif',
-                'brand_text': 'Test App'
+                "brand_image": "test_app/images/icon.gif",
+                "brand_text": "Test App",
             },
         }
         self.assertDictEqual(expected_context, ret)

--- a/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
+++ b/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
@@ -2,7 +2,7 @@ import json
 import tempfile
 from unittest import mock
 import zipfile
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.http import JsonResponse
 
 from tethys_gizmos.gizmo_options import (
@@ -723,6 +723,7 @@ class TestMapLayout(TestCase):
             },
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     def test_build_legend_item(self):
         request = self.factory.post(
             "/some/endpoint",
@@ -829,6 +830,7 @@ class TestMapLayout(TestCase):
             },
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     def test_build_layer_tree_item_create(self):
         request = self.factory.post(
             "/some/endpoint",
@@ -984,6 +986,7 @@ class TestMapLayout(TestCase):
             },
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     def test_build_layer_tree_item_append_with_rename_remove_download(self):
         request = self.factory.post(
             "/some/endpoint",

--- a/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
+++ b/tests/unit_tests/test_tethys_layouts/test_views/test_map_layout.py
@@ -105,6 +105,7 @@ class TestMapLayout(TestCase):
     def setUp(self):
         self.inst = MapLayout()
         self.factory = RequestFactory()
+        self.mock_user = mock.MagicMock(is_active=True, is_authenticated=True)
 
     def tearDown(self):
         pass
@@ -737,6 +738,7 @@ class TestMapLayout(TestCase):
                 "layer_id": "12345",
             },
         )
+        request.user = self.mock_user
         controller = MapLayout.as_controller()
         ret = controller(request)
         self.assertIsInstance(ret, JsonResponse)
@@ -843,6 +845,7 @@ class TestMapLayout(TestCase):
                 "show_download": "false",
             },
         )
+        request.user = self.mock_user
 
         controller = MapLayout.as_controller()
         ret = controller(request)
@@ -997,6 +1000,7 @@ class TestMapLayout(TestCase):
                 "show_download": "true",
             },
         )
+        request.user = self.mock_user
 
         controller = MapLayout.as_controller()
         ret = controller(request)

--- a/tests/unit_tests/test_tethys_portal/test_asgi.py
+++ b/tests/unit_tests/test_tethys_portal/test_asgi.py
@@ -18,7 +18,7 @@ class TestAsgiApplication(TethysTestCase):
         self.assertIn("http", application.application_mapping)
 
 
-@override_settings(PREFIX_URL="test/prefix")
+@override_settings(PREFIX_URL="test/prefix", MULTIPLE_APP_MODE=True)
 class TestAsgiApplicationWithURLPrefix(TethysTestCase):
     import sys
     from importlib import reload, import_module
@@ -31,6 +31,7 @@ class TestAsgiApplicationWithURLPrefix(TethysTestCase):
         if urlconf is None:
             urlconf = self.settings.ROOT_URLCONF
         if urlconf in self.sys.modules:
+            self.reload(self.sys.modules["tethys_apps.urls"])
             self.reload(self.sys.modules[urlconf])
         else:
             self.import_module(urlconf)

--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -12,12 +12,17 @@ class TestStaticDependency(unittest.TestCase):
 
     @override_settings(MULTIPLE_APP_MODE=False)
     def test_check_single_app_mode_single(self):
-        single_app_mode = context_processors.check_single_app_mode()
+        single_app_mode, configured_single_app = (
+            context_processors.check_single_app_mode()
+        )
 
         self.assertTrue(single_app_mode)
-        self.assertTrue(single_app_mode.name == "Test App")
+        self.assertTrue(configured_single_app.name == "Test App")
 
     def test_check_single_app_mode_multiple(self):
-        single_app_mode = context_processors.check_single_app_mode()
+        single_app_mode, configured_single_app = (
+            context_processors.check_single_app_mode()
+        )
 
-        self.assertTrue(single_app_mode is None)
+        self.assertFalse(single_app_mode)
+        self.assertIsNone(configured_single_app)

--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -10,6 +10,7 @@ class TestTethysPortalContext(TestCase):
     def tearDown(self):
         pass
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     def test_context_processors_multiple_app_mode(self):
         mock_user = mock.MagicMock(is_authenticated=True, is_active=True)
         mock_request = mock.MagicMock(user=mock_user)

--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -12,13 +12,12 @@ class TestStaticDependency(unittest.TestCase):
 
     @override_settings(MULTIPLE_APP_MODE=False)
     def test_check_single_app_mode_single(self):
-        single_app_mode, single_app_name = context_processors.check_single_app_mode()
+        single_app_mode = context_processors.check_single_app_mode()
 
         self.assertTrue(single_app_mode)
-        self.assertTrue(single_app_name == "Test App")
+        self.assertTrue(single_app_mode.name == "Test App")
 
     def test_check_single_app_mode_multiple(self):
-        single_app_mode, single_app_name = context_processors.check_single_app_mode()
+        single_app_mode = context_processors.check_single_app_mode()
 
-        self.assertFalse(single_app_mode)
-        self.assertTrue(single_app_name is None)
+        self.assertTrue(single_app_mode is None)

--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -3,49 +3,57 @@ from django.test import override_settings
 from tethys_portal import context_processors
 
 
-class TestStaticDependency(TestCase):
+class TestTethysPortalContext(TestCase):
     def setUp(self):
         pass
 
     def tearDown(self):
         pass
 
-    @override_settings(MULTIPLE_APP_MODE=False)
-    @mock.patch("tethys_portal.context_processors.messages")
-    def test_check_single_app_mode_single(self, mock_messages):
-        mock_request = mock.MagicMock()
-        single_app_mode, configured_single_app = (
-            context_processors.check_single_app_mode(mock_request)
-        )
+    def test_context_processors_multiple_app_mode(self):
+        mock_user = mock.MagicMock(is_authenticated=True, is_active=True)
+        mock_request = mock.MagicMock(user=mock_user)
+        context = context_processors.tethys_portal_context(mock_request)
 
-        self.assertTrue(single_app_mode)
-        self.assertTrue(configured_single_app.name == "Test App")
-        mock_messages.assert_not_called()
+        expected_context = {
+            "has_analytical": True,
+            "has_terms": True,
+            "has_mfa": True,
+            "has_gravatar": True,
+            "has_session_security": True,
+            "has_oauth2_provider": True,
+            "show_app_library_button": True,
+            "single_app_mode": False,
+            "configured_single_app": None,
+            "idp_backends": {}.keys(),
+        }
+        self.assertTrue(context == expected_context)
 
     @override_settings(MULTIPLE_APP_MODE=False)
     @mock.patch("tethys_portal.context_processors.messages")
     @mock.patch("tethys_portal.context_processors.get_configured_standalone_app")
-    def test_check_single_app_mode_single_no_app(
+    def test_context_processors_single_app_mode(
         self, mock_get_configured_standalone_app, mock_messages
     ):
-        mock_request = mock.MagicMock()
+        mock_user = mock.MagicMock(is_authenticated=True, is_active=True)
+        mock_request = mock.MagicMock(user=mock_user)
         mock_get_configured_standalone_app.return_value = None
-        single_app_mode, configured_single_app = (
-            context_processors.check_single_app_mode(mock_request)
-        )
+        context = context_processors.tethys_portal_context(mock_request)
 
-        self.assertTrue(single_app_mode)
-        self.assertIsNone(configured_single_app)
+        expected_context = {
+            "has_analytical": True,
+            "has_terms": True,
+            "has_mfa": True,
+            "has_gravatar": True,
+            "has_session_security": True,
+            "has_oauth2_provider": True,
+            "show_app_library_button": False,
+            "single_app_mode": True,
+            "configured_single_app": None,
+            "idp_backends": {}.keys(),
+        }
+        self.assertTrue(context == expected_context)
         mock_messages.warning.assert_called_with(
             mock_request,
-            "MULTIPLE_APP_MODE is disabled but there is no configured tethys application.",
+            "MULTIPLE_APP_MODE is disabled but there is no Tethys application installed.",
         )
-
-    def test_check_single_app_mode_multiple(self):
-        mock_request = mock.MagicMock()
-        single_app_mode, configured_single_app = (
-            context_processors.check_single_app_mode(mock_request)
-        )
-
-        self.assertFalse(single_app_mode)
-        self.assertIsNone(configured_single_app)

--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -1,9 +1,9 @@
-import unittest
+from unittest import TestCase, mock
 from django.test import override_settings
 from tethys_portal import context_processors
 
 
-class TestStaticDependency(unittest.TestCase):
+class TestStaticDependency(TestCase):
     def setUp(self):
         pass
 
@@ -11,17 +11,40 @@ class TestStaticDependency(unittest.TestCase):
         pass
 
     @override_settings(MULTIPLE_APP_MODE=False)
-    def test_check_single_app_mode_single(self):
+    @mock.patch("tethys_portal.context_processors.messages")
+    def test_check_single_app_mode_single(self, mock_messages):
+        mock_request = mock.MagicMock()
         single_app_mode, configured_single_app = (
-            context_processors.check_single_app_mode()
+            context_processors.check_single_app_mode(mock_request)
         )
 
         self.assertTrue(single_app_mode)
         self.assertTrue(configured_single_app.name == "Test App")
+        mock_messages.assert_not_called()
+
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_portal.context_processors.messages")
+    @mock.patch("tethys_portal.context_processors.get_configured_standalone_app")
+    def test_check_single_app_mode_single_no_app(
+        self, mock_get_configured_standalone_app, mock_messages
+    ):
+        mock_request = mock.MagicMock()
+        mock_get_configured_standalone_app.return_value = None
+        single_app_mode, configured_single_app = (
+            context_processors.check_single_app_mode(mock_request)
+        )
+
+        self.assertTrue(single_app_mode)
+        self.assertIsNone(configured_single_app)
+        mock_messages.warning.assert_called_with(
+            mock_request,
+            "MULTIPLE_APP_MODE is disabled but there is no configured tethys application.",
+        )
 
     def test_check_single_app_mode_multiple(self):
+        mock_request = mock.MagicMock()
         single_app_mode, configured_single_app = (
-            context_processors.check_single_app_mode()
+            context_processors.check_single_app_mode(mock_request)
         )
 
         self.assertFalse(single_app_mode)

--- a/tests/unit_tests/test_tethys_portal/test_utilities.py
+++ b/tests/unit_tests/test_tethys_portal/test_utilities.py
@@ -91,33 +91,6 @@ class TethysPortalUtilitiesTests(unittest.TestCase):
         # mock redirect after logged in using next parameter or default to user profile
         mock_redirect.assert_called_once_with("/")
 
-    @override_settings(MULTIPLE_APP_MODE=False)
-    @mock.patch("tethys_portal.utilities.login")
-    @mock.patch("tethys_portal.utilities.redirect")
-    @mock.patch("tethys_portal.utilities.get_configured_standalone_app")
-    def test_utilities_no_user_exist_single_app_mode_no_app(
-        self, mock_get_configured_standalone_app, mock_redirect, mock_authenticate
-    ):
-        mock_request = mock.MagicMock()
-        mock_request.method = "POST"
-        mock_request.POST = "login-submit"
-        mock_request.user.is_anonymous = True
-        mock_request.user.username = "sam"
-        mock_request.GET = ""
-        mock_get_configured_standalone_app.return_value = None
-
-        # mock authenticate
-        mock_user = mock.MagicMock()
-        mock_authenticate.return_value = mock_user
-
-        # mock the password has been verified for the user
-        mock_user.is_active = True
-
-        utilities.log_user_in(mock_request, user=mock_user)
-
-        # mock redirect after logged in using next parameter or default to user profile
-        mock_redirect.assert_called_once_with("user:profile")
-
     @mock.patch("tethys_portal.utilities.login")
     @mock.patch("tethys_portal.utilities.redirect")
     def test_utilities_no_user_exist_next(self, mock_redirect, mock_authenticate):

--- a/tests/unit_tests/test_tethys_portal/test_utilities.py
+++ b/tests/unit_tests/test_tethys_portal/test_utilities.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 import unittest
 from unittest import mock
+from django.test import override_settings
 
 from tethys_portal import utilities
 
@@ -64,6 +65,29 @@ class TethysPortalUtilitiesTests(unittest.TestCase):
 
         # mock redirect after logged in using next parameter or default to user profile
         mock_redirect.assert_called_once_with("app_library")
+
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_portal.utilities.login")
+    @mock.patch("tethys_portal.utilities.redirect")
+    def test_utilities_no_user_exist_single_app_mode(self, mock_redirect, mock_authenticate):
+        mock_request = mock.MagicMock()
+        mock_request.method = "POST"
+        mock_request.POST = "login-submit"
+        mock_request.user.is_anonymous = True
+        mock_request.user.username = "sam"
+        mock_request.GET = ""
+
+        # mock authenticate
+        mock_user = mock.MagicMock()
+        mock_authenticate.return_value = mock_user
+
+        # mock the password has been verified for the user
+        mock_user.is_active = True
+
+        utilities.log_user_in(mock_request, user=mock_user)
+
+        # mock redirect after logged in using next parameter or default to user profile
+        mock_redirect.assert_called_once_with("/")
 
     @mock.patch("tethys_portal.utilities.login")
     @mock.patch("tethys_portal.utilities.redirect")

--- a/tests/unit_tests/test_tethys_portal/test_utilities.py
+++ b/tests/unit_tests/test_tethys_portal/test_utilities.py
@@ -44,6 +44,7 @@ class TethysPortalUtilitiesTests(unittest.TestCase):
         # mock redirect after logged in using next parameter or default to user profile
         mock_redirect.assert_called_once_with("accounts:login")
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_portal.utilities.login")
     @mock.patch("tethys_portal.utilities.redirect")
     def test_utilities_no_user_exist(self, mock_redirect, mock_authenticate):

--- a/tests/unit_tests/test_tethys_portal/test_utilities.py
+++ b/tests/unit_tests/test_tethys_portal/test_utilities.py
@@ -69,7 +69,9 @@ class TethysPortalUtilitiesTests(unittest.TestCase):
     @override_settings(MULTIPLE_APP_MODE=False)
     @mock.patch("tethys_portal.utilities.login")
     @mock.patch("tethys_portal.utilities.redirect")
-    def test_utilities_no_user_exist_single_app_mode(self, mock_redirect, mock_authenticate):
+    def test_utilities_no_user_exist_single_app_mode(
+        self, mock_redirect, mock_authenticate
+    ):
         mock_request = mock.MagicMock()
         mock_request.method = "POST"
         mock_request.POST = "login-submit"

--- a/tests/unit_tests/test_tethys_portal/test_utilities.py
+++ b/tests/unit_tests/test_tethys_portal/test_utilities.py
@@ -91,6 +91,33 @@ class TethysPortalUtilitiesTests(unittest.TestCase):
         # mock redirect after logged in using next parameter or default to user profile
         mock_redirect.assert_called_once_with("/")
 
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_portal.utilities.login")
+    @mock.patch("tethys_portal.utilities.redirect")
+    @mock.patch("tethys_portal.utilities.get_configured_standalone_app")
+    def test_utilities_no_user_exist_single_app_mode_no_app(
+        self, mock_get_configured_standalone_app, mock_redirect, mock_authenticate
+    ):
+        mock_request = mock.MagicMock()
+        mock_request.method = "POST"
+        mock_request.POST = "login-submit"
+        mock_request.user.is_anonymous = True
+        mock_request.user.username = "sam"
+        mock_request.GET = ""
+        mock_get_configured_standalone_app.return_value = None
+
+        # mock authenticate
+        mock_user = mock.MagicMock()
+        mock_authenticate.return_value = mock_user
+
+        # mock the password has been verified for the user
+        mock_user.is_active = True
+
+        utilities.log_user_in(mock_request, user=mock_user)
+
+        # mock redirect after logged in using next parameter or default to user profile
+        mock_redirect.assert_called_once_with("user:profile")
+
     @mock.patch("tethys_portal.utilities.login")
     @mock.patch("tethys_portal.utilities.redirect")
     def test_utilities_no_user_exist_next(self, mock_redirect, mock_authenticate):

--- a/tests/unit_tests/test_tethys_portal/test_views/test_accounts.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_accounts.py
@@ -645,6 +645,7 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
 
         mock_get_template.assert_called_once()
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_portal.views.accounts.messages")
     @mock.patch("tethys_portal.views.accounts.logout")
     @mock.patch("tethys_portal.views.accounts.redirect")

--- a/tests/unit_tests/test_tethys_portal/test_views/test_accounts.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_accounts.py
@@ -668,3 +668,30 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
         )
 
         mock_redirect.assert_called_once_with("home")
+
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_portal.views.accounts.messages")
+    @mock.patch("tethys_portal.views.accounts.logout")
+    @mock.patch("tethys_portal.views.accounts.redirect")
+    def test_logout_view_with_single_app_mode(
+        self, mock_redirect, mock_logout, mock_messages
+    ):
+        mock_request = mock.MagicMock()
+        mock_request.user.is_anonymous = False
+        mock_request.user.first_name = "foo"
+        mock_request.user.username = "bar"
+
+        mock_redirect.return_value = "home"
+
+        ret = logout_view(mock_request)
+
+        self.assertEqual("home", ret)
+
+        mock_logout.assert_called_once_with(mock_request)
+
+        mock_messages.success.assert_called_once_with(
+            mock_request,
+            "Goodbye, {0}. Come back soon!".format(mock_request.user.first_name),
+        )
+
+        mock_redirect.assert_called_once_with("accounts:login")

--- a/tests/unit_tests/test_tethys_portal/test_views/test_api.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_api.py
@@ -80,6 +80,7 @@ class TethysPortalApiTests(TethysTestCase):
         self.assertEqual("foo", json["username"])
         self.assertTrue(json["isAuthenticated"])
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @override_settings(STATIC_URL="/static")
     @override_settings(PREFIX_URL="/")
     @override_settings(LOGIN_URL="/accounts/login/")
@@ -117,6 +118,7 @@ class TethysPortalApiTests(TethysTestCase):
             r"^/admin/tethys_apps/tethysapp/[0-9]+/change/$",
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @override_settings(PREFIX_URL="test/prefix")
     @override_settings(LOGIN_URL="/test/prefix/test/login/")
     @override_settings(STATIC_URL="/test/prefix/test/static/")
@@ -156,6 +158,7 @@ class TethysPortalApiTests(TethysTestCase):
             r"^/test/prefix/admin/tethys_apps/tethysapp/[0-9]+/change/$",
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @override_settings(STATIC_URL="/static")
     @override_settings(PREFIX_URL="/")
     @override_settings(LOGIN_URL="/accounts/login/")

--- a/tests/unit_tests/test_tethys_portal/test_views/test_user.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_user.py
@@ -406,6 +406,7 @@ class TethysPortalUserTests(unittest.TestCase):
             mock_request, "tethys_portal/user/disconnect.html", expected_context
         )
 
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_portal.views.user.messages.success")
     @mock.patch("tethys_portal.views.user.logout")
     @mock.patch("tethys_portal.views.user.redirect")

--- a/tests/unit_tests/test_tethys_portal/test_views/test_user.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_user.py
@@ -433,6 +433,34 @@ class TethysPortalUserTests(unittest.TestCase):
 
         mock_redirect.assert_called_once_with("home")
 
+    @override_settings(MULTIPLE_APP_MODE=False)
+    @mock.patch("tethys_portal.views.user.messages.success")
+    @mock.patch("tethys_portal.views.user.logout")
+    @mock.patch("tethys_portal.views.user.redirect")
+    def test_delete_account_post_with_single_app_mode(
+        self, mock_redirect, mock_logout, mock_messages_success
+    ):
+        mock_user = mock.MagicMock()
+        mock_user.username = "foo"
+
+        mock_request = mock.MagicMock()
+        mock_request.user = mock_user
+
+        mock_request.method = "POST"
+        mock_request.POST = "delete-account-submit"
+
+        delete_account(mock_request)
+
+        mock_request.user.delete.assert_called()
+
+        mock_logout.assert_called_once_with(mock_request)
+
+        mock_messages_success.assert_called_once_with(
+            mock_request, "Your account has been successfully deleted."
+        )
+
+        mock_redirect.assert_called_once_with("accounts:login")
+
     @mock.patch("tethys_portal.views.user.render")
     def test_delete_account_not_post(self, mock_render):
         mock_user = mock.MagicMock()

--- a/tests/unit_tests/test_tethys_services/test_backends/test_hydroshare.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_hydroshare.py
@@ -58,7 +58,9 @@ class HydroShareBackendTest(unittest.TestCase):
 
         hydro_share_auth2_obj.set_expires_in_to = 100
 
-        ret = hydro_share_auth2_obj.extra_data("user1", "0001-009", mock_response)
+        ret = hydro_share_auth2_obj.extra_data(
+            "user1", "0001-009", mock_response, details={}
+        )
 
         self.assertEqual("foo@gmail.com", ret["email"])
         self.assertEqual("token1", ret["access_token"])

--- a/tethys_apps/decorators.py
+++ b/tethys_apps/decorators.py
@@ -168,7 +168,10 @@ def permission_required(*args, **kwargs):
                         messages.add_message(request, messages.WARNING, message)
 
                         # Default redirect URL
-                        redirect_url = reverse("app_library")
+                        if settings.MULTIPLE_APP_MODE:
+                            redirect_url = reverse("app_library")
+                        else:
+                            redirect_url = reverse("user:profile")
 
                         # If there is a referer (i.e.: we followed a link to get here)
                         if "HTTP_REFERER" in request.META:

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -16,7 +16,6 @@ from tethys_apps.views import library, send_beta_feedback_email
 from tethys_apps.utilities import get_configured_standalone_app
 from django.conf import settings
 from django.conf.urls.static import static
-from django.views.generic.base import RedirectView
 
 tethys_log = logging.getLogger("tethys." + __name__)
 prefix_url = f"{settings.PREFIX_URL}"
@@ -34,8 +33,6 @@ else:
     standalone_app = get_configured_standalone_app()
     if standalone_app:
         url_namespaces = [standalone_app.url_namespace]
-    else:
-        urlpatterns.append(re_path(r"^$", RedirectView.as_view(pattern_name="user:profile"), name="home"))
 
 # Append the app urls urlpatterns
 harvester = SingletonHarvester()

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -16,6 +16,7 @@ from tethys_apps.views import library, send_beta_feedback_email
 from tethys_apps.utilities import get_configured_standalone_app
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 
 tethys_log = logging.getLogger("tethys." + __name__)
 prefix_url = f"{settings.PREFIX_URL}"
@@ -33,6 +34,12 @@ else:
     standalone_app = get_configured_standalone_app()
     if standalone_app:
         url_namespaces = [standalone_app.url_namespace]
+    else:
+        urlpatterns.append(
+            re_path(
+                r"^$", RedirectView.as_view(pattern_name="user:profile"), name="home"
+            )
+        )
 
 # Append the app urls urlpatterns
 harvester = SingletonHarvester()

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -9,6 +9,7 @@
 """
 
 import logging
+import copy
 from django.urls import include, re_path
 from channels.routing import URLRouter
 from django.views.generic import RedirectView
@@ -35,7 +36,7 @@ else:
     urlpatterns.append(
         re_path(
             r"^apps/",
-            RedirectView.as_view(pattern_name="home"),
+            RedirectView.as_view(pattern_name=standalone_app.index_url),
             name="app_library",
         )
     )
@@ -66,14 +67,11 @@ for namespace, urls in normal_url_patterns["app_url_patterns"].items():
         root_pattern = r"^{0}/".format(namespace.replace("_", "-"))
     else:
         root_pattern = ""
-        home_urls = [url for url in urls if url.name == "home"]
-        urlpatterns.append(
-            re_path(
-                r"",
-                include(home_urls[:1]),
-                name="home",
-            ),
-        )
+        index_urls = [url for url in urls if url.name == standalone_app.index]
+        app_index_url = copy.deepcopy(index_urls[0])
+        app_index_url.name = "home"
+        app_index_url.pattern.name = "home"
+        urlpatterns.append(app_index_url)
 
     urlpatterns.append(
         re_path(root_pattern, include((urls, namespace), namespace=namespace))

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -33,13 +33,6 @@ if settings.MULTIPLE_APP_MODE:
     url_namespaces = None
 else:
     standalone_app = get_configured_standalone_app()
-    urlpatterns.append(
-        re_path(
-            r"^apps/",
-            RedirectView.as_view(pattern_name=standalone_app.index_url),
-            name="app_library",
-        )
-    )
     url_namespaces = [standalone_app.url_namespace]
 
 # Append the app urls urlpatterns
@@ -67,11 +60,6 @@ for namespace, urls in normal_url_patterns["app_url_patterns"].items():
         root_pattern = r"^{0}/".format(namespace.replace("_", "-"))
     else:
         root_pattern = ""
-        index_urls = [url for url in urls if url.name == standalone_app.index]
-        app_index_url = copy.deepcopy(index_urls[0])
-        app_index_url.name = "home"
-        app_index_url.pattern.name = "home"
-        urlpatterns.append(app_index_url)
 
     urlpatterns.append(
         re_path(root_pattern, include((urls, namespace), namespace=namespace))

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -9,10 +9,8 @@
 """
 
 import logging
-import copy
 from django.urls import include, re_path
 from channels.routing import URLRouter
-from django.views.generic import RedirectView
 from tethys_apps.harvester import SingletonHarvester
 from tethys_apps.views import library, send_beta_feedback_email
 from tethys_apps.utilities import get_configured_standalone_app

--- a/tethys_apps/urls.py
+++ b/tethys_apps/urls.py
@@ -16,6 +16,7 @@ from tethys_apps.views import library, send_beta_feedback_email
 from tethys_apps.utilities import get_configured_standalone_app
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 
 tethys_log = logging.getLogger("tethys." + __name__)
 prefix_url = f"{settings.PREFIX_URL}"
@@ -26,12 +27,15 @@ urlpatterns = [
     ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+url_namespaces = None
 if settings.MULTIPLE_APP_MODE:
     urlpatterns.append(re_path(r"^$", library, name="app_library"))
-    url_namespaces = None
 else:
     standalone_app = get_configured_standalone_app()
-    url_namespaces = [standalone_app.url_namespace]
+    if standalone_app:
+        url_namespaces = [standalone_app.url_namespace]
+    else:
+        urlpatterns.append(re_path(r"^$", RedirectView.as_view(pattern_name="user:profile"), name="home"))
 
 # Append the app urls urlpatterns
 harvester = SingletonHarvester()

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -628,11 +628,11 @@ def get_configured_standalone_app():
             app = TethysApp.objects.get(package=standalone_app)
         else:
             app = TethysApp.objects.first()
-    except ProgrammingError as e:
-        # This catch ensures that tethys can still configuration commands when tethys portal is being created
-        tethys_log.warning(
-            f"{str(e)}. Process will continue with the assumption that tethys is still being setup"
-        )
+    except ProgrammingError:
+        # When MULTIPLE_APP_MODE is enabled but there is no app installed, then setting up the tethys DB fails because
+        # the code is trying to fetch data from a table that doesn't exist. Catch this exception and pass so setup can
+        # finish
+        pass
 
     return app
 

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -29,6 +29,7 @@ from tethys_apps.base.mixins import (
 )
 from tethys_apps.exceptions import TethysAppSettingNotAssigned
 from .harvester import SingletonHarvester
+from django.db.utils import ProgrammingError
 
 tethys_log = logging.getLogger("tethys." + __name__)
 
@@ -620,13 +621,16 @@ def get_configured_standalone_app():
     from tethys_apps.models import TethysApp
 
     standalone_app = settings.STANDALONE_APP
+    app = None
 
-    if standalone_app:
-        app = TethysApp.objects.get(package=standalone_app)
-    else:
-        app = TethysApp.objects.first()
-        if not app:
-            raise ObjectDoesNotExist("No Tethys Apps have been installed")
+    try:
+        if standalone_app:
+            app = TethysApp.objects.get(package=standalone_app)
+        else:
+            app = TethysApp.objects.first()
+    except ProgrammingError as e:
+        # This catch ensures that tethys can still configuration commands when tethys portal is being created
+        tethys_log.warning(f"{str(e)}. Process will continue with the assumption that tethys is still being setup")
 
     return app
 

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -622,16 +622,13 @@ def get_configured_standalone_app():
 
     standalone_app = settings.STANDALONE_APP
     app = None
-
     try:
         if standalone_app:
             app = TethysApp.objects.get(package=standalone_app)
         else:
             app = TethysApp.objects.first()
-    except ProgrammingError:
-        # When MULTIPLE_APP_MODE is enabled but there is no app installed, then setting up the tethys DB fails because
-        # the code is trying to fetch data from a table that doesn't exist. Catch this exception and pass so setup can
-        # finish
+    except (ProgrammingError, TethysApp.DoesNotExist):
+        # If a tethys application is not actually installed or DB is not setup yet, continue and the UI will notify the user
         pass
 
     return app

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -630,7 +630,9 @@ def get_configured_standalone_app():
             app = TethysApp.objects.first()
     except ProgrammingError as e:
         # This catch ensures that tethys can still configuration commands when tethys portal is being created
-        tethys_log.warning(f"{str(e)}. Process will continue with the assumption that tethys is still being setup")
+        tethys_log.warning(
+            f"{str(e)}. Process will continue with the assumption that tethys is still being setup"
+        )
 
     return app
 

--- a/tethys_config/context_processors.py
+++ b/tethys_config/context_processors.py
@@ -9,7 +9,10 @@
 """
 
 import datetime as dt
+import re
+from django.conf import settings
 from tethys_portal.optional_dependencies import optional_import, has_module
+from tethys_apps.utilities import get_configured_standalone_app
 
 
 def tethys_global_settings_context(request):
@@ -51,6 +54,19 @@ def tethys_global_settings_context(request):
     # Get terms and conditions
     if has_module(TermsAndConditions):
         site_globals.update({"documents": TermsAndConditions.get_active_terms_list()})
+
+    # Override settings for single app mode
+    if not settings.MULTIPLE_APP_MODE:
+        configured_single_app = get_configured_standalone_app()
+        brand_image = site_globals.get("brand_image", "")
+        brand_text = site_globals.get("brand_text")
+        if configured_single_app and (
+            not brand_image
+            or re.match(r"/tethys_portal/images/tethys-logo-\d{2}.png", brand_image)
+        ):
+            site_globals["brand_image"] = configured_single_app.icon
+        if configured_single_app and (not brand_text or brand_text == "Tethys Portal"):
+            site_globals["brand_text"] = configured_single_app.name
 
     context = {
         "site_globals": site_globals,

--- a/tethys_config/context_processors.py
+++ b/tethys_config/context_processors.py
@@ -60,6 +60,7 @@ def tethys_global_settings_context(request):
         configured_single_app = get_configured_standalone_app()
         brand_image = site_globals.get("brand_image", "")
         brand_text = site_globals.get("brand_text")
+        site_title = site_globals.get("site_title")
         if configured_single_app and (
             not brand_image
             or re.match(r"/tethys_portal/images/tethys-logo-\d{2}.png", brand_image)
@@ -67,6 +68,8 @@ def tethys_global_settings_context(request):
             site_globals["brand_image"] = configured_single_app.icon
         if configured_single_app and (not brand_text or brand_text == "Tethys Portal"):
             site_globals["brand_text"] = configured_single_app.name
+        if configured_single_app and (not site_title or site_title == "Tethys Portal"):
+            site_globals["site_title"] = configured_single_app.name
 
     context = {
         "site_globals": site_globals,

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -10,6 +10,7 @@
 
 from .optional_dependencies import has_module
 from django.conf import settings
+from django.contrib import messages
 from tethys_apps.utilities import get_configured_standalone_app
 
 
@@ -20,7 +21,7 @@ def tethys_portal_context(request):
         else {}
     )
 
-    single_app_mode, configured_single_app = check_single_app_mode()
+    single_app_mode, configured_single_app = check_single_app_mode(request)
 
     context = {
         "has_analytical": has_module("analytical"),
@@ -37,8 +38,15 @@ def tethys_portal_context(request):
     return context
 
 
-def check_single_app_mode():
+def check_single_app_mode(request):
     if settings.MULTIPLE_APP_MODE:
         return False, None
     else:
-        return True, get_configured_standalone_app()
+        configured_app = get_configured_standalone_app()
+        if not configured_app:
+            messages.warning(
+                request,
+                "MULTIPLE_APP_MODE is disabled but there is no configured tethys application.",
+            )
+
+        return True, configured_app

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -20,7 +20,7 @@ def tethys_portal_context(request):
         else {}
     )
 
-    single_app_mode, single_app_name = check_single_app_mode()
+    standalone_app = check_single_app_mode()
 
     context = {
         "has_analytical": has_module("analytical"),
@@ -29,8 +29,7 @@ def tethys_portal_context(request):
         "has_gravatar": has_module("django_gravatar"),
         "has_session_security": has_module("session_security"),
         "has_oauth2_provider": has_module("oauth2_provider"),
-        "single_app_mode": single_app_mode,
-        "single_app_name": single_app_name,
+        "single_app_mode": standalone_app if standalone_app else False,
         "idp_backends": idps.keys(),
     }
 
@@ -39,6 +38,6 @@ def tethys_portal_context(request):
 
 def check_single_app_mode():
     if settings.MULTIPLE_APP_MODE:
-        return False, None
+        return None
     else:
-        return True, get_configured_standalone_app().name
+        return get_configured_standalone_app()

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -21,7 +21,24 @@ def tethys_portal_context(request):
         else {}
     )
 
-    single_app_mode, configured_single_app = check_single_app_mode(request)
+    configured_single_app = None
+    if not settings.MULTIPLE_APP_MODE:
+        configured_single_app = get_configured_standalone_app()
+        if not configured_single_app:
+            messages.warning(
+                request,
+                "MULTIPLE_APP_MODE is disabled but there is no Tethys application installed.",
+            )
+
+    show_app_library_button = (
+        True
+        if settings.MULTIPLE_APP_MODE
+        and (
+            settings.ENABLE_OPEN_PORTAL
+            or (request.user.is_authenticated and request.user.is_active)
+        )
+        else False
+    )
 
     context = {
         "has_analytical": has_module("analytical"),
@@ -30,23 +47,10 @@ def tethys_portal_context(request):
         "has_gravatar": has_module("django_gravatar"),
         "has_session_security": has_module("session_security"),
         "has_oauth2_provider": has_module("oauth2_provider"),
-        "single_app_mode": single_app_mode,
+        "show_app_library_button": show_app_library_button,
+        "single_app_mode": not settings.MULTIPLE_APP_MODE,
         "configured_single_app": configured_single_app,
         "idp_backends": idps.keys(),
     }
 
     return context
-
-
-def check_single_app_mode(request):
-    if settings.MULTIPLE_APP_MODE:
-        return False, None
-    else:
-        configured_app = get_configured_standalone_app()
-        if not configured_app:
-            messages.warning(
-                request,
-                "MULTIPLE_APP_MODE is disabled but there is no configured tethys application.",
-            )
-
-        return True, configured_app

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -20,7 +20,7 @@ def tethys_portal_context(request):
         else {}
     )
 
-    standalone_app = check_single_app_mode()
+    single_app_mode, configured_single_app = check_single_app_mode()
 
     context = {
         "has_analytical": has_module("analytical"),
@@ -29,7 +29,8 @@ def tethys_portal_context(request):
         "has_gravatar": has_module("django_gravatar"),
         "has_session_security": has_module("session_security"),
         "has_oauth2_provider": has_module("oauth2_provider"),
-        "single_app_mode": standalone_app if standalone_app else False,
+        "single_app_mode": single_app_mode,
+        "configured_single_app": configured_single_app,
         "idp_backends": idps.keys(),
     }
 
@@ -38,6 +39,6 @@ def tethys_portal_context(request):
 
 def check_single_app_mode():
     if settings.MULTIPLE_APP_MODE:
-        return None
+        return False, None
     else:
-        return get_configured_standalone_app()
+        return True, get_configured_standalone_app()

--- a/tethys_portal/templates/header.html
+++ b/tethys_portal/templates/header.html
@@ -5,7 +5,7 @@
   <nav id="header-navbar" class="navbar navbar-expand-md navbar-dark shadow px-4 py-3 mx-3" style="background-color: {{ site_globals.primary_color|default:'#0a62a9' }};">
     <div class="container-fluid">
       {% block header_brand %}
-        <a id="header-brand" class="navbar-brand" href="{% url 'home' %}">
+        <a id="header-brand" class="navbar-brand" href="{% if single_app_mode %} {% url single_app_mode.index_url %} {% else %} {% url 'home' %} {% endif %}">
           {% if site_globals.brand_image and 'http' in site_globals.brand_image %}
             <img  src="{{ site_globals.brand_image }}" alt="" class="d-inline-block align-text-top">
           {% elif site_globals.brand_image %}
@@ -27,10 +27,14 @@
       <div id="header-navbar-nav" class="collapse navbar-collapse">
         <ul class="navbar-nav ms-auto">
           {% block header_nav_items %}
-            {% url 'app_library' as app_library_url %}
+            {% if single_app_mode %}
+              {% url single_app_mode.index_url as header_url %}
+            {% else %}
+              {% url 'app_library' as header_url %}
+            {% endif %}
             {% if ENABLE_OPEN_PORTAL or user.is_authenticated and user.is_active %}
               <li class="nav-item">
-                <a class="h5 me-3 mb-0 nav-link{% if request.path == app_library_url %} active" aria-current="page{% endif %}" href="{{ app_library_url }}" title="{% if single_app_name %}{{ single_app_name }}{% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_name %}{{ single_app_name }}{% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
+                <a class="h5 me-3 mb-0 nav-link{% if request.path == header_url %} active" aria-current="page{% endif %}" href="{{ header_url }}" title="{% if single_app_mode %}{{ single_app_mode.name }}{% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_mode %}{{ single_app_mode.name }}{% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
               </li>
             {% endif %}
           {% endblock %}

--- a/tethys_portal/templates/header.html
+++ b/tethys_portal/templates/header.html
@@ -27,21 +27,11 @@
       <div id="header-navbar-nav" class="collapse navbar-collapse">
         <ul class="navbar-nav ms-auto">
           {% block header_nav_items %}
-            {% if single_app_mode %}
-              {% if configured_single_app %}
-                {% url configured_single_app.index_url as header_url %}
-              {% else %} 
-                {% url 'user:profile' as header_url  %} 
-              {% endif %}
-            {% else %}
-              {% url 'app_library' as header_url %}
-            {% endif %}
-            {% if ENABLE_OPEN_PORTAL or user.is_authenticated and user.is_active %}
-              {% if not single_app_mode or single_app_mode and configured_single_app.name %}
+            {% url 'app_library' as app_library_url %}
+            {% if show_app_library_button %}
                 <li class="nav-item">
-                  <a class="h5 me-3 mb-0 nav-link{% if request.path == header_url %} active" aria-current="page{% endif %}" href="{{ header_url }}" title="{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }} {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }} {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
+                  <a class="h5 me-3 mb-0 nav-link{% if request.path == app_library_url %} active" aria-current="page{% endif %}" href="{{ app_library_url }}" title="{% if site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
                 </li>
-              {% endif %}
             {% endif %}
           {% endblock %}
         </ul>

--- a/tethys_portal/templates/header.html
+++ b/tethys_portal/templates/header.html
@@ -37,9 +37,11 @@
               {% url 'app_library' as header_url %}
             {% endif %}
             {% if ENABLE_OPEN_PORTAL or user.is_authenticated and user.is_active %}
-              <li class="nav-item">
-                <a class="h5 me-3 mb-0 nav-link{% if request.path == header_url %} active" aria-current="page{% endif %}" href="{{ header_url }}" title="{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }}  {% else %} No Configured Apps {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }}  {% else %} No Configured Apps {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
-              </li>
+              {% if not single_app_mode or single_app_mode and configured_single_app.name %}
+                <li class="nav-item">
+                  <a class="h5 me-3 mb-0 nav-link{% if request.path == header_url %} active" aria-current="page{% endif %}" href="{{ header_url }}" title="{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }} {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }} {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
+                </li>
+              {% endif %}
             {% endif %}
           {% endblock %}
         </ul>

--- a/tethys_portal/templates/header.html
+++ b/tethys_portal/templates/header.html
@@ -5,7 +5,7 @@
   <nav id="header-navbar" class="navbar navbar-expand-md navbar-dark shadow px-4 py-3 mx-3" style="background-color: {{ site_globals.primary_color|default:'#0a62a9' }};">
     <div class="container-fluid">
       {% block header_brand %}
-        <a id="header-brand" class="navbar-brand" href="{% if single_app_mode %} {% url single_app_mode.index_url %} {% else %} {% url 'home' %} {% endif %}">
+        <a id="header-brand" class="navbar-brand" href="{% if single_app_mode %} {% if configured_single_app %} {% url configured_single_app.index_url %}  {% else %} {% url 'user:profile' %} {% endif %} {% else %} {% url 'home' %} {% endif %}">
           {% if site_globals.brand_image and 'http' in site_globals.brand_image %}
             <img  src="{{ site_globals.brand_image }}" alt="" class="d-inline-block align-text-top">
           {% elif site_globals.brand_image %}
@@ -28,13 +28,17 @@
         <ul class="navbar-nav ms-auto">
           {% block header_nav_items %}
             {% if single_app_mode %}
-              {% url single_app_mode.index_url as header_url %}
+              {% if configured_single_app %}
+                {% url configured_single_app.index_url as header_url %}
+              {% else %} 
+                {% url 'user:profile' as header_url  %} 
+              {% endif %}
             {% else %}
               {% url 'app_library' as header_url %}
             {% endif %}
             {% if ENABLE_OPEN_PORTAL or user.is_authenticated and user.is_active %}
               <li class="nav-item">
-                <a class="h5 me-3 mb-0 nav-link{% if request.path == header_url %} active" aria-current="page{% endif %}" href="{{ header_url }}" title="{% if single_app_mode %}{{ single_app_mode.name }}{% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_mode %}{{ single_app_mode.name }}{% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
+                <a class="h5 me-3 mb-0 nav-link{% if request.path == header_url %} active" aria-current="page{% endif %}" href="{{ header_url }}" title="{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }}  {% else %} No Configured Apps {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}">{% if single_app_mode %} {% if configured_single_app %} {{ configured_single_app.name }}  {% else %} No Configured Apps {% endif %} {% elif site_globals.apps_library_title %}{{ site_globals.apps_library_title }}{% else %}Apps{% endif %}</a>
               </li>
             {% endif %}
           {% endblock %}

--- a/tethys_portal/templates/tethys_portal/user/user_header_menu.html
+++ b/tethys_portal/templates/tethys_portal/user/user_header_menu.html
@@ -1,4 +1,4 @@
-<div class="btn-group">
+<div class="btn-group" style="margin-right: 15px">
   <a id="user-profile" class="btn btn-light btn-user-profile" href="{% url 'user:profile' %}" title="User Profile">
     <span>
       {% if user.first_name %}{{ user.first_name }}{% else %}{{ user.username }}{% endif %}

--- a/tethys_portal/utilities.py
+++ b/tethys_portal/utilities.py
@@ -59,8 +59,6 @@ def log_user_in(request, user=None, username=None):
         else:
             if get_configured_standalone_app():
                 return redirect("/")
-            else:
-                return redirect("user:profile")
 
 
 def json_serializer(obj):

--- a/tethys_portal/utilities.py
+++ b/tethys_portal/utilities.py
@@ -14,6 +14,7 @@ from django.contrib.auth import login
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.contrib.auth.models import User
+from django.conf import settings
 
 
 def log_user_in(request, user=None, username=None):
@@ -52,7 +53,10 @@ def log_user_in(request, user=None, username=None):
     if "next" in request.GET:
         return redirect(request.GET["next"])
     else:
-        return redirect("app_library")
+        if settings.MULTIPLE_APP_MODE:
+            return redirect("app_library")
+        else:
+            return redirect("/")
 
 
 def json_serializer(obj):

--- a/tethys_portal/utilities.py
+++ b/tethys_portal/utilities.py
@@ -15,7 +15,6 @@ from django.contrib import messages
 from django.shortcuts import redirect
 from django.contrib.auth.models import User
 from django.conf import settings
-from tethys_apps.utilities import get_configured_standalone_app
 
 
 def log_user_in(request, user=None, username=None):
@@ -57,8 +56,7 @@ def log_user_in(request, user=None, username=None):
         if settings.MULTIPLE_APP_MODE:
             return redirect("app_library")
         else:
-            if get_configured_standalone_app():
-                return redirect("/")
+            return redirect("/")
 
 
 def json_serializer(obj):

--- a/tethys_portal/utilities.py
+++ b/tethys_portal/utilities.py
@@ -15,6 +15,7 @@ from django.contrib import messages
 from django.shortcuts import redirect
 from django.contrib.auth.models import User
 from django.conf import settings
+from tethys_apps.utilities import get_configured_standalone_app
 
 
 def log_user_in(request, user=None, username=None):
@@ -56,7 +57,10 @@ def log_user_in(request, user=None, username=None):
         if settings.MULTIPLE_APP_MODE:
             return redirect("app_library")
         else:
-            return redirect("/")
+            if get_configured_standalone_app():
+                return redirect("/")
+            else:
+                return redirect("user:profile")
 
 
 def json_serializer(obj):

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -173,4 +173,7 @@ def logout_view(request):
         logout(request)
 
     # Redirect home
-    return redirect("home")
+    if settings.MULTIPLE_APP_MODE:
+        return redirect("home")
+    else:
+        return redirect("/accounts/login/")

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -176,4 +176,4 @@ def logout_view(request):
     if settings.MULTIPLE_APP_MODE:
         return redirect("home")
     else:
-        return redirect("/accounts/login/")
+        return redirect("accounts:login")

--- a/tethys_portal/views/api.py
+++ b/tethys_portal/views/api.py
@@ -3,6 +3,7 @@ from django.middleware.csrf import get_token
 from django.templatetags.static import static
 from django.shortcuts import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.conf import settings
 
 from tethys_apps.exceptions import TethysAppSettingNotAssigned
 from tethys_portal.utilities import json_serializer
@@ -55,10 +56,14 @@ def get_app(request, app):
         "urlNamespace": app.url_namespace,
         "color": app.color,
         "icon": static(app.icon),
-        "exitUrl": reverse("app_library"),
         "rootUrl": reverse(app.index_url),
         "settingsUrl": f'{reverse("admin:index")}tethys_apps/tethysapp/{app.id}/change/',
     }
+    
+    if settings.MULTIPLE_APP_MODE:
+        metadata['exitUrl'] = reverse("app_library")
+    else:
+        metadata['exitUrl'] = reverse(app.index_url)
 
     if request.user.is_authenticated:
         metadata["customSettings"] = dict()

--- a/tethys_portal/views/api.py
+++ b/tethys_portal/views/api.py
@@ -56,14 +56,14 @@ def get_app(request, app):
         "urlNamespace": app.url_namespace,
         "color": app.color,
         "icon": static(app.icon),
+        "exitUrl": (
+            reverse("app_library")
+            if settings.MULTIPLE_APP_MODE
+            else reverse(app.index_url)
+        ),
         "rootUrl": reverse(app.index_url),
         "settingsUrl": f'{reverse("admin:index")}tethys_apps/tethysapp/{app.id}/change/',
     }
-
-    if settings.MULTIPLE_APP_MODE:
-        metadata["exitUrl"] = reverse("app_library")
-    else:
-        metadata["exitUrl"] = reverse(app.index_url)
 
     if request.user.is_authenticated:
         metadata["customSettings"] = dict()

--- a/tethys_portal/views/api.py
+++ b/tethys_portal/views/api.py
@@ -59,11 +59,11 @@ def get_app(request, app):
         "rootUrl": reverse(app.index_url),
         "settingsUrl": f'{reverse("admin:index")}tethys_apps/tethysapp/{app.id}/change/',
     }
-    
+
     if settings.MULTIPLE_APP_MODE:
-        metadata['exitUrl'] = reverse("app_library")
+        metadata["exitUrl"] = reverse("app_library")
     else:
-        metadata['exitUrl'] = reverse(app.index_url)
+        metadata["exitUrl"] = reverse(app.index_url)
 
     if request.user.is_authenticated:
         metadata["customSettings"] = dict()

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -181,7 +181,7 @@ def delete_account(request):
         if django_settings.MULTIPLE_APP_MODE:
             return redirect("home")
         else:
-            return redirect("/accounts/login/")
+            return redirect("accounts:login")
 
     context = {}
 

--- a/tethys_portal/views/user.py
+++ b/tethys_portal/views/user.py
@@ -178,7 +178,10 @@ def delete_account(request):
         messages.success(request, "Your account has been successfully deleted.")
 
         # Redirect to home
-        return redirect("home")
+        if django_settings.MULTIPLE_APP_MODE:
+            return redirect("home")
+        else:
+            return redirect("/accounts/login/")
 
     context = {}
 


### PR DESCRIPTION
This PR looks to resolve https://github.com/tethysplatform/tethys/issues/1042. The issue is that there are many redirects and reverses that point to a hardcoded "home" url. While this works fine when the single app index is home, these redirects fail when an app index is not "home". 

The PR resolves the issue by putting conditional logic in front of the hardcoded "home" redirects. If the tethys portal is in single app mode, then the "home" redirects will point towards the app index url instead. 

Along with the hardcoded "home" fix, I have also updated additional redirects that point to the app_library url which is no longer available in standalone app mode. If the tethys portal is in single app mode, these old app_library redirects will point to more appropriate endpoints instead. 

This PR also adds a warning to users on all pages when single app mode is enabled but there are no applications installed.

![image](https://github.com/tethysplatform/tethys/assets/153777116/37d29693-454e-4dc8-8149-e224179ba6de)
