### PR TITLE
Fix test for social auth v4.5.4

### DIFF
--- a/tests/unit_tests/test_tethys_services/test_backends/test_hydroshare.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_hydroshare.py
@@ -55,15 +55,17 @@ class HydroShareBackendTest(unittest.TestCase):
         )
 
         mock_details = dict(
-            name='',
-            alias='',
+            name="",
+            alias="",
         )
 
         hydro_share_auth2_obj = HydroShareOAuth2()
 
         hydro_share_auth2_obj.set_expires_in_to = 100
 
-        ret = hydro_share_auth2_obj.extra_data("user1", "0001-009", mock_response, mock_details)
+        ret = hydro_share_auth2_obj.extra_data(
+            "user1", "0001-009", mock_response, mock_details
+        )
 
         self.assertEqual("foo@gmail.com", ret["email"])
         self.assertEqual("token1", ret["access_token"])

--- a/tests/unit_tests/test_tethys_services/test_backends/test_hydroshare.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_hydroshare.py
@@ -54,11 +54,16 @@ class HydroShareBackendTest(unittest.TestCase):
             scope="scope",
         )
 
+        mock_details = dict(
+            name='',
+            alias='',
+        )
+
         hydro_share_auth2_obj = HydroShareOAuth2()
 
         hydro_share_auth2_obj.set_expires_in_to = 100
 
-        ret = hydro_share_auth2_obj.extra_data("user1", "0001-009", mock_response)
+        ret = hydro_share_auth2_obj.extra_data("user1", "0001-009", mock_response, mock_details)
 
         self.assertEqual("foo@gmail.com", ret["email"])
         self.assertEqual("token1", ret["access_token"])


### PR DESCRIPTION
@swainn, @shawncrawley, This fixes a test for compatibility with the latest version of `social-auth-core`. We need to get this merged so that the tests will pass for all of the other PRs.

The library made a seemingly innocuous change:

from:
```python
value = response.get(name) or details.get(name) or details.get(alias)
```

to:
```python
value = response.get(name, details.get(name, details.get(alias)))
```

The problem was that in the first case the `details.get` would not get evaluated unless `response.get(name)` returned `None`. Whereas in the second case it gets evaluated regardless. In our test we had a mock response with a `name` attribute, but we were not passing `details`. 