### PR TITLE
Added CQL (Common Query Language) filter for building WMS layers.

### DIFF
--- a/tests/unit_tests/test_tethys_layouts/test_mixins/test_map_layout.py
+++ b/tests/unit_tests/test_tethys_layouts/test_mixins/test_map_layout.py
@@ -1177,6 +1177,60 @@ class TestMapLayoutMixin(unittest.TestCase):
             },
         )
 
+    def test_build_wms_layer_cql_filter(self):
+        class CustomMapLayoutThing(MapLayoutMixin):
+            map_extent = [-65.69, 23.81, -129.17, 49.38]
+
+        ret = CustomMapLayoutThing.build_wms_layer(
+            endpoint="http://example.com/geoserver/wms",
+            layer_name="foo:bar",
+            layer_title="Foo Bar",
+            layer_variable="baz",
+            env="foo:1;bar:baz",
+            cql_filter="baz > 1",
+        )
+
+        self.assertIsInstance(ret, MVLayer)
+        self.assertEqual(ret.source, "TileWMS")
+        self.assertEqual(ret.legend_title, "Foo Bar")
+        self.assertListEqual(ret.legend_extent, [-65.69, 23.81, -129.17, 49.38])
+        self.assertFalse(ret.feature_selection)
+        self.assertListEqual(ret.legend_classes, [])
+        self.assertDictEqual(
+            ret.options,
+            {
+                "url": "http://example.com/geoserver/wms",
+                "params": {
+                    "LAYERS": "foo:bar",
+                    "TILED": True,
+                    "TILESORIGIN": "0.0,0.0",
+                    "ENV": "foo:1;bar:baz",
+                    "CQL_FILTER": "baz > 1",
+                },
+                "serverType": "geoserver",
+                "crossOrigin": None,
+                "tileGrid": _DEFAULT_TILE_GRID,
+            },
+        )
+        self.assertDictEqual(
+            ret.layer_options, {"visible": True, "show_download": False}
+        )
+        self.assertDictEqual(
+            ret.data,
+            {
+                "layer_id": "foo:bar",
+                "layer_name": "foo:bar",
+                "popup_title": "Foo Bar",
+                "layer_variable": "baz",
+                "toggle_status": True,
+                "excluded_properties": ["id", "type", "layer_name"],
+                "removable": False,
+                "renamable": False,
+                "show_legend": True,
+                "legend_url": None,
+            },
+        )
+
     def test_build_arc_gis_layer_default(self):
         class CustomMapLayoutThing(MapLayoutMixin):
             map_extent = [-65.69, 23.81, -129.17, 49.38]

--- a/tethys_layouts/mixins/map_layout.py
+++ b/tethys_layouts/mixins/map_layout.py
@@ -705,6 +705,7 @@ class MapLayoutMixin:
         removable=False,
         show_legend=True,
         legend_url=None,
+        cql_filter=None,
     ):
         """
         Build an WMS MVLayer object with supplied arguments.
@@ -736,6 +737,7 @@ class MapLayoutMixin:
             removable(bool): Show Remove option in layer context menu when True. Must implement the appropriate method to persist the change. Defaults to False.
             show_legend(bool): Show the legend for this layer when True and legends are enabled. Defaults to True.
             legend_url(str): URL of a legend image to display for the layer when legends are enabled.
+            cql_filter(str): geoserver CQL filter string.
 
         Returns:
             MVLayer: the MVLayer object.
@@ -748,6 +750,9 @@ class MapLayoutMixin:
 
         if viewparams:
             params["VIEWPARAMS"] = viewparams
+
+        if cql_filter:
+            params["CQL_FILTER"] = cql_filter
 
         if styles:
             params["STYLES"] = styles


### PR DESCRIPTION
Added option to include a CQl filter when building a WMS layer, by adding it to the params dict used to build the layer.  This can be uesd to filter a layer based on an attribute, filter function, geometric filter, etc.