### PR TITLE
Finish Fixing CI Deprecations

### DIFF
--- a/.github/workflows/tethys-release.yml
+++ b/.github/workflows/tethys-release.yml
@@ -122,9 +122,8 @@ jobs:
           conda update -q conda
       # Export Conda Build Path
       - name: Set Conda Build Path
-        uses: allenevans/set-env@v3.0.0
-        with:
-          CONDA_BLD_PATH: "/home/runner/conda-bld"
+        run: |
+          echo "CONDA_BLD_PATH=/home/runner/conda-bld" >> $GITHUB_ENV
       # Generate Conda Recipe With Constrained Dependencies
       - name: Generate Conda Recipe
         run: |

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -200,9 +200,8 @@ jobs:
           conda update -q conda
       # Export Conda Build Path
       - name: Set Conda Build Path
-        uses: allenevans/set-env@v3.0.0
-        with:
-          CONDA_BLD_PATH: "/home/runner/conda-bld"
+        run: |
+          echo "CONDA_BLD_PATH=/home/runner/conda-bld" >> $GITHUB_ENV
       # Generate Conda Recipe Without Constrained Dependencies
       - name: Generate Conda Recipe
         run: |


### PR DESCRIPTION
### Description
This merge request addresses finishing fixing warnings that have cropped up in the CI do to deprecation of Node.js v16

### Changes Made to Code:
 - Update CI to use actions/checkout@v4

### Related
actions/checkout [version history](https://github.com/actions/checkout/releases)

### Additional Notes
This finishes the fixes that @swainn merged earlier today.

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
