### PR TITLE
Fix Matrix Issue with Pinned Versions

### DIFF
--- a/.github/workflows/tethys-release.yml
+++ b/.github/workflows/tethys-release.yml
@@ -122,9 +122,8 @@ jobs:
           conda update -q conda
       # Export Conda Build Path
       - name: Set Conda Build Path
-        uses: allenevans/set-env@v3.0.0
-        with:
-          CONDA_BLD_PATH: "/home/runner/conda-bld"
+        run: |
+          echo "CONDA_BLD_PATH=/home/runner/conda-bld" >> $GITHUB_ENV
       # Generate Conda Recipe With Constrained Dependencies
       - name: Generate Conda Recipe
         run: |

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -200,9 +200,8 @@ jobs:
           conda update -q conda
       # Export Conda Build Path
       - name: Set Conda Build Path
-        uses: allenevans/set-env@v3.0.0
-        with:
-          CONDA_BLD_PATH: "/home/runner/conda-bld"
+        run: |
+          echo "CONDA_BLD_PATH=/home/runner/conda-bld" >> $GITHUB_ENV
       # Generate Conda Recipe Without Constrained Dependencies
       - name: Generate Conda Recipe
         run: |

--- a/scripts/install_tethys.sh
+++ b/scripts/install_tethys.sh
@@ -158,7 +158,7 @@ case $key in
     set_option_value DJANGO_VERSION "$2"
     shift # past argument
     ;;
-    -v|--python-version)
+    -p|--python-version)
     set_option_value PYTHON_VERSION "$2"
     shift # past argument
     ;;
@@ -366,15 +366,15 @@ then
     if [ -n "${DJANGO_VERSION}" ]
     then
         echo "Updating environment.yml Django version ${DJANGO_VERSION}..."
-        sudo sed -i.bak "s/django>=.*/django>=${DJANGO_VERSION}/" "${TETHYS_SRC}/environment.yml"
-        sudo sed -i.bak "s/django>=.*/django>=${DJANGO_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
+        sudo sed -i.bak "s/django>=.*/django==${DJANGO_VERSION}/" "${TETHYS_SRC}/environment.yml"
+        sudo sed -i.bak "s/django>=.*/django==${DJANGO_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
     fi
 
     if [ -n "${PYTHON_VERSION}" ]
     then
         echo "Updating environment.yml Python version ${PYTHON_VERSION}..."
-        sudo sed -i.bak "s/django>=.*/python>=${PYTHON_VERSION}/" "${TETHYS_SRC}/environment.yml"
-        sudo sed -i.bak "s/django>=.*/python>=${PYTHON_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
+        sudo sed -i.bak "s/django>=.*/python==${PYTHON_VERSION}/" "${TETHYS_SRC}/environment.yml"
+        sudo sed -i.bak "s/django>=.*/python==${PYTHON_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
     fi
 
     if [ -n "${CREATE_ENV}" ]


### PR DESCRIPTION
### Description
This merge request addresses an issue where running the install script didn't pin to a specific version of python or Django. It was only setting the lower bounds. We want to pin it when we set a version.

### Changes Made to Code:
 - Update the install script to set version to be `==` rather than `>=`
 - Fix python version flag to be `-p` rather than `-v`

### Related
- None

### Additional Notes
- This was found when trying to update the `tethysext-atcore` dockers. 

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
