### PR TITLE
Fix Matrix Issue with Pinned Versions

### DIFF
--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd ..
           bash ./tethys/scripts/install_tethys.sh -h
-          bash ./tethys/scripts/install_tethys.sh --partial-tethys-install meds -n tethys -s $PWD/tethys -x -d ${{ matrix.django-version }} -p ${{ matrix.python-version }}
+          bash ./tethys/scripts/install_tethys.sh --partial-tethys-install meds -n tethys -s $PWD/tethys -x -d ${{ matrix.django-version }} --python-version ${{ matrix.python-version }}
       # Setup Tethys and Conda
       - name: Setup Tethys and Conda
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,12 +154,12 @@ RUN if [ -n "$DJANGO_VERSION" ]; then \
 
 # Create the conda environment based on the environment.yml or micro_environment.yml file
 RUN if [ "${MICRO_TETHYS}" = "true" ]; then \
-  sed -i "s/- python[^-].*/ - python==${PYTHON_VERSION}/g" micro_environment.yml && \
+  sed -i "s/- python[^-].*/- python==${PYTHON_VERSION}/g" micro_environment.yml && \
   micromamba create -n "${CONDA_ENV_NAME}" --yes --file "micro_environment.yml" && \
   micromamba clean --all --yes && \
   rm -rf environment.yml; \
   else \
-  sed -i "s/- python[^-].*/ - python==${PYTHON_VERSION}/g" environment.yml && \
+  sed -i "s/- python[^-].*/- python==${PYTHON_VERSION}/g" environment.yml && \
   micromamba create -n "${CONDA_ENV_NAME}" --yes --file "environment.yml" && \
   micromamba clean --all --yes && \
   rm -rf micro_environment.yml; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,12 +154,12 @@ RUN if [ -n "$DJANGO_VERSION" ]; then \
 
 # Create the conda environment based on the environment.yml or micro_environment.yml file
 RUN if [ "${MICRO_TETHYS}" = "true" ]; then \
-  sed -i "s/- python$/- python=${PYTHON_VERSION}/g" micro_environment.yml && \
+  sed -i "s/- python$/- python==${PYTHON_VERSION}/g" micro_environment.yml && \
   micromamba create -n "${CONDA_ENV_NAME}" --yes --file "micro_environment.yml" && \
   micromamba clean --all --yes && \
   rm -rf environment.yml; \
   else \
-  sed -i "s/- python$/- python=${PYTHON_VERSION}/g" environment.yml && \
+  sed -i "s/- python$/- python==${PYTHON_VERSION}/g" environment.yml && \
   micromamba create -n "${CONDA_ENV_NAME}" --yes --file "environment.yml" && \
   micromamba clean --all --yes && \
   rm -rf micro_environment.yml; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,12 +154,12 @@ RUN if [ -n "$DJANGO_VERSION" ]; then \
 
 # Create the conda environment based on the environment.yml or micro_environment.yml file
 RUN if [ "${MICRO_TETHYS}" = "true" ]; then \
-  sed -i "s/- python$/- python==${PYTHON_VERSION}/g" micro_environment.yml && \
+  sed -i "s/- python[^-].*/ - python==${PYTHON_VERSION}/g" micro_environment.yml && \
   micromamba create -n "${CONDA_ENV_NAME}" --yes --file "micro_environment.yml" && \
   micromamba clean --all --yes && \
   rm -rf environment.yml; \
   else \
-  sed -i "s/- python$/- python==${PYTHON_VERSION}/g" environment.yml && \
+  sed -i "s/- python[^-].*/ - python==${PYTHON_VERSION}/g" environment.yml && \
   micromamba create -n "${CONDA_ENV_NAME}" --yes --file "environment.yml" && \
   micromamba clean --all --yes && \
   rm -rf micro_environment.yml; \

--- a/scripts/install_tethys.sh
+++ b/scripts/install_tethys.sh
@@ -158,7 +158,7 @@ case $key in
     set_option_value DJANGO_VERSION "$2"
     shift # past argument
     ;;
-    -v|--python-version)
+    -p|--python-version)
     set_option_value PYTHON_VERSION "$2"
     shift # past argument
     ;;
@@ -366,15 +366,15 @@ then
     if [ -n "${DJANGO_VERSION}" ]
     then
         echo "Updating environment.yml Django version ${DJANGO_VERSION}..."
-        sudo sed -i.bak "s/django>=.*/django>=${DJANGO_VERSION}/" "${TETHYS_SRC}/environment.yml"
-        sudo sed -i.bak "s/django>=.*/django>=${DJANGO_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
+        sudo sed -i.bak "s/django>=.*/django==${DJANGO_VERSION}/" "${TETHYS_SRC}/environment.yml"
+        sudo sed -i.bak "s/django>=.*/django==${DJANGO_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
     fi
 
     if [ -n "${PYTHON_VERSION}" ]
     then
         echo "Updating environment.yml Python version ${PYTHON_VERSION}..."
-        sudo sed -i.bak "s/django>=.*/python>=${PYTHON_VERSION}/" "${TETHYS_SRC}/environment.yml"
-        sudo sed -i.bak "s/django>=.*/python>=${PYTHON_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
+        sudo sed -i.bak "s/django>=.*/python==${PYTHON_VERSION}/" "${TETHYS_SRC}/environment.yml"
+        sudo sed -i.bak "s/django>=.*/python==${PYTHON_VERSION}/" "${TETHYS_SRC}/micro_environment.yml"
     fi
 
     if [ -n "${CREATE_ENV}" ]

--- a/scripts/install_tethys.sh
+++ b/scripts/install_tethys.sh
@@ -16,7 +16,7 @@ OPTIONS:\n
 \t    -b, --branch <BRANCH_NAME>          \t\t Branch to checkout from version control. Default is 'main'.\n
 \t    -c, --conda-home <PATH>             \t\t Path where Miniconda will be installed, or to an existing installation of Miniconda. Default is ~/miniconda.\n
 \t    -d, --django-version <VERSION>      \t\t Version of Django to install. Default is '4.2'.\n
-\t    -p, --python-version <VERSION>      \t\t Version of Python to install. Default is '3.12'.\n
+\t    --python-version <VERSION>      \t\t Version of Python to install. Default is '3.12'.\n
 \t    --db-username <USERNAME>            \t\t Username that the tethys database server will use. Default is 'tethys_default'.\n
 \t    --db-password <PASSWORD>            \t\t Password that the tethys database server will use. Default is 'pass'.\n
 \t    --db-super-username <USERNAME>      \t Username for super user on the tethys database server. Default is 'tethys_super'.\n
@@ -158,7 +158,7 @@ case $key in
     set_option_value DJANGO_VERSION "$2"
     shift # past argument
     ;;
-    -p|--python-version)
+    --python-version)
     set_option_value PYTHON_VERSION "$2"
     shift # past argument
     ;;


### PR DESCRIPTION
### Description
This merge request addresses an issue where running the install script didn't pin to a specific version of python or Django. It was only setting the lower bounds. We want to pin it when we set a version.

### Changes Made to Code:
 - Update the install script to set version to be `==` rather than `>=`
 - Fix python version flag to be `-p` rather than `-v` to match usage notes
 - Update the docker file to `sed` the python version correctly

### Related
- None

### Additional Notes
- This was found when trying to update the `tethysext-atcore` dockers. 

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
