### PR TITLE
add line for django version 3.2 to install channels version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,7 +204,11 @@ RUN pip install -e .
 RUN tethys gen portal_config
 
 # Install channel-redis
-RUN pip install channels_redis
+RUN if [ "${DJANGO_VERSION}" = "3.2" ]; then \
+    RUN pip install channels==4.0.0 channels_redis \
+  else \
+    RUN pip install channels_redis \
+  fi
 
 ############
 # CLEAN UP #


### PR DESCRIPTION
### Description
This merge request addresses an issue where the Django 3.2 docker builds would overwrite the installed version of django because the used channels version would require Django >= 4.2. 

### Changes Made to Code:
 - Add a line to the Dockerbuild file that wil check for django 3.2 and install an older version of channels.

### Related
- None

### Additional Notes
- This was found when trying to update the `tethysext-atcore` dockers. 

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
