### PR TITLE
Fix Dask scheduler Client import error

### DIFF
--- a/tethys_compute/models/dask/dask_scheduler.py
+++ b/tethys_compute/models/dask/dask_scheduler.py
@@ -14,7 +14,7 @@ from tethys_compute.models.dask.dask_job_exception import DaskJobException
 from tethys_portal.optional_dependencies import optional_import
 
 # optional imports
-Client = optional_import("client", from_module="dask.distributed")
+Client = optional_import("Client", from_module="dask.distributed")
 
 log = logging.getLogger("tethys." + __name__)
 


### PR DESCRIPTION
### Description
Introduced in #967, f863b48, tethys_compute/models/dask/dask_scheduler.py , the changed code has lowercase `client` instead of `Client`, which imports the module instead of the class, resulting in a  `TypeError: 'module' object is not callable` error.

### Changes Made to Code:
 - `Client = optional_import("client", from_module="dask.distributed")` ➡️ `Client = optional_import("Client", from_module="dask.distributed")`

### Related
- #967

### Additional Notes
-  This bug _might_ not appear on macOS HFS+/APFS because of case-insensitive filesystems? But I'm seeing it on Windows. I'm guessing this is the case everywhere though.

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
