### PR TITLE
Changes to conf.py in preparation for RTD Addons rollout

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,6 +248,15 @@ todo_include_todos = True
 # If this is True, todo emits a warning for each TODO entries. The default is False.
 todo_emit_warnings = True
 
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 html_title = f"{project} Documentation"
 html_short_title = "Tethys Docs"
 # html_logo = "images/features/tethys-logo-75.png"


### PR DESCRIPTION
### Description
Update conf.py per RTD's recommendations. See: https://about.readthedocs.com/blog/2024/07/addons-by-default/

### Changes Made to Code:
 - Get `html_baseurl` from `READTHEDOCS_CANONICAL_URL` environment variable.
 - Add `READTHEDOCS` to the `html_context`.

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
