### PR TITLE
bug fix for issue #998 - typos in map layout basemaps

### DIFF
--- a/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
@@ -150,7 +150,7 @@ var TETHYS_MAP_VIEW = (function() {
   var update_field;
 
   // Utility Methods
-  var is_defined, in_array, string_to_function, build_ol_objects;
+  var is_defined, in_array, string_to_function, build_ol_objects, add_default_layer;
 
   // Class Declarations
   var DrawingControl, DragFeatureInteraction, DeleteFeatureInteraction;
@@ -291,16 +291,18 @@ var TETHYS_MAP_VIEW = (function() {
             base_map_labels.push(label);
             // Add the base map to layers
             m_map.addLayer(base_map_layer);
+        } else {
+          console.warn('Unsupported base map: ' + base_map_layer_name);
         }
       });
+      if (m_map.getLayers().getLength() == 0) {
+        // Default base map
+        add_default_layer();
+      }
     }
     else{
         // Default base map
-        base_map_layer = new ol.layer.Tile({
-          source: new ol.source.OSM()
-        });
-        // Add the base map to layers
-        m_map.addLayer(base_map_layer);
+        add_default_layer();
     }
   }
 
@@ -2331,6 +2333,14 @@ var TETHYS_MAP_VIEW = (function() {
       }
     }
     return stack;
+  };
+
+  add_default_layer = function() {
+    var default_base_map_layer = new ol.layer.Tile({
+      source: new ol.source.OSM()
+    });
+    // Add the base map to layers
+    m_map.addLayer(default_base_map_layer);
   };
 
   /***********************************


### PR DESCRIPTION
### Description
This merge request addresses an issue where if all base map names are misspelled, no base map layer is added to the map and no map is shown at all. 

### Changes Made to Code:
 - In tethys_map_view.js, added an 'add_default_layer' function for when either no base maps are specified in the map layout gizmo, or when all base maps are misspelled. 

### Related
-  https://github.com/tethysplatform/tethys/issues/998

### Additional Notes
- None

### Quality Checks
 - [] New code is 100% tested
 - [] Code has been formated
 - [] Code has been linted
 - [] Docstrings for new methods have been added
