### PR TITLE
Nonexit Tethys Create DB CLI Command

### DIFF
--- a/tests/unit_tests/test_tethys_cli/test_db_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_db_commands.py
@@ -197,18 +197,63 @@ class TestCommandTests(unittest.TestCase):
             **kwargs,
         )
 
+    @mock.patch("tethys_cli.db_commands.write_error")
     @mock.patch("tethys_cli.db_commands.create_db_user")
-    def test_db_command_create(self, mock_create_db_user):
+    def test_db_command_create_error_code_without_exit(
+        self, mock_create_db_user, mock_write_error
+    ):
         mock_args = mock.MagicMock()
         mock_args.command = "create"
+        self.options["exit_creation_on_error"] = False
+        mock_create_db_user.return_value = 1
         db_command(mock_args)
         call_args = mock_create_db_user.call_args_list
         kwargs = self._get_kwargs(remove=["superuser_name", "superuser_password"])
+        kwargs["exit_on_error"] = False
+        kwargs.pop("exit_creation_on_error")
         self.assertEqual(call_args[1], mock.call(**kwargs))
         kwargs.pop("db_name")
         kwargs["username"] = self.options["superuser_name"]
         kwargs["password"] = self.options["superuser_password"]
+        self.assertEqual(call_args[0], mock.call(is_superuser=True, **kwargs))
+        err_msg = "Failed to setup user/superuser users/tables"
+        mock_write_error.assert_called_with(err_msg)
+
+    @mock.patch("tethys_cli.db_commands.write_error")
+    @mock.patch("tethys_cli.db_commands.create_db_user")
+    def test_db_command_create_error_code_with_exit(
+        self, mock_create_db_user, mock_write_error
+    ):
+        mock_args = mock.MagicMock()
+        mock_args.command = "create"
+        self.options["exit_creation_on_error"] = True
+        mock_create_db_user.return_value = 1
+        self.assertRaises(SystemExit, db_command, mock_args)
+        call_args = mock_create_db_user.call_args_list
+        kwargs = self._get_kwargs(remove=["superuser_name", "superuser_password"])
         kwargs["exit_on_error"] = False
+        kwargs.pop("exit_creation_on_error")
+        self.assertEqual(call_args[1], mock.call(**kwargs))
+        kwargs.pop("db_name")
+        kwargs["username"] = self.options["superuser_name"]
+        kwargs["password"] = self.options["superuser_password"]
+        self.assertEqual(call_args[0], mock.call(is_superuser=True, **kwargs))
+        err_msg = "Failed to setup user/superuser users/tables"
+        mock_write_error.assert_called_with(err_msg)
+
+    @mock.patch("tethys_cli.db_commands.create_db_user")
+    def test_db_command_create_no_error_codes(self, mock_create_db_user):
+        mock_args = mock.MagicMock()
+        mock_args.command = "create"
+        mock_create_db_user.return_value = None
+        db_command(mock_args)
+        call_args = mock_create_db_user.call_args_list
+        kwargs = self._get_kwargs(remove=["superuser_name", "superuser_password"])
+        kwargs["exit_on_error"] = False
+        self.assertEqual(call_args[1], mock.call(**kwargs))
+        kwargs.pop("db_name")
+        kwargs["username"] = self.options["superuser_name"]
+        kwargs["password"] = self.options["superuser_password"]
         self.assertEqual(call_args[0], mock.call(is_superuser=True, **kwargs))
 
     def test_db_command_create_db_user(self):
@@ -405,10 +450,11 @@ class TestCommandTests(unittest.TestCase):
         mock_args.command = "configure"
         db_command(mock_args)
         kwargs = self._get_kwargs()
+        creation_kwargs = kwargs | {"exit_creation_on_error": False}
         calls = [
             mock.call(init_db_server, **kwargs),
             mock.call(start_db_server, **kwargs),
-            mock.call(create_tethys_db, **kwargs),
+            mock.call(create_tethys_db, **creation_kwargs),
         ]
         mock_prompt_err.assert_has_calls(calls)
         mock_migrate.assert_called_with(**self.options)

--- a/tests/unit_tests/test_tethys_cli/test_db_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_db_commands.py
@@ -317,7 +317,7 @@ class TestCommandTests(unittest.TestCase):
         create_db_user(is_superuser=True, **self.options)
         call_args = self.mock_run_process.call_args_list
         command = (
-            f"CREATE USER {self.options['username']} WITH CREATEDB NOCREATEROLE SUPERUSER PASSWORD "
+            f"CREATE USER {self.options['username']} WITH CREATEDB NOCREATEROLE PASSWORD "
             f"'{self.options['password']}';"
         )
         command = (

--- a/tests/unit_tests/test_tethys_cli/test_db_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_db_commands.py
@@ -317,7 +317,7 @@ class TestCommandTests(unittest.TestCase):
         create_db_user(is_superuser=True, **self.options)
         call_args = self.mock_run_process.call_args_list
         command = (
-            f"CREATE USER {self.options['username']} WITH CREATEDB NOCREATEROLE PASSWORD "
+            f"CREATE USER {self.options['username']} WITH CREATEDB NOCREATEROLE SUPERUSER PASSWORD "
             f"'{self.options['password']}';"
         )
         command = (

--- a/tests/unit_tests/test_tethys_cli/test_db_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_db_commands.py
@@ -208,6 +208,7 @@ class TestCommandTests(unittest.TestCase):
         kwargs.pop("db_name")
         kwargs["username"] = self.options["superuser_name"]
         kwargs["password"] = self.options["superuser_password"]
+        kwargs["exit_on_error"] = False
         self.assertEqual(call_args[0], mock.call(is_superuser=True, **kwargs))
 
     def test_db_command_create_db_user(self):
@@ -262,8 +263,8 @@ class TestCommandTests(unittest.TestCase):
         )
         self.mock_run_process.assert_called_with(
             args,
-            'Creating Tethys database user "foo"...',
-            'Failed to create default database for database user "foo"',
+            'Creating Tethys database table "db_name" for user "foo"...',
+            'Failed to create Tethys database table "db_name" for user "foo"',
             **kwargs,
         )
 

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -275,7 +275,9 @@ def create_db_user(
     db_name = db_name or username
 
     if is_superuser:
-        create_user_command = f"CREATE USER {username} WITH CREATEDB NOCREATEROLE PASSWORD '{password}';"
+        create_user_command = (
+            f"CREATE USER {username} WITH CREATEDB NOCREATEROLE PASSWORD '{password}';"
+        )
     else:
         create_user_command = f"CREATE USER {username} WITH NOCREATEDB NOCREATEROLE NOSUPERUSER PASSWORD '{password}';"
 

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -275,9 +275,7 @@ def create_db_user(
     db_name = db_name or username
 
     if is_superuser:
-        create_user_command = (
-            f"CREATE USER {username} WITH CREATEDB NOCREATEROLE PASSWORD '{password}';"
-        )
+        create_user_command = f"CREATE USER {username} WITH CREATEDB NOCREATEROLE SUPERUSER PASSWORD '{password}';"
     else:
         create_user_command = f"CREATE USER {username} WITH NOCREATEDB NOCREATEROLE NOSUPERUSER PASSWORD '{password}';"
 

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -272,9 +272,6 @@ def create_db_user(
     Returns: error code
 
     """
-    msg = f'Creating Tethys database user "{username}"...'
-    err_msg = f'Failed to create Tethys database user for "{username}"'
-
     db_name = db_name or username
 
     if is_superuser:
@@ -306,7 +303,10 @@ def create_db_user(
         "--command",
         create_user_command,
     ]
+    msg = f'Creating Tethys database user "{username}"...'
+    err_msg = f'Failed to create Tethys database user "{username}"'
     result_1 = _run_process(args, msg, err_msg, **kwargs)
+
     args = [
         "createdb",
         "-h",
@@ -323,8 +323,12 @@ def create_db_user(
         username,
         db_name,
     ]
-    err_msg = f'Failed to create default database for database user "{username}"'
+    msg = f'Creating Tethys database table "{db_name}" for user "{username}"...'
+    err_msg = (
+        f'Failed to create Tethys database table "{db_name}" for user "{username}"'
+    )
     result_2 = _run_process(args, msg, err_msg, **kwargs)
+
     return result_1 or result_2
 
 
@@ -362,6 +366,7 @@ def create_tethys_db(
             username=superuser_name,
             password=superuser_password,
             is_superuser=True,
+            exit_on_error=False,
             **kwargs,
         )
     # Create Tethys db user next

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -275,7 +275,7 @@ def create_db_user(
     db_name = db_name or username
 
     if is_superuser:
-        create_user_command = f"CREATE USER {username} WITH CREATEDB NOCREATEROLE SUPERUSER PASSWORD '{password}';"
+        create_user_command = f"CREATE USER {username} WITH CREATEDB NOCREATEROLE PASSWORD '{password}';"
     else:
         create_user_command = f"CREATE USER {username} WITH NOCREATEDB NOCREATEROLE NOSUPERUSER PASSWORD '{password}';"
 

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -353,6 +353,7 @@ def create_tethys_db(
         password: password for `username` account
         superuser_name: superuser account name for Tethys Portal database
         superuser_password: password for `superuser_name` account
+        exit_creation_on_error: If True then exit if either child process returns and error code
         **kwargs: processed key word arguments from commandline
 
     Returns: error code


### PR DESCRIPTION
### Description
This merge request addresses an issue with the tethys db create CLI command. The issue occurs when multiple portals are trying to share a single database with the same tethys_super table. If the tethys_super table already exists, then the tethys db create CLI command will try to create the tethys_super table, fail to do so, and then exit before the table for the portal is created. 

This merge request sets the exit_on_error to False for the create_db_user call inside of the create_tethys_db function. This will ensure that both create_db_user calls are executed, whether they are successful or not. To keep the same behavior currently where the create_tethys_db function can exit on an error, I have added a exit_creation_on_error argument to the function. If set to True, then the function will exit if either one of the create_db_user calls fails.

I also updated the logging in the create_tethys_db function to give more details on what user or database is being created

### Steps to reproduce
- Setup the tethys_super DB table (without having the tethys default/portal table setup)
- Run tethys db create
- You will receive an error that the tethys_super table already exists and the tethys default table will not be created

### Quality Checks
 - [X] New code is 100% tested
 - [X] Code has been formated
 - [X] Code has been linted
 - [X] Docstrings for new methods have been added
