### PR TITLE
Fix URL redirect for apps with no slash

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_utilities.py
+++ b/tests/unit_tests/test_tethys_apps/test_utilities.py
@@ -168,6 +168,15 @@ class TethysAppsUtilitiesTests(unittest.TestCase):
         self.assertEqual(mock_app.objects.get(), result)
 
     @override_settings(MULTIPLE_APP_MODE=True)
+    def test_get_active_app_no_app(self):
+        # check apps with /
+        result = utilities.get_active_app(url="/apps/")
+        self.assertEqual(None, result)
+        # check apps without /
+        result = utilities.get_active_app(url="/apps")
+        self.assertEqual(None, result)
+
+    @override_settings(MULTIPLE_APP_MODE=True)
     @mock.patch("tethys_apps.utilities.SingletonHarvester")
     @mock.patch("tethys_apps.models.TethysApp")
     def test_get_active_app_class(self, mock_app, mock_harvester):

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -141,10 +141,14 @@ def get_active_app(request=None, url=None, get_class=False):
             the_url = url
         else:
             return None
+        
+        apps_root = "apps"
+        if the_url.endswith(f"/{apps_root}"):
+            the_url += "/"
 
         url_parts = the_url.split("/")
         app = None
-        apps_root = "apps"
+        
         if apps_root in url_parts:
             # The app root_url is the path item following (+1) the apps_root item
             app_root_url_index = url_parts.index(apps_root) + 1

--- a/tethys_apps/utilities.py
+++ b/tethys_apps/utilities.py
@@ -141,14 +141,14 @@ def get_active_app(request=None, url=None, get_class=False):
             the_url = url
         else:
             return None
-        
+
         apps_root = "apps"
         if the_url.endswith(f"/{apps_root}"):
             the_url += "/"
 
         url_parts = the_url.split("/")
         app = None
-        
+
         if apps_root in url_parts:
             # The app root_url is the path item following (+1) the apps_root item
             app_root_url_index = url_parts.index(apps_root) + 1


### PR DESCRIPTION
### Description
This merge request addresses issue #1061 where the redirect for apps with no trailing / would break

### Changes Made to Code:
 - Append the slash if the there is no app to redirect to

### Related
- N/A

### Additional Notes
-  This was an issue caused in django5

### Quality Checks
 - [] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
