### PR TITLE
Jobs table fixes

### DIFF
--- a/tests/unit_tests/test_tethys_compute/test_models/test_TethysJob.py
+++ b/tests/unit_tests/test_tethys_compute/test_models/test_TethysJob.py
@@ -55,6 +55,30 @@ class TethysJobTest(TethysTestCase):
         ret = self.tethysjob.type
         self.assertEqual("TethysJob", ret)
 
+    def test_add_custom_pre_running_status(self):
+        custom_status = 'test-pre-running'
+        TethysJob.add_custom_pre_running_status(custom_status)
+        self.assertIn(custom_status, TethysJob.PRE_RUNNING_STATUSES)
+        self.assertIn(custom_status, TethysJob.NON_TERMINAL_STATUSES)
+
+    def test_add_custom_running_status(self):
+        custom_status = 'test-running'
+        TethysJob.add_custom_running_status(custom_status)
+        self.assertIn(custom_status, TethysJob.RUNNING_STATUSES)
+        self.assertIn(custom_status, TethysJob.ACTIVE_STATUSES)
+        self.assertIn(custom_status, TethysJob.NON_TERMINAL_STATUSES)
+
+    def test_add_custom_active_status(self):
+        custom_status = 'test-active'
+        TethysJob.add_custom_active_status(custom_status)
+        self.assertIn(custom_status, TethysJob.ACTIVE_STATUSES)
+        self.assertIn(custom_status, TethysJob.NON_TERMINAL_STATUSES)
+
+    def test_add_custom_terminal_status(self):
+        custom_status = 'test-terminal'
+        TethysJob.add_custom_terminal_status(custom_status)
+        self.assertIn(custom_status, TethysJob.TERMINAL_STATUSES)
+
     def test_update_status_interval_prop(self):
         ret = TethysJob.objects.get(name="test_tethysjob").update_status_interval
 

--- a/tests/unit_tests/test_tethys_compute/test_models/test_TethysJob.py
+++ b/tests/unit_tests/test_tethys_compute/test_models/test_TethysJob.py
@@ -56,26 +56,26 @@ class TethysJobTest(TethysTestCase):
         self.assertEqual("TethysJob", ret)
 
     def test_add_custom_pre_running_status(self):
-        custom_status = 'test-pre-running'
+        custom_status = "test-pre-running"
         TethysJob.add_custom_pre_running_status(custom_status)
         self.assertIn(custom_status, TethysJob.PRE_RUNNING_STATUSES)
         self.assertIn(custom_status, TethysJob.NON_TERMINAL_STATUSES)
 
     def test_add_custom_running_status(self):
-        custom_status = 'test-running'
+        custom_status = "test-running"
         TethysJob.add_custom_running_status(custom_status)
         self.assertIn(custom_status, TethysJob.RUNNING_STATUSES)
         self.assertIn(custom_status, TethysJob.ACTIVE_STATUSES)
         self.assertIn(custom_status, TethysJob.NON_TERMINAL_STATUSES)
 
     def test_add_custom_active_status(self):
-        custom_status = 'test-active'
+        custom_status = "test-active"
         TethysJob.add_custom_active_status(custom_status)
         self.assertIn(custom_status, TethysJob.ACTIVE_STATUSES)
         self.assertIn(custom_status, TethysJob.NON_TERMINAL_STATUSES)
 
     def test_add_custom_terminal_status(self):
-        custom_status = 'test-terminal'
+        custom_status = "test-terminal"
         TethysJob.add_custom_terminal_status(custom_status)
         self.assertIn(custom_status, TethysJob.TERMINAL_STATUSES)
 

--- a/tethys_compute/models/tethys_job.py
+++ b/tethys_compute/models/tethys_job.py
@@ -116,7 +116,9 @@ class TethysJob(models.Model):
         Args:
             status (str): The name of the status to classify
         """
-        cls._add_custom_status(status, (cls.PRE_RUNNING_STATUSES, cls.NON_TERMINAL_STATUSES))
+        cls._add_custom_status(
+            status, (cls.PRE_RUNNING_STATUSES, cls.NON_TERMINAL_STATUSES)
+        )
 
     @classmethod
     def add_custom_running_status(cls, status):
@@ -127,7 +129,10 @@ class TethysJob(models.Model):
         Args:
             status (str): The name of the status to classify
         """
-        cls._add_custom_status(status, (cls.RUNNING_STATUSES, cls.ACTIVE_STATUSES, cls.NON_TERMINAL_STATUSES))
+        cls._add_custom_status(
+            status,
+            (cls.RUNNING_STATUSES, cls.ACTIVE_STATUSES, cls.NON_TERMINAL_STATUSES),
+        )
 
     @classmethod
     def add_custom_active_status(cls, status):
@@ -237,9 +242,10 @@ class TethysJob(models.Model):
 
         """
         old_status = self._status
-        update_needed = (
-                old_status in self.NON_TERMINAL_STATUS_CODES or
-                (old_status == "OTH" and self.extended_properties[self.OTHER_STATUS_KEY] in self.NON_TERMINAL_STATUSES)
+        update_needed = old_status in self.NON_TERMINAL_STATUS_CODES or (
+            old_status == "OTH"
+            and self.extended_properties[self.OTHER_STATUS_KEY]
+            in self.NON_TERMINAL_STATUSES
         )
 
         # Set status from status given

--- a/tethys_compute/models/tethys_job.py
+++ b/tethys_compute/models/tethys_job.py
@@ -58,10 +58,10 @@ class TethysJob(models.Model):
     RUNNING_STATUSES = DISPLAY_STATUSES[2:4]
     ACTIVE_STATUSES = DISPLAY_STATUSES[1:5]
     NON_TERMINAL_STATUSES = DISPLAY_STATUSES[0:5]
-    TERMINAL_STATUSES = DISPLAY_STATUSES[5:]
+    TERMINAL_STATUSES = DISPLAY_STATUSES[5:-1]
 
     NON_TERMINAL_STATUS_CODES = VALID_STATUSES[0:5]
-    TERMINAL_STATUS_CODES = VALID_STATUSES[5:]
+    TERMINAL_STATUS_CODES = VALID_STATUSES[5:-1]
 
     OTHER_STATUS_KEY = "__other_status__"
 
@@ -91,6 +91,65 @@ class TethysJob(models.Model):
         Returns the name of Tethys Job type.
         """
         return self.__class__.__name__
+
+    @classmethod
+    def _add_custom_status(cls, status, status_categories):
+        """
+        Adds a custom status to all ``status_categories`` lists if they are not already in the list.
+
+        Args:
+            status (str): Name of the custom status to add
+            status_categories (list of lists): a list of the status category lists defined on this class:
+                (i.e. ``PRE_RUNNING_STATUSES``, ``RUNNING_STATUSES``, ``ACTIVE_STATUSES``,
+                 ``NON_TERMINAL_STATUSES``, ``TERMINAL_STATUSES``)
+        """
+        for status_list in status_categories:
+            if status not in status_list:
+                status_list.append(status)
+
+    @classmethod
+    def add_custom_pre_running_status(cls, status):
+        """
+        Classify a custom status as a "Pre-Running" Status.
+        The status will be added to ``PRE_RUNNING_STATUSES`` and ``NON_TERMINAL_STATUSES``.
+
+        Args:
+            status (str): The name of the status to classify
+        """
+        cls._add_custom_status(status, (cls.PRE_RUNNING_STATUSES, cls.NON_TERMINAL_STATUSES))
+
+    @classmethod
+    def add_custom_running_status(cls, status):
+        """
+        Classify a custom status as a "Running" Status.
+        The status will be added to ``RUNNING_STATUSES``, ``ACTIVE_STATUSES``, and ``NON_TERMINAL_STATUSES``.
+
+        Args:
+            status (str): The name of the status to classify
+        """
+        cls._add_custom_status(status, (cls.RUNNING_STATUSES, cls.ACTIVE_STATUSES, cls.NON_TERMINAL_STATUSES))
+
+    @classmethod
+    def add_custom_active_status(cls, status):
+        """
+        Classify a custom status as an "Active" Status.
+        The status will be added to ``ACTIVE_STATUSES`` and ``NON_TERMINAL_STATUSES``.
+
+        Args:
+            status (str): The name of the status to classify
+        """
+        cls._add_custom_status(status, (cls.ACTIVE_STATUSES, cls.NON_TERMINAL_STATUSES))
+
+    @classmethod
+    def add_custom_terminal_status(cls, status):
+        """
+        Classify a custom status as a "Terminal" Status.
+        The status will be added to ``TERMINAL_STATUSES``.
+
+        Args:
+            status (str): The name of the status to classify
+        """
+        cls._add_custom_status(status, (cls.TERMINAL_STATUSES,))
 
     @property
     def update_status_interval(self):
@@ -178,7 +237,11 @@ class TethysJob(models.Model):
 
         """
         old_status = self._status
-        update_needed = old_status in self.NON_TERMINAL_STATUS_CODES
+        update_needed = (
+                old_status in self.NON_TERMINAL_STATUS_CODES or
+                (old_status == "OTH" and self.extended_properties[self.OTHER_STATUS_KEY] in self.NON_TERMINAL_STATUSES)
+        )
+
         # Set status from status given
         if status:
             if status not in self.VALID_STATUSES:

--- a/tethys_gizmos/gizmo_options/jobs_table.py
+++ b/tethys_gizmos/gizmo_options/jobs_table.py
@@ -536,7 +536,9 @@ class JobsTable(TethysGizmoOptions):
         for action, properties in job_actions.items():
             properties["enabled"] = getattr(
                 job, CustomJobAction.get_enabled_callback_name(action), lambda js: True
-            )(job.cached_status)  # use cached status in case job_status is None
+            )(
+                job.cached_status
+            )  # use cached status in case job_status is None
 
         return JobsTableRow(row_values, job_status=job_status, actions=job_actions)
 

--- a/tethys_gizmos/gizmo_options/jobs_table.py
+++ b/tethys_gizmos/gizmo_options/jobs_table.py
@@ -315,6 +315,7 @@ class JobsTable(TethysGizmoOptions):
 
         self.show_status = show_status
         self.show_actions = show_actions
+        self.active_statuses = TethysJob.ACTIVE_STATUSES
         self.hover = hover
         self.striped = striped
         self.bordered = bordered
@@ -387,7 +388,7 @@ class JobsTable(TethysGizmoOptions):
                 label="Terminate",
                 callback_or_url="stop",
                 enabled_callback=lambda job, job_status: job_status
-                in TethysJob.ACTIVE_STATUSES,
+                in self.active_statuses,
                 confirmation_message="Are you sure you want to terminate this job?",
                 show_overlay=True,
             ),
@@ -395,7 +396,7 @@ class JobsTable(TethysGizmoOptions):
                 label="Delete",
                 callback_or_url="delete",
                 enabled_callback=lambda job, job_status: job_status
-                not in TethysJob.ACTIVE_STATUSES,
+                not in self.active_statuses,
                 confirmation_message="Are you sure you want to permanently delete this job?",
                 show_overlay=True,
             ),
@@ -535,7 +536,7 @@ class JobsTable(TethysGizmoOptions):
         for action, properties in job_actions.items():
             properties["enabled"] = getattr(
                 job, CustomJobAction.get_enabled_callback_name(action), lambda js: True
-            )(job_status)
+            )(job.cached_status)  # use cached status in case job_status is None
 
         return JobsTableRow(row_values, job_status=job_status, actions=job_actions)
 

--- a/tethys_gizmos/static/tethys_gizmos/css/jobs_table.css
+++ b/tethys_gizmos/static/tethys_gizmos/css/jobs_table.css
@@ -212,6 +212,10 @@ p.loading-error {
 }
 
 /* Status indicator */
+td.job-status > div{
+    min-width: 100px;
+}
+
 .status-indicator{
     border-radius: 50%;
     height: 14px;

--- a/tethys_gizmos/static/tethys_gizmos/js/jobs_table.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/jobs_table.js
@@ -294,6 +294,7 @@ function update_row(table_elem){
     var refresh_interval = $(table).data('refresh-interval');
     var job_id = $(table_elem).data('job-id');
     var update_url = base_ajax_url + job_id + '/update-row';
+    var active_statuses = $(table).data('active-statuses');
 
     var data = {
         column_fields: column_fields,
@@ -314,7 +315,7 @@ function update_row(table_elem){
                 status = json.status;
             }
 
-            if(status == 'Running' || status == 'Submitted' || status == 'Various') {
+            if(active_statuses.includes(status)) {
                 active_counter++;
                 setTimeout(function(){
                     update_row(table_elem);
@@ -386,6 +387,7 @@ function update_workflow_nodes_row(table_elem){
     var target_selector = "#" + $(table_elem).attr('id') + " td .workflow-nodes-graph";
     var error_selector = target_selector + ' .loading-error';
     var update_url = base_ajax_url + job_id + '/update-workflow-nodes-row';
+    var active_statuses = $(table_elem).data('active-statuses');
 
     $.ajax({
         method: 'POST',
@@ -401,7 +403,7 @@ function update_workflow_nodes_row(table_elem){
 
             // Update again?
             status = json.status;
-            if(status == 'Running' || status == 'Submitted' || status == 'Various'){
+            if(active_statuses.includes(status)){
                 setTimeout(function(){
                     update_workflow_nodes_row(table_elem);
                 }, refresh_interval);

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/job_row.html
@@ -34,7 +34,7 @@
         {% else %}
           <div class="status-indicator status-{{ job_status|codify }}"></div>
         {% endif %}
-        {{ job_status }}
+        <span>{{ job_status }}</span>
       {% endif %}
     </div>
     {% endif %}

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/jobs_table.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/jobs_table.html
@@ -13,6 +13,7 @@
        data-monitor-url="{{ monitor_url }}"
        data-results-url="{{ results_url }}"
        data-refresh-interval="{{ refresh_interval }}"
+       data-active-statuses="{{ active_statuses|jsonify }}"
        data-actions="{{ actions|jsonify }}"
        data-enable-data-table="{{ enable_data_table|jsonify }}"
        data-data-table-options="{{ data_table_options|jsonify }}"


### PR DESCRIPTION
### Description
The functionality of `update_status` and the status updating of the Jobs Table Gizmo were limited to hard-coded statuses. All custom statuses were considered to be "terminal" statuses. This PR changes the logic of the Jobs Table JS to make it more flexible with which statuses it will continue to update. It also add convenience functions for classifying custom job statuses and adds documentation to better describe custom job statuses.

### Changes Made to Code:
 - Jobs Table Gizmo JS now checks for ``TethysJob.ACTIVE_STATUSES`` rather than a list of hard coded statuses
 - adds methods to classify custom statuses in the ``TethysJob`` class.
 - changes the logic of the ``update_status`` method to check if ``OTH`` statuses should be updated.

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
