### PR TITLE
Patch to syncstores to enable support for PostGIS 3.4

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_models/test_PersistentStoreDatabaseSetting.py
+++ b/tests/unit_tests/test_tethys_apps/test_models/test_PersistentStoreDatabaseSetting.py
@@ -427,16 +427,247 @@ class PersistentStoreDatabaseSettingTests(TethysTestCase):
         ).create_persistent_store_database(refresh=True, force_first_time=True)
 
         # Check mock called
-        rts_get_args = mock_log.getLogger().info.call_args_list
+        mock_log_info_calls = mock_log.getLogger().info.call_args_list
         check_log1 = 'Creating database "spatial_db" for app "test_app"...'
         check_log2 = 'Enabling PostGIS on database "spatial_db" for app "test_app"...'
         check_log3 = (
             'Initializing database "spatial_db" for app "test_app" '
             'with initializer "appsettings.model.init_spatial_db"...'
         )
-        self.assertEqual(check_log1, rts_get_args[0][0][0])
-        self.assertEqual(check_log2, rts_get_args[1][0][0])
-        self.assertEqual(check_log3, rts_get_args[2][0][0])
+        self.assertEqual(check_log1, mock_log_info_calls[0][0][0])
+        self.assertEqual(check_log2, mock_log_info_calls[1][0][0])
+        self.assertEqual(check_log3, mock_log_info_calls[2][0][0])
+        mock_init.assert_called()
+
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.drop_persistent_store_database"
+    )
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.get_namespaced_persistent_store_name"
+    )
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.persistent_store_database_exists"
+    )
+    @mock.patch("tethys_apps.models.PersistentStoreDatabaseSetting.get_value")
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.initializer_function"
+    )
+    @mock.patch("tethys_apps.models.logging")
+    def test_create_persistent_store_database_postgis2(
+        self, mock_log, mock_init, mock_get, mock_ps_de, mock_gn, mock_drop
+    ):
+        # Mock Get Name
+        mock_gn.return_value = "spatial_db"
+
+        # Mock Drop Database
+        mock_drop.return_value = ""
+
+        # Mock persistent_store_database_exists
+        mock_ps_de.return_value = False  # DB does not exist
+
+        # Mock get_values
+        mock_url = mock.MagicMock(username="test_app")
+        mock_engine = mock.MagicMock()
+        mock_new_db_engine = mock.MagicMock()
+        mock_db_connection = mock_new_db_engine.connect()
+        mock_init_param = mock.MagicMock()
+        mock_get.side_effect = [
+            mock_url,
+            mock_engine,
+            mock_new_db_engine,
+            mock_init_param,
+        ]
+        mock_db_connection.execute.side_effect = [
+            mock.MagicMock(),  # Enable PostGIS Statement
+            [
+                mock.MagicMock(postgis_version="2.5 USE_GEOS=1 USE_PROJ=1 USE_STATS=1")
+            ],  # Check PostGIS Version
+            mock.MagicMock(),  # Enable PostGIS Raster Statement
+        ]
+
+        # Execute
+        self.test_app.settings_set.select_subclasses().get(
+            name="spatial_db"
+        ).create_persistent_store_database(refresh=False, force_first_time=False)
+
+        # Check mock calls
+        mock_execute_calls = mock_db_connection.execute.call_args_list
+        self.assertEqual(2, len(mock_execute_calls))
+        execute1 = "CREATE EXTENSION IF NOT EXISTS postgis;"
+        execute2 = "SELECT PostGIS_Version();"
+        self.assertEqual(execute1, mock_execute_calls[0][0][0])
+        self.assertEqual(execute2, mock_execute_calls[1][0][0])
+
+        mock_log_info_calls = mock_log.getLogger().info.call_args_list
+        self.assertEqual(4, len(mock_log_info_calls))
+        check_log1 = 'Creating database "spatial_db" for app "test_app"...'
+        check_log2 = 'Enabling PostGIS on database "spatial_db" for app "test_app"...'
+        check_log3 = "Detected PostGIS version 2.5"
+        check_log4 = (
+            'Initializing database "spatial_db" for app "test_app" '
+            'with initializer "appsettings.model.init_spatial_db"...'
+        )
+        self.assertEqual(check_log1, mock_log_info_calls[0][0][0])
+        self.assertEqual(check_log2, mock_log_info_calls[1][0][0])
+        self.assertEqual(check_log3, mock_log_info_calls[2][0][0])
+        self.assertEqual(check_log4, mock_log_info_calls[3][0][0])
+        mock_init.assert_called()
+
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.drop_persistent_store_database"
+    )
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.get_namespaced_persistent_store_name"
+    )
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.persistent_store_database_exists"
+    )
+    @mock.patch("tethys_apps.models.PersistentStoreDatabaseSetting.get_value")
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.initializer_function"
+    )
+    @mock.patch("tethys_apps.models.logging")
+    def test_create_persistent_store_database_postgis3(
+        self, mock_log, mock_init, mock_get, mock_ps_de, mock_gn, mock_drop
+    ):
+        # Mock Get Name
+        mock_gn.return_value = "spatial_db"
+
+        # Mock Drop Database
+        mock_drop.return_value = ""
+
+        # Mock persistent_store_database_exists
+        mock_ps_de.return_value = False  # DB does not exist
+
+        # Mock get_values
+        mock_url = mock.MagicMock(username="test_app")
+        mock_engine = mock.MagicMock()
+        mock_new_db_engine = mock.MagicMock()
+        mock_db_connection = mock_new_db_engine.connect()
+        mock_init_param = mock.MagicMock()
+        mock_get.side_effect = [
+            mock_url,
+            mock_engine,
+            mock_new_db_engine,
+            mock_init_param,
+        ]
+        mock_db_connection.execute.side_effect = [
+            mock.MagicMock(),  # Enable PostGIS Statement
+            [
+                mock.MagicMock(postgis_version="3.5 USE_GEOS=1 USE_PROJ=1 USE_STATS=1")
+            ],  # Check PostGIS Version
+            mock.MagicMock(),  # Enable PostGIS Raster Statement
+        ]
+
+        # Execute
+        self.test_app.settings_set.select_subclasses().get(
+            name="spatial_db"
+        ).create_persistent_store_database(refresh=False, force_first_time=False)
+
+        # Check mock calls
+        mock_execute_calls = mock_db_connection.execute.call_args_list
+        self.assertEqual(3, len(mock_execute_calls))
+        execute1 = "CREATE EXTENSION IF NOT EXISTS postgis;"
+        execute2 = "SELECT PostGIS_Version();"
+        execute3 = "CREATE EXTENSION IF NOT EXISTS postgis_raster;"
+        self.assertEqual(execute1, mock_execute_calls[0][0][0])
+        self.assertEqual(execute2, mock_execute_calls[1][0][0])
+        self.assertEqual(execute3, mock_execute_calls[2][0][0])
+
+        mock_log_info_calls = mock_log.getLogger().info.call_args_list
+        self.assertEqual(5, len(mock_log_info_calls))
+        check_log1 = 'Creating database "spatial_db" for app "test_app"...'
+        check_log2 = 'Enabling PostGIS on database "spatial_db" for app "test_app"...'
+        check_log3 = "Detected PostGIS version 3.5"
+        check_log4 = (
+            'Enabling PostGIS Raster on database "spatial_db" for app "test_app"...'
+        )
+        check_log5 = (
+            'Initializing database "spatial_db" for app "test_app" '
+            'with initializer "appsettings.model.init_spatial_db"...'
+        )
+        self.assertEqual(check_log1, mock_log_info_calls[0][0][0])
+        self.assertEqual(check_log2, mock_log_info_calls[1][0][0])
+        self.assertEqual(check_log3, mock_log_info_calls[2][0][0])
+        self.assertEqual(check_log4, mock_log_info_calls[3][0][0])
+        self.assertEqual(check_log5, mock_log_info_calls[4][0][0])
+        mock_init.assert_called()
+
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.drop_persistent_store_database"
+    )
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.get_namespaced_persistent_store_name"
+    )
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.persistent_store_database_exists"
+    )
+    @mock.patch("tethys_apps.models.PersistentStoreDatabaseSetting.get_value")
+    @mock.patch(
+        "tethys_apps.models.PersistentStoreDatabaseSetting.initializer_function"
+    )
+    @mock.patch("tethys_apps.models.logging")
+    def test_create_persistent_store_database_postgis3_bad_version_string(
+        self, mock_log, mock_init, mock_get, mock_ps_de, mock_gn, mock_drop
+    ):
+        # Mock Get Name
+        mock_gn.return_value = "spatial_db"
+
+        # Mock Drop Database
+        mock_drop.return_value = ""
+
+        # Mock persistent_store_database_exists
+        mock_ps_de.return_value = False  # DB does not exist
+
+        # Mock get_values
+        mock_url = mock.MagicMock(username="test_app")
+        mock_engine = mock.MagicMock()
+        mock_new_db_engine = mock.MagicMock()
+        mock_db_connection = mock_new_db_engine.connect()
+        mock_init_param = mock.MagicMock()
+        mock_get.side_effect = [
+            mock_url,
+            mock_engine,
+            mock_new_db_engine,
+            mock_init_param,
+        ]
+        mock_db_connection.execute.side_effect = [
+            mock.MagicMock(),  # Enable PostGIS Statement
+            [
+                mock.MagicMock(postgis_version="BAD VERSION STRING")
+            ],  # Check PostGIS Version
+            mock.MagicMock(),  # Enable PostGIS Raster Statement
+        ]
+
+        # Execute
+        self.test_app.settings_set.select_subclasses().get(
+            name="spatial_db"
+        ).create_persistent_store_database(refresh=False, force_first_time=False)
+
+        # Check mock calls
+        mock_execute_calls = mock_db_connection.execute.call_args_list
+        self.assertEqual(2, len(mock_execute_calls))
+        execute1 = "CREATE EXTENSION IF NOT EXISTS postgis;"
+        execute2 = "SELECT PostGIS_Version();"
+        self.assertEqual(execute1, mock_execute_calls[0][0][0])
+        self.assertEqual(execute2, mock_execute_calls[1][0][0])
+
+        mock_log_warning_calls = mock_log.getLogger().warning.call_args_list
+        self.assertEqual(1, len(mock_log_warning_calls))
+        check_log1 = 'Could not parse PostGIS version from "BAD VERSION STRING"'
+        self.assertEqual(check_log1, mock_log_warning_calls[0][0][0])
+
+        mock_log_info_calls = mock_log.getLogger().info.call_args_list
+        self.assertEqual(3, len(mock_log_info_calls))
+        check_log1 = 'Creating database "spatial_db" for app "test_app"...'
+        check_log2 = 'Enabling PostGIS on database "spatial_db" for app "test_app"...'
+        check_log3 = (
+            'Initializing database "spatial_db" for app "test_app" '
+            'with initializer "appsettings.model.init_spatial_db"...'
+        )
+        self.assertEqual(check_log1, mock_log_info_calls[0][0][0])
+        self.assertEqual(check_log2, mock_log_info_calls[1][0][0])
+        self.assertEqual(check_log3, mock_log_info_calls[2][0][0])
         mock_init.assert_called()
 
     @mock.patch("sqlalchemy.exc")

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1163,22 +1163,12 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                 )
             )
 
-            enable_postgis_statement = "CREATE EXTENSION IF NOT EXISTS postgis"
-
             # Execute postgis statement
             try:
-                new_db_connection.execute(enable_postgis_statement)
-            except sqlalchemy.exc.ProgrammingError:
-                raise PersistentStorePermissionError(
-                    'Database user "{0}" has insufficient permissions to enable '
-                    'spatial extension on persistent store database "{1}": must be a '
-                    "superuser.".format(url.username, self.name)
-                )
+                new_db_connection.execute("CREATE EXTENSION IF NOT EXISTS postgis;")
 
-            try:
                 # Get the POSTGIS version
-                check_postgis_version = "SELECT PostGIS_Version();"
-                ret = new_db_connection.execute(check_postgis_version)
+                ret = new_db_connection.execute("SELECT PostGIS_Version();")
                 postgis_version = None
                 for r in ret:
                     # Example version string: "3.4 USE_GEOS=1 USE_PROJ=1 USE_STATS=1"
@@ -1198,8 +1188,9 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                             self.tethys_app.package,
                         )
                     )
-                    enable_postgis_raster_statement = "CREATE EXTENSION IF NOT EXISTS postgis_raster"
-                    new_db_connection.execute(enable_postgis_raster_statement)
+                    new_db_connection.execute(
+                        "CREATE EXTENSION IF NOT EXISTS postgis_raster;"
+                    )
 
             except sqlalchemy.exc.ProgrammingError:
                 raise PersistentStorePermissionError(

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1175,8 +1175,6 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                     "superuser.".format(url.username, self.name)
                 )
 
-
-            
             try:
                 # Get the POSTGIS version
                 check_postgis_version = "SELECT PostGIS_Version();"
@@ -1186,6 +1184,8 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                     # Example version string: "3.4 USE_GEOS=1 USE_PROJ=1 USE_STATS=1"
                     try:
                         postgis_version = float(r.postgis_version.split(" ")[0])
+                        log.info(f'Detected PostGIS version {postgis_version}')
+                        break
                     except Exception:
                         log.warning(f'Could not parse PostGIS version from "{r.postgis_version}"')
                         continue

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1174,11 +1174,9 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                     'spatial extension on persistent store database "{1}": must be a '
                     "superuser.".format(url.username, self.name)
                 )
-            finally:
-                new_db_connection.close()
 
             enable_postgis_raster_statement = "CREATE EXTENSION IF NOT EXISTS postgis_raster"
-
+            
             # Execute postgis raster statement
             try:
                 new_db_connection.execute(enable_postgis_raster_statement)

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1177,6 +1177,20 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
             finally:
                 new_db_connection.close()
 
+            enable_postgis_raster_statement = "CREATE EXTENSION IF NOT EXISTS postgis_raster"
+
+            # Execute postgis raster statement
+            try:
+                new_db_connection.execute(enable_postgis_raster_statement)
+            except sqlalchemy.exc.ProgrammingError:
+                raise PersistentStorePermissionError(
+                    'Database user "{0}" has insufficient permissions to enable '
+                    'spatial extension on persistent store database "{1}": must be a '
+                    "superuser.".format(url.username, self.name)
+                )
+            finally:
+                new_db_connection.close()
+
         # -------------------------------------------------------------------------------------------------------------#
         # 4. Run initialization function
         # -------------------------------------------------------------------------------------------------------------#

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1174,10 +1174,12 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                     # Example version string: "3.4 USE_GEOS=1 USE_PROJ=1 USE_STATS=1"
                     try:
                         postgis_version = float(r.postgis_version.split(" ")[0])
-                        log.info(f'Detected PostGIS version {postgis_version}')
+                        log.info(f"Detected PostGIS version {postgis_version}")
                         break
                     except Exception:
-                        log.warning(f'Could not parse PostGIS version from "{r.postgis_version}"')
+                        log.warning(
+                            f'Could not parse PostGIS version from "{r.postgis_version}"'
+                        )
                         continue
 
                 # Execute postgis raster statement for verions 3.0 and above

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1175,19 +1175,41 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
                     "superuser.".format(url.username, self.name)
                 )
 
-            enable_postgis_raster_statement = "CREATE EXTENSION IF NOT EXISTS postgis_raster"
+
             
-            # Execute postgis raster statement
             try:
-                new_db_connection.execute(enable_postgis_raster_statement)
+                # Get the POSTGIS version
+                check_postgis_version = "SELECT PostGIS_Version();"
+                ret = new_db_connection.execute(check_postgis_version)
+                postgis_version = None
+                for r in ret:
+                    # Example version string: "3.4 USE_GEOS=1 USE_PROJ=1 USE_STATS=1"
+                    try:
+                        postgis_version = float(r.postgis_version.split(" ")[0])
+                    except Exception:
+                        log.warning(f'Could not parse PostGIS version from "{r.postgis_version}"')
+                        continue
+
+                # Execute postgis raster statement for verions 3.0 and above
+                if postgis_version is not None and postgis_version >= 3.0:
+                    log.info(
+                        'Enabling PostGIS Raster on database "{0}" for app "{1}"...'.format(
+                            self.name,
+                            self.tethys_app.package,
+                        )
+                    )
+                    enable_postgis_raster_statement = "CREATE EXTENSION IF NOT EXISTS postgis_raster"
+                    new_db_connection.execute(enable_postgis_raster_statement)
+
             except sqlalchemy.exc.ProgrammingError:
                 raise PersistentStorePermissionError(
                     'Database user "{0}" has insufficient permissions to enable '
                     'spatial extension on persistent store database "{1}": must be a '
                     "superuser.".format(url.username, self.name)
                 )
-            finally:
-                new_db_connection.close()
+
+            # Close connection
+            new_db_connection.close()
 
         # -------------------------------------------------------------------------------------------------------------#
         # 4. Run initialization function


### PR DESCRIPTION
### Description
In PostGIS 3, the raster functionality is moved to a separate extension: postgis_raster. This PR updates syncstores to add the raster extension if it detects PostGIS version 3.

### Changes Made to Code:
 - Syncstores command checks PostGIS version and creates the postgis_raster extension if on version 3.X when initializing a postgis database.

### Additional Notes:
 - CHL has requested this be released as a patch of 4.2 so their new server can get the fix.

### Related
 - Will create separate PR for merge into main for the 4.3 release.


### Quality Checks
 - [ ] New code is 100% tested
 - [ ] Code has been formated
 - [ ] Code has been linted
 - [ ] Docstrings for new methods have been added
