### PR TITLE
App description as tooltip

### DIFF
--- a/tethys_apps/templates/tethys_apps/app_card.html
+++ b/tethys_apps/templates/tethys_apps/app_card.html
@@ -2,7 +2,7 @@
 <div class="app-card-container position-relative" data-tags="{{ app|get_tag_class }}">
     {% if not unconfigured %}
     <a class="app-link-wrapper rounded d-block mt-4 {% if not app.show_in_apps_library or not app.enabled %} veiled{% endif %}"
-       title="{% if not app.show_in_apps_library %}Hidden{% elif not app.enabled %}Disabled{% else %}{{ app.name }}{% endif %}"
+       title="{% if not app.show_in_apps_library %}Hidden{% elif not app.enabled %}Disabled{% elif app.description %}{{ app.description }}{% else %}{{ app.name }}{% endif %}"
        href="{% if app.proxied %}{{ app.url }}{% if app.back_url %}?back={{ app.back_url }}{% endif %}{% else %}{% url app.index_url %}{% endif %}"
        {% if app.proxied and app.open_in_new_tab %}target="_blank"{% endif %}
     >
@@ -20,7 +20,7 @@
                         <i class="bi bi-box-arrow-up-right"></i>
                     </div>
                 {% endif %}
-                <h5 class="card-title app-title mt-2 mb-0">{{ app.name }}</h5>
+                <h5 class="card-title app-title mt-2 mb-0" title="{{ app.name }}">{{ app.name }}</h5>
             </div>
         </div>
     </a>


### PR DESCRIPTION
### Description
In addition to having the app description available through the info icon on the app card, some user feedback has suggested that having the app description as a tooltip on the app card would be helpful.

This PR uses the `app.description` for the app card `title` if it's available. It also adds a `title` attribute to the app name header on the card and sets that as the `app.name`