### PR TITLE
Fix release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
     - title: Features
       labels:
         - major feature
+        - minor feature
     - title: Experimental Features
       labels:
         - experimental

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,12 +1,8 @@
 changelog:
   categories:
-    - title: Test
-      labels:
-        - test
     - title: Features
       labels:
-        - "major features"
-        - "minor features"
+        - major feature
     - title: Experimental Features
       labels:
         - experimental

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,8 @@
 changelog:
   categories:
+    - title: Test
+      labels:
+        - test
     - title: Features
       labels:
         - "major features"


### PR DESCRIPTION
A typo in the `release.yml` file was preventing the `Feature` category from generating in the auto-generated release notes. 

Also, note that if multiple labels are applied to the same PR (e.g. `experimental` and `major feature`) then it will only match the first category.