### PR TITLE
Fire select event after boxend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,6 +183,7 @@ RUN groupadd www \
 ADD --chown=www:www resources ${TETHYS_HOME}/tethys/resources/
 ADD --chown=www:www tethys_apps ${TETHYS_HOME}/tethys/tethys_apps/
 ADD --chown=www:www tethys_cli ${TETHYS_HOME}/tethys/tethys_cli/
+ADD --chown=www:www tethys_components ${TETHYS_HOME}/tethys/tethys_components/
 ADD --chown=www:www tethys_compute ${TETHYS_HOME}/tethys/tethys_compute/
 ADD --chown=www:www tethys_config ${TETHYS_HOME}/tethys/tethys_config/
 ADD --chown=www:www tethys_layouts ${TETHYS_HOME}/tethys/tethys_layouts/

--- a/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
+++ b/tethys_gizmos/static/tethys_gizmos/js/tethys_map_view.js
@@ -1312,6 +1312,12 @@ add_drag_box_interaction = function() {
 
     // Call draw end callback
     draw_end_callback(feature);
+
+    m_select_interaction.getFeatures().push(feature);
+    m_select_interaction.dispatchEvent({
+      type: 'select',
+      selected: [feature]
+    });
   });
 
   m_map.addInteraction(m_drag_box_interaction);
@@ -1340,9 +1346,7 @@ add_snap_interaction = function() {
 
 add_modify_interaction = function() {
   // Modify interaction works in conjunction with a selection interaction
-  var selected_features;
-
-  selected_features = null;
+  var selected_features = null;
 
   // Create select interaction
   m_modify_select_interaction = new ol.interaction.Select({


### PR DESCRIPTION
### Description
Fire select event in the callback of `boxend` event, so the name attribute will pop up automatically.

(Click Play button to see the gif)

![Screen Recording 2024-11-27 at 10 19 14 AM](https://github.com/user-attachments/assets/f7773fb9-8ed3-4f84-ad64-476046cce0dd)


### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added
