### PR TITLE
Allow anonymous users to get condor job status

### DIFF
--- a/tests/unit_tests/test_tethys_compute/test_job_manager.py
+++ b/tests/unit_tests/test_tethys_compute/test_job_manager.py
@@ -106,7 +106,9 @@ class TestJobManager(unittest.TestCase):
     @mock.patch("tethys_compute.job_manager.get_anonymous_user")
     @mock.patch("tethys_compute.job_manager.get_user_workspace")
     @mock.patch("tethys_compute.job_manager.CondorJob")
-    def test_JobManager_create_job_anonymous_user(self, mock_cj, mock_guw, mock_get_anonymous_user, mock_isinstance):
+    def test_JobManager_create_job_anonymous_user(
+        self, mock_cj, mock_guw, mock_get_anonymous_user, mock_isinstance
+    ):
         mock_app = mock.MagicMock()
         mock_app.package = "test_label"
         mock_guw().path = "test_user_workspace"

--- a/tethys_apps/decorators.py
+++ b/tethys_apps/decorators.py
@@ -23,6 +23,17 @@ from tethys_portal.views import error as tethys_portal_error
 from .base import has_permission
 
 
+def async_login_required(func):
+    @wraps(func)
+    async def wrapper(request, *args, **kwargs):
+        redirect = login_required(lambda r: r)(request)
+        if redirect != request:
+            return redirect
+        return await func(request, *args, **kwargs)
+
+    return wrapper
+
+
 def login_required(
     function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None
 ):

--- a/tethys_compute/job_manager.py
+++ b/tethys_compute/job_manager.py
@@ -10,7 +10,7 @@
 
 import logging
 
-
+from django.contrib.auth.models import User
 from django.urls import reverse
 from guardian.utils import get_anonymous_user
 
@@ -69,7 +69,7 @@ class JobManager:
         # Allow the job class to be passed in as job_type.
         if isinstance(job_type, str):
             job_type = JOB_TYPES[job_type]
-        if user.is_anonymous:
+        if isinstance(user, User) and user.is_anonymous:
             user = get_anonymous_user()
         user_workspace = get_user_workspace(self.app, user)
         kwrgs = dict(

--- a/tethys_compute/job_manager.py
+++ b/tethys_compute/job_manager.py
@@ -12,6 +12,7 @@ import logging
 
 
 from django.urls import reverse
+from guardian.utils import get_anonymous_user
 
 from tethys_compute.models.tethys_job import TethysJob
 from tethys_compute.models.basic_job import BasicJob
@@ -68,6 +69,8 @@ class JobManager:
         # Allow the job class to be passed in as job_type.
         if isinstance(job_type, str):
             job_type = JOB_TYPES[job_type]
+        if user.is_anonymous:
+            user = get_anonymous_user()
         user_workspace = get_user_workspace(self.app, user)
         kwrgs = dict(
             name=name, user=user, label=self.label, workspace=user_workspace.path

--- a/tethys_compute/views/update_status.py
+++ b/tethys_compute/views/update_status.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 
 from django.http import JsonResponse
+from guardian.utils import get_anonymous_user
 from channels.db import database_sync_to_async
 
 from tethys_compute.models import TethysJob, DaskJob
@@ -33,6 +34,8 @@ def get_job(job_id, user=None):
     Returns: `TethysJob` object
 
     """
+    if user.is_anonymous:
+        user = get_anonymous_user()
     if (
         user is None
         or user.is_staff

--- a/tethys_compute/views/update_status.py
+++ b/tethys_compute/views/update_status.py
@@ -34,7 +34,7 @@ def get_job(job_id, user=None):
     Returns: `TethysJob` object
 
     """
-    if user.is_anonymous:
+    if user is not None and user.is_anonymous:
         user = get_anonymous_user()
     if (
         user is None

--- a/tethys_gizmos/views/gizmos/jobs_table.py
+++ b/tethys_gizmos/views/gizmos/jobs_table.py
@@ -11,13 +11,12 @@
 import inspect
 import logging
 import re
-from functools import wraps
 
 from django.http import JsonResponse
 from django.template.loader import render_to_string
-from django.contrib.auth.decorators import login_required
 from channels.db import database_sync_to_async
 
+from tethys_apps.decorators import async_login_required
 from tethys_compute.models import CondorWorkflow, DaskJob, DaskScheduler
 from tethys_gizmos.gizmo_options.jobs_table import JobsTable
 from tethys_sdk.gizmos import SelectInput
@@ -28,17 +27,6 @@ from tethys_compute.views import get_job, do_job_action
 server_document = optional_import("server_document", from_module="bokeh.embed")
 
 logger = logging.getLogger(f"tethys.{__name__}")
-
-
-def async_login_required(func):
-    @wraps(func)
-    async def wrapper(request, *args, **kwargs):
-        redirect = login_required(lambda r: r)(request)
-        if redirect != request:
-            return redirect
-        return await func(request, *args, **kwargs)
-
-    return wrapper
 
 
 async def _get_log_content(job, key1, key2):


### PR DESCRIPTION
### Description
This merge request addresses anonymous users being unable to get the status of a condor job. Without this fix, the anonymous user cannot view a jobs_table gizmo that correctly refreshes the status of its jobs.

### Changes Made to Code:
 - 

### Related
- 

### Additional Notes
-  

### Quality Checks
 - [ ] New code is 100% tested
 - [ ] Code has been formated
 - [ ] Code has been linted
 - [ ] Docstrings for new methods have been added
