### PR TITLE
Hotfix: url kwargs title

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
@@ -263,20 +263,20 @@ class TestController(unittest.TestCase):
     def test__get_url_map_kwargs_list_url_dict(self):
         result = tethys_controller._get_url_map_kwargs_list(
             url={
-                'test': 'test/url/',
-                'another_test': 'test/{another}/url/',
+                "test": "test/url/",
+                "another_test": "test/{another}/url/",
             }
         )
-        self.assertEqual(result[0]['title'], 'Test')
-        self.assertEqual(result[1]['title'], 'Another Test')
+        self.assertEqual(result[0]["title"], "Test")
+        self.assertEqual(result[1]["title"], "Another Test")
 
     def test__get_url_map_kwargs_list_url_list(self):
         result = tethys_controller._get_url_map_kwargs_list(
-            name='test',
+            name="test",
             url=[
-                'test/url/',
-                'test/{another}/url/',
-            ]
+                "test/url/",
+                "test/{another}/url/",
+            ],
         )
-        self.assertEqual(result[0]['title'], 'Test')
-        self.assertEqual(result[1]['title'], 'Test 1')
+        self.assertEqual(result[0]["title"], "Test")
+        self.assertEqual(result[1]["title"], "Test 1")

--- a/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
+++ b/tests/unit_tests/test_tethys_apps/test_base/test_controller.py
@@ -259,3 +259,24 @@ class TestController(unittest.TestCase):
         mock_UrlMap.assert_called_with(
             name="catch_all", url="root/.*/", controller=mock_controller
         )
+
+    def test__get_url_map_kwargs_list_url_dict(self):
+        result = tethys_controller._get_url_map_kwargs_list(
+            url={
+                'test': 'test/url/',
+                'another_test': 'test/{another}/url/',
+            }
+        )
+        self.assertEqual(result[0]['title'], 'Test')
+        self.assertEqual(result[1]['title'], 'Another Test')
+
+    def test__get_url_map_kwargs_list_url_list(self):
+        result = tethys_controller._get_url_map_kwargs_list(
+            name='test',
+            url=[
+                'test/url/',
+                'test/{another}/url/',
+            ]
+        )
+        self.assertEqual(result[0]['title'], 'Test')
+        self.assertEqual(result[1]['title'], 'Test 1')

--- a/tethys_apps/base/controller.py
+++ b/tethys_apps/base/controller.py
@@ -821,9 +821,6 @@ def _get_url_map_kwargs_list(
             for i, final_url in enumerate(final_urls)
         }
 
-    if not title:
-        title = url_name.replace("_", " ").title()
-
     return [
         dict(
             name=url_name,
@@ -833,7 +830,7 @@ def _get_url_map_kwargs_list(
             regex=regex,
             handler=handler,
             handler_type=handler_type,
-            title=title,
+            title=title or url_name.replace("_", " ").title(),
             index=index,
         )
         for url_name, final_url in final_urls.items()
@@ -950,7 +947,7 @@ def register_controllers(
     UrlMap = url_map_maker(root_url)
     url_maps = [UrlMap(**kwargs) for name, kwargs in names.items()]
 
-    # Add a catch all endpoint for any URL following the app's root URL and map it to the named controller
+    # Add a catch-all endpoint for any URL following the app's root URL and map it to the named controller
     if catch_all and catch_all in names:
         url_maps.append(
             UrlMap(


### PR DESCRIPTION
fix bug preventing the url arg from being defined as a dict in routing decorators

### Description
The way the `title` value was being created in the `_get_url_map_kwargs_list` function causes a bug when the `url` argument is a `dict`. This fix addresses that bug and adds tests to catch the original error.


### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formated
 - [x] Code has been linted
 - [x] Docstrings for new methods have been added