### PR TITLE
Avoid "File name too long" error

### DIFF
--- a/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
+++ b/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
@@ -44,3 +44,19 @@ class TestSiteSettings(unittest.TestCase):
 
         ret = ss.load_custom_css("test.css")
         self.assertEqual(ret, "<style>test.css</style>")
+
+    def test_long_css_text(self):
+        long_css_text = """
+            .site-header { margin: 0 50px 0 0; background-color: red; }
+            .site-header .navbar-brand { 
+                background-color: darkred; 
+                color: black; 
+                font-style: italic;
+                font-variant: small-caps;
+                font-family: cursive;
+                font-size: 24px;
+            }
+        """
+
+        ret = ss.load_custom_css(long_css_text)
+        self.assertEqual(ret, f"<style>{long_css_text}</style>")

--- a/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
+++ b/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
@@ -48,9 +48,9 @@ class TestSiteSettings(unittest.TestCase):
     def test_long_css_text(self):
         long_css_text = """
             .site-header { margin: 0 50px 0 0; background-color: red; }
-            .site-header .navbar-brand { 
-                background-color: darkred; 
-                color: black; 
+            .site-header .navbar-brand {
+                background-color: darkred;
+                color: black;
                 font-style: italic;
                 font-variant: small-caps;
                 font-family: cursive;

--- a/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
+++ b/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
@@ -43,7 +43,9 @@ class TestSiteSettings(unittest.TestCase):
         mock_settings.STATICFILES_DIRS = ["test_base_path2"]
 
         ret = ss.load_custom_css(".navbar-brand { background-color: darkred; }")
-        self.assertEqual(ret, "<style>.navbar-brand { background-color: darkred; }</style>")
+        self.assertEqual(
+            ret, "<style>.navbar-brand { background-color: darkred; }</style>"
+        )
 
     def test_long_css_text(self):
         long_css_text = """

--- a/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
+++ b/tests/unit_tests/test_tethys_apps/test_templatetags/test_site_settings.py
@@ -42,8 +42,8 @@ class TestSiteSettings(unittest.TestCase):
         mock_settings.STATIC_ROOT = "test_base_path1"
         mock_settings.STATICFILES_DIRS = ["test_base_path2"]
 
-        ret = ss.load_custom_css("test.css")
-        self.assertEqual(ret, "<style>test.css</style>")
+        ret = ss.load_custom_css(".navbar-brand { background-color: darkred; }")
+        self.assertEqual(ret, "<style>.navbar-brand { background-color: darkred; }</style>")
 
     def test_long_css_text(self):
         long_css_text = """

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from django import template
@@ -10,6 +11,8 @@ static_finder = TethysStaticFinder()
 
 register = template.Library()
 
+log = logging.getLogger(f"tethys.{__name__}")
+
 
 @register.filter
 @stringfilter
@@ -19,9 +22,12 @@ def load_custom_css(var):
     Args:
         var: a filename of CSS to load or CSS text to embed into the page
 
-    Returns: a string of HTML that either embeds CSS text or points to a file
+    Returns:
+        a string of HTML that either embeds CSS text or points to a file
 
     """
+    if not var.strip():
+        return ""
     if var.startswith("/"):
         var = var.lstrip("/")
 
@@ -32,7 +38,18 @@ def load_custom_css(var):
         for path in settings.STATICFILES_DIRS:
             if (Path(path) / var).is_file():
                 return f'<link href="/static/{var}" rel="stylesheet" />'
-    except OSError:
+    except OSError as e:
+        oserror_exception = ": " + str(e)
         pass
+    else:
+        oserror_exception = ""
+
+    common_css_chars = "{};,"
+    if not any(c in var for c in common_css_chars):
+        # This appears to be a filename and not a CSS string
+        log.warning(
+            "Could not load file '%s' for custom styles%s", var, oserror_exception
+        )
+        return ""
 
     return "<style>" + var + "</style>"

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -39,7 +39,7 @@ def load_custom_css(var):
         for path in settings.STATICFILES_DIRS:
             if (Path(path) / var).is_file():
                 return f'<link href="/static/{var}" rel="stylesheet" />'
-    # If the string is too long for a file path, which could happen if it is CSS, 
+    # If the string is too long for a file path, which could happen if it is CSS,
     # an OSError will be raised during the file path checks. This could also happen
     # if a lengthy file path is given or is otherwise invalid.
     except OSError as e:

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -1,8 +1,8 @@
+from pathlib import Path
+
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.conf import settings
-
-from pathlib import Path
 
 from ..static_finders import TethysStaticFinder
 
@@ -14,6 +14,14 @@ register = template.Library()
 @register.filter
 @stringfilter
 def load_custom_css(var):
+    """Load Custom Styles defined in Tethys Portal -> Site Settings
+
+    Args:
+        var: a filename of CSS to load or CSS text to embed into the page
+
+    Returns: a string of HTML that either embeds CSS text or points to a file
+
+    """
     if var.startswith("/"):
         var = var.lstrip("/")
 

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -40,7 +40,6 @@ def load_custom_css(var):
                 return f'<link href="/static/{var}" rel="stylesheet" />'
     except OSError as e:
         oserror_exception = ": " + str(e)
-        pass
     else:
         oserror_exception = ""
 

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -47,6 +47,7 @@ def load_custom_css(var):
     else:
         oserror_exception = ""
 
+    # Verify the string is CSS and log warning if it is not
     common_css_chars = "{};,"
     if not any(c in var for c in common_css_chars):
         # This appears to be a filename and not a CSS string

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -32,6 +32,7 @@ def load_custom_css(var):
         var = var.lstrip("/")
 
     try:
+        # Check if var is a path to a file, if so return a link tag to the file
         if (Path(settings.STATIC_ROOT) / var).is_file() or static_finder.find(var):
             return f'<link href="/static/{var}" rel="stylesheet" />'
 

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -17,12 +17,14 @@ def load_custom_css(var):
     if var.startswith("/"):
         var = var.lstrip("/")
 
-    if (Path(settings.STATIC_ROOT) / var).is_file() or static_finder.find(var):
-        return f'<link href="/static/{var}" rel="stylesheet" />'
+    try:
+        if (Path(settings.STATIC_ROOT) / var).is_file() or static_finder.find(var):
+            return f'<link href="/static/{var}" rel="stylesheet" />'
 
-    else:
         for path in settings.STATICFILES_DIRS:
             if (Path(path) / var).is_file():
                 return f'<link href="/static/{var}" rel="stylesheet" />'
+    except OSError:
+        pass
 
     return "<style>" + var + "</style>"

--- a/tethys_apps/templatetags/site_settings.py
+++ b/tethys_apps/templatetags/site_settings.py
@@ -39,6 +39,9 @@ def load_custom_css(var):
         for path in settings.STATICFILES_DIRS:
             if (Path(path) / var).is_file():
                 return f'<link href="/static/{var}" rel="stylesheet" />'
+    # If the string is too long for a file path, which could happen if it is CSS, 
+    # an OSError will be raised during the file path checks. This could also happen
+    # if a lengthy file path is given or is otherwise invalid.
     except OSError as e:
         oserror_exception = ": " + str(e)
     else:


### PR DESCRIPTION
### Description
This merge request addresses https://github.com/tethysplatform/tethys/issues/1127 where CSS text greater than 256 characters causes an OSError exception on many pages, including admin pages.

### Changes Made to Code:
 - On any file error, treat "var" as CSS text to embed
 - Add docstring
 - Reorder imports
 - Remove unnecessary else: after return
 - Add unit test

### Related
- https://github.com/tethysplatform/tethys/issues/1127

### Additional Notes
- While making the unit test, I found that added a /* CSS Comment */ bypassed the issue. So the test variable is a little shorter than I hoped for. Also, that test CSS is not going to win any design awards.

### Quality Checks
 - [x] New code is 100% tested
 - [x] Code has been formatted (black)
 - [x] Code has been linted (pylint, flake8)
 - [x] Docstrings for new methods have been added
