### PR TITLE
Fixed index names in tutorial docs

### DIFF
--- a/docs/tethys_portal/feedback.rst
+++ b/docs/tethys_portal/feedback.rst
@@ -39,7 +39,7 @@ Example
         """
 
         name = 'My First App'
-        index = 'my_first_app:home'
+        index = 'home'
         icon = 'my_first_app/images/icon.gif'
         package = 'my_first_app'
         root_url = 'my-first-app'

--- a/docs/tutorials/thredds/new_app_project.rst
+++ b/docs/tutorials/thredds/new_app_project.rst
@@ -90,7 +90,7 @@ Download this :download:`Unidata App Icon <./resources/unidata_logo.png>` or fin
         """
 
         name = 'THREDDS Tutorial'
-        index = 'thredds_tutorial:home'
+        index = 'home'
         icon = f'{package}/images/unidata_logo.png'
         package = 'thredds_tutorial'
         root_url = 'thredds-tutorial'


### PR DESCRIPTION

Removed a few instances of the old app_name:controller convention from the app.py file contents in tutorial documents