### PR TITLE
Small fixes for google earth engine tutorial

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ a. To install ``tethys-platform`` into a new conda environment then run the foll
 
     **Django Version**
 
-    As of Tethys 3.4 and above, the version of Django is no longer pinned in the ``tethys-platform`` package. You will need to specify the version of Django that you want to use when creating the environment. This is especially important for production installations, as only the LTS versions of Django recieve bug and security fixes. For development installations, we recommend using the same version of Django that you plan to use in production. For production installations, we recommend using the current LTS version of Django (see: `How to get Django - Supported Versions <https://www.djangoproject.com/download/>`_. Failing to provide the Django version will result in installing the latest version of Django which may not be the LTS version.
+    As of Tethys 4.3 and above, the version of Django is no longer pinned in the ``tethys-platform`` package. You will need to specify the version of Django that you want to use when creating the environment. This is especially important for production installations, as only the LTS versions of Django recieve bug and security fixes. For development installations, we recommend using the same version of Django that you plan to use in production. For production installations, we recommend using the current LTS version of Django (see: `How to get Django - Supported Versions <https://www.djangoproject.com/download/>`_. Failing to provide the Django version will result in installing the latest version of Django which may not be the LTS version.
 
 .. tip::
 

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -72,7 +72,7 @@ Alternatively, if you set ``libmamba`` to be the default solver in step 2, run t
 
     **Django Version**
 
-    As of Tethys 3.4 and above, the version of Django is no longer pinned in the ``tethys-platform`` package. You will need to specify the version of Django that you want to use when creating the environment. This is especially important for production installations, as only the LTS versions of Django recieve bug and security fixes. For development installations, we recommend using the same version of Django that you plan to use in production. For production installations, we recommend using the current LTS version of Django (see: `How to get Django - Supported Versions <https://www.djangoproject.com/download/>`_. Failing to provide the Django version will result in installing the latest version of Django which may not be the LTS version.
+    As of Tethys 4.3 and above, the version of Django is no longer pinned in the ``tethys-platform`` package. You will need to specify the version of Django that you want to use when creating the environment. This is especially important for production installations, as only the LTS versions of Django recieve bug and security fixes. For development installations, we recommend using the same version of Django that you plan to use in production. For production installations, we recommend using the current LTS version of Django (see: `How to get Django - Supported Versions <https://www.djangoproject.com/download/>`_. Failing to provide the Django version will result in installing the latest version of Django which may not be the LTS version.
 
 Install Packages
 ----------------

--- a/docs/installation/production/manual/installation.rst
+++ b/docs/installation/production/manual/installation.rst
@@ -34,7 +34,7 @@ Install Tethys Platform
 
     **Django Version**
 
-    As of Tethys 3.4 and above, the version of Django is no longer pinned in the ``tethys-platform`` package. You will need to specify the version of Django that you want to use when creating the environment. This is especially important for production installations, as only the LTS versions of Django recieve bug and security fixes. We recommend using the current Django LTS version for production installations (see: `How to get Django - Supported Versions <https://www.djangoproject.com/download/>`_. Failing to provide the Django version will result in installing the latest version of Django which may not be the LTS version.
+    As of Tethys 4.3 and above, the version of Django is no longer pinned in the ``tethys-platform`` package. You will need to specify the version of Django that you want to use when creating the environment. This is especially important for production installations, as only the LTS versions of Django recieve bug and security fixes. We recommend using the current Django LTS version for production installations (see: `How to get Django - Supported Versions <https://www.djangoproject.com/download/>`_. Failing to provide the Django version will result in installing the latest version of Django which may not be the LTS version.
 
 2. Activate the ``tethys`` conda environment after it is created:
 

--- a/docs/tutorials/google_earth_engine/part_2/about_page.rst
+++ b/docs/tutorials/google_earth_engine/part_2/about_page.rst
@@ -85,7 +85,7 @@ To minimize the amount of code that is duplicated, you will create a new :file:`
 .. code-block:: html+django
 
     {% block header_buttons %}
-      {% include tethys_app.package|add:"header_buttons.html" %}
+      {% include tethys_app.package|add:"/header_buttons.html" %}
     {% endblock %}
 
 3. The Home button is included in :file:`header_buttons.html` and provided by :file:`base.html`, so it will be removed from :file:`viewer.html`. Delete the ``header_buttons`` block in :file:`templates/earth_engine/viewer.html`:

--- a/docs/tutorials/google_earth_engine/part_2/clip_by_asset.rst
+++ b/docs/tutorials/google_earth_engine/part_2/clip_by_asset.rst
@@ -272,7 +272,7 @@ Now that the shapefile has been converted to an ``ee.FeatureCollection``, it can
 3. Update the ``upload_shapefile_to_gee`` function in :file:`gee/methods.py` to call the new ``get_user_boundary_path`` function and then export the ``ee.FeatureCollection`` to an asset at that path: (no try/except)
 
 .. code-block:: python
-    :emphasize-lines: 29-39
+    :emphasize-lines: 29-40
 
     def upload_shapefile_to_gee(user, shp_file):
         """
@@ -314,6 +314,10 @@ Now that the shapefile has been converted to an ``ee.FeatureCollection``, it can
         )
 
         task.start()
+
+.. tip:: 
+
+    You may need to manually add these empty folders to your assets. In the Google Earth Engine code editor, navigate to the **Assets** tab in the top-left pane of the code editor and create a new folder named  **users**, then another named **earth_engine_app**. Then, simply drag the **earth_engine_app** folder into the **users** folder. 
 
 4. Navigate to `<http://localhost:8000/apps/earth-engine/viewer/>`_ and upload the :file:`USA_simplified.zip`. Verify that the path returned from ``get_user_boundary_path`` is printed to the terminal where Tethys is running.
 

--- a/docs/tutorials/google_earth_engine/part_3/prepare.rst
+++ b/docs/tutorials/google_earth_engine/part_3/prepare.rst
@@ -96,10 +96,10 @@ Although using the :file:`gee/params.py` file to store our service account crede
 
     from . import params as gee_account
 
-4. Use the private key path custom setting in ``get_asset_dir_for_user`` in :file:`gee/methods.py` by replacing the ``private_key`` variable with the following:
+4. Use the private key path custom setting in ``get_asset_dir_for_user`` in :file:`gee/methods.py` with the following:
 
 .. code-block:: python
-    :emphasize-lines: 12
+    :emphasize-lines: 13-17
 
     def get_asset_dir_for_user(user):
         """
@@ -111,11 +111,19 @@ Although using the :file:`gee/params.py` file to store our service account crede
         Returns:
             str: asset directory path for given user.
         """
+        asset_roots = ee.batch.data.getAssetRoots()
+        
         # Retreieve project ID from private key file
-        with open(private_key_path, 'r') as f:
-            private_key = json.load(f)
+        if len(asset_roots) < 1:
+            with open(private_key_path) as f:
+                private_key_contents = json.load(f)
+                project_id = private_key_contents.get("project", None)
+            
+        asset_path = f"projects/{project_id}/assets/tethys"
 
         ...
+
+You can also delete the ``get_earth_engine_credentials_path`` function from :file:`gee/methods.py` as it is no longer needed.
 
 5. **Delete** :file:`gee/params.py`.
 


### PR DESCRIPTION
Made a small addition to tutorial instructions in the google earth engine tutorial to address an issue with creating the base folders in assets.

Fixed a missing line of highlighted code for changes to a code block in the tutorial as well.