### PR TITLE
Remove the css_integrity hash for bootstrap-icons dependency

### DIFF
--- a/tethys_portal/dependencies.py
+++ b/tethys_portal/dependencies.py
@@ -165,8 +165,6 @@ vendor_static_dependencies = {
         npm_name="bootstrap-icons",
         version="1.11.3",
         css_path="font/bootstrap-icons.min.css",
-        # SRI for version 1.7.1 (version 1.8.0 is out)
-        css_integrity="sha256-vjH7VdGY8KK8lp5whX56uTiObc5vJsK+qFps2Cfq5mY=",
     ),
     "bootstrap-switch": JsDelivrStaticDependency(
         npm_name="bootstrap-switch",


### PR DESCRIPTION
The `css_integrity` hash for the boostrap icons JS library was not updated when the version was updated. As a result, the library won't load on secure deployments of Tethys.

### Description
The documentation for bootstrap-icons no longer provides the security hash  (see: https://icons.getbootstrap.com/#install), so this PR removes it.

### Changes Made to Code
 - Removed the `css_integrity` argument for the `bootstrap_icons` library in `dependecies.py`

### Related PRs, Issues, and Discussions
- Introduced by #1081 

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
