### PR TITLE
Conda build and Docker Python Version fix

### DIFF
--- a/.github/workflows/tethys-release.yml
+++ b/.github/workflows/tethys-release.yml
@@ -60,7 +60,7 @@ jobs:
           full_tag="${{ steps.version.outputs.full }}";
           # no "+" characters allowed in Docker tags
           safe_tag="${full_tag//+/-}";
-          docker build -t ${{ env.DOCKER_UPLOAD_URL }}:"${{ steps.safetag.outputs.safetag }}" .;
+          docker build --build-arg DJANGO_VERSION=${{ matrix.django-version }} --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ${{ env.DOCKER_UPLOAD_URL }}:"${{ steps.safetag.outputs.safetag }}" .;
       # Authenticate docker
       - name: Authenticate Docker
         run: |

--- a/.github/workflows/tethys-release.yml
+++ b/.github/workflows/tethys-release.yml
@@ -155,7 +155,7 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh;
           conda activate conda-build;
           echo "Publishing to release channel...";
-          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} $CONDA_BLD_PATH/noarch/tethys-platform*.tar.bz2 --force;
+          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} $CONDA_BLD_PATH/noarch/tethys-platform*.* --force;
       - name: Upload to Conda Dev Channel
         if: ${{ steps.version.outputs.prerelease != '' }}
         run: |
@@ -163,7 +163,7 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh;
           conda activate conda-build;
           echo "Publishing to dev channel...";
-          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/tethys-platform*.tar.bz2 --force;
+          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/tethys-platform*.* --force;
 
       # BUILD micro-tethys-platform
 
@@ -194,7 +194,7 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh;
           conda activate conda-build;
           echo "Publishing to release channel...";
-          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} $CONDA_BLD_PATH/noarch/micro-tethys-platform*.tar.bz2 --force;
+          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} $CONDA_BLD_PATH/noarch/micro-tethys-platform*.* --force;
       - name: Upload to Conda Dev Channel - micro
         if: ${{ steps.version.outputs.prerelease != '' }}
         run: |
@@ -202,4 +202,4 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh;
           conda activate conda-build;
           echo "Publishing to dev channel...";
-          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/micro-tethys-platform*.tar.bz2 --force;
+          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/micro-tethys-platform*.* --force;

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -233,7 +233,7 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh;
           ls ~/conda-bld/noarch
           conda activate conda-build
-          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/tethys-platform*.tar.bz2 --force;
+          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/tethys-platform*.* --force;
       # No Upload if Pull Request
       - name: No Upload
         if: ${{ github.event_name == 'pull_request' }}
@@ -272,7 +272,7 @@ jobs:
           . ~/miniconda/etc/profile.d/conda.sh;
           ls ~/conda-bld/noarch
           conda activate conda-build
-          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/micro-tethys-platform*.tar.bz2 --force;
+          anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/micro-tethys-platform*.* --force;
       # No Upload if Pull Request
       - name: No Upload - micro
         if: ${{ github.event_name == 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ARG DJANGO_VERSION=4.2.*
 ARG DJANGO_CHANNELS_VERSION
 ARG DAPHNE_VERSION
 
+RUN echo "Build Options: Python ${PYTHON_VERSION}, Django ${DJANGO_VERSION}, Daphne ${DAPHNE_VERSION}, Django Channels ${DJANGO_CHANNELS_VERSION}, Micro Tethys ${MICRO_TETHYS}"
+
 ###############
 # ENVIRONMENT #
 ###############


### PR DESCRIPTION
The Conda build is broken and Docker images in release do not have the right version of Python in them. This pull request fixes both issues.

### Description
This merge request addresses...

### Changes Made to Code
 - remove the ".tar.gz2" extension from conda upload glob to address change to ".conda" extension
 - add the build args for python and django versions to the docker build command in tethys-release.yml

### Quality Checks
 - [x] At least one new test has been written for new code
 - [x] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
