### PR TITLE
Terms and conditions error

### DIFF
--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -28,7 +28,7 @@ class TestTethysPortalContext(TestCase):
             "configured_single_app": None,
             "idp_backends": {}.keys(),
         }
-        self.assertTrue(context == expected_context)
+        self.assertDictEqual(context, expected_context)
 
     @override_settings(MULTIPLE_APP_MODE=True)
     def test_context_processors_multiple_app_mode_no_request_user(self):
@@ -49,7 +49,7 @@ class TestTethysPortalContext(TestCase):
             "configured_single_app": None,
             "idp_backends": {}.keys(),
         }
-        self.assertTrue(context == expected_context)
+        self.assertDictEqual(context, expected_context)
 
     @override_settings(MULTIPLE_APP_MODE=False)
     @mock.patch("tethys_portal.context_processors.messages")
@@ -74,7 +74,7 @@ class TestTethysPortalContext(TestCase):
             "configured_single_app": None,
             "idp_backends": {}.keys(),
         }
-        self.assertTrue(context == expected_context)
+        self.assertDictEqual(context, expected_context)
         mock_messages.warning.assert_called_with(
             mock_request,
             "MULTIPLE_APP_MODE is disabled but there is no Tethys application installed.",

--- a/tests/unit_tests/test_tethys_portal/test_context_processors.py
+++ b/tests/unit_tests/test_tethys_portal/test_context_processors.py
@@ -30,6 +30,27 @@ class TestTethysPortalContext(TestCase):
         }
         self.assertTrue(context == expected_context)
 
+    @override_settings(MULTIPLE_APP_MODE=True)
+    def test_context_processors_multiple_app_mode_no_request_user(self):
+        mock_request = mock.MagicMock()
+        del mock_request.user
+        assert not hasattr(mock_request, "user")
+        context = context_processors.tethys_portal_context(mock_request)
+
+        expected_context = {
+            "has_analytical": True,
+            "has_terms": False,
+            "has_mfa": True,
+            "has_gravatar": True,
+            "has_session_security": True,
+            "has_oauth2_provider": True,
+            "show_app_library_button": False,
+            "single_app_mode": False,
+            "configured_single_app": None,
+            "idp_backends": {}.keys(),
+        }
+        self.assertTrue(context == expected_context)
+
     @override_settings(MULTIPLE_APP_MODE=False)
     @mock.patch("tethys_portal.context_processors.messages")
     @mock.patch("tethys_portal.context_processors.get_configured_standalone_app")

--- a/tethys_apps/templates/tethys_apps/app_base.html
+++ b/tethys_apps/templates/tethys_apps/app_base.html
@@ -307,7 +307,7 @@
     {% endblock %}
 
     {% block terms-of-service-override %}
-      {% if has_terms %}
+      {% if has_terms and request.user %}
       {% include "terms.html" %}
       {% endif %}
     {% endblock %}

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -35,7 +35,11 @@ def tethys_portal_context(request):
         if settings.MULTIPLE_APP_MODE
         and (
             settings.ENABLE_OPEN_PORTAL
-            or (getattr(request, "user", None) and request.user.is_authenticated and request.user.is_active)
+            or (
+                getattr(request, "user", None)
+                and request.user.is_authenticated
+                and request.user.is_active
+            )
         )
         else False
     )

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -46,7 +46,8 @@ def tethys_portal_context(request):
 
     context = {
         "has_analytical": has_module("analytical"),
-        "has_terms": has_module("termsandconditions"),
+        "has_terms": has_module("termsandconditions")
+        and getattr(request, "user", None),
         "has_mfa": has_module("mfa"),
         "has_gravatar": has_module("django_gravatar"),
         "has_session_security": has_module("session_security"),

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -35,7 +35,7 @@ def tethys_portal_context(request):
         if settings.MULTIPLE_APP_MODE
         and (
             settings.ENABLE_OPEN_PORTAL
-            or (request.user.is_authenticated and request.user.is_active)
+            or (getattr(request, "user", None) and request.user.is_authenticated and request.user.is_active)
         )
         else False
     )

--- a/tethys_portal/context_processors.py
+++ b/tethys_portal/context_processors.py
@@ -47,7 +47,7 @@ def tethys_portal_context(request):
     context = {
         "has_analytical": has_module("analytical"),
         "has_terms": has_module("termsandconditions")
-        and getattr(request, "user", None),
+        and getattr(request, "user", None) is not None,
         "has_mfa": has_module("mfa"),
         "has_gravatar": has_module("django_gravatar"),
         "has_session_security": has_module("session_security"),

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -299,6 +299,8 @@ if has_module("session_security"):
     )  # TODO: Templates need to be upgraded
 if has_module("axes"):
     MIDDLEWARE.append("axes.middleware.AxesMiddleware")
+# if has_module("termsandconditions"):
+#     MIDDLEWARE.append("termsandconditions.middleware.TermsAndConditionsRedirectMiddleware")
 
 MIDDLEWARE = tuple(MIDDLEWARE + portal_config_settings.pop("MIDDLEWARE", []))
 

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -299,8 +299,6 @@ if has_module("session_security"):
     )  # TODO: Templates need to be upgraded
 if has_module("axes"):
     MIDDLEWARE.append("axes.middleware.AxesMiddleware")
-# if has_module("termsandconditions"):
-#     MIDDLEWARE.append("termsandconditions.middleware.TermsAndConditionsRedirectMiddleware")
 
 MIDDLEWARE = tuple(MIDDLEWARE + portal_config_settings.pop("MIDDLEWARE", []))
 

--- a/tethys_portal/templates/base.html
+++ b/tethys_portal/templates/base.html
@@ -306,7 +306,7 @@
     {% endblock %}
 
     {% block tos_override %}
-      {% if has_terms %}
+      {% if has_terms and request.user %}
       {% include "terms.html" %}
       {% endif %}
     {% endblock %}

--- a/tethys_portal/templates/tethys_portal/error.html
+++ b/tethys_portal/templates/tethys_portal/error.html
@@ -51,4 +51,6 @@
       </div>
     </div>
   </div>
+  {# Override TOS block, b/c some errors prevent middleware from running and TOS can't handle it #}
+  {% block tos_override %}{% endblock %}
 {% endblock %}

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -180,6 +180,7 @@ developer_urls = [
 #     re_path(r'^404/$', tethys_portal_error.handler_404, name='error_404'),
 #     re_path(r'^500/$', tethys_portal_error.handler_500, name='error_500'),
 # ]
+# developer_urls.extend(development_error_urls)
 
 if settings.MULTIPLE_APP_MODE:
     urlpatterns = [

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -174,6 +174,7 @@ developer_urls = [
     ),
 ]
 
+# Uncomment these lines to debug the error views more easily (e.g. http://localhost:8000/developer/500/)
 # development_error_urls = [
 #     re_path(r'^400/$', tethys_portal_error.handler_400, name='error_400'),
 #     re_path(r'^403/$', tethys_portal_error.handler_403, name='error_403'),


### PR DESCRIPTION
### Description
This PR addresses an issue with loading error templates when the middleware hasn't been processed.

The specific issue was caused by a missing host in ALLOWED_HOSTS, which would end up raising this error:

<details>

```
ERROR Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add '127.0.0.1' to ALLOWED_HOSTS.
Traceback (most recent call last):
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/utils/deprecation.py", line 128, in __call__
    response = self.process_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/middleware/common.py", line 48, in process_request
    host = request.get_host()
           ^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/http/request.py", line 151, in get_host
    raise DisallowedHost(msg)
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add '127.0.0.1' to ALLOWED_HOSTS.
Exception inside application: 'ASGIRequest' object has no attribute 'user'
Traceback (most recent call last):
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/utils/deprecation.py", line 128, in __call__
    response = self.process_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/middleware/common.py", line 48, in process_request
    host = request.get_host()
           ^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/http/request.py", line 151, in get_host
    raise DisallowedHost(msg)
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add '127.0.0.1' to ALLOWED_HOSTS.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/core/handlers/exception.py", line 164, in get_exception_response
    response = callback(request, exception=exception)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/tethys/tethys_portal/views/error.py", line 25, in handler_400
    return render(request, "tethys_portal/error.html", context, status=400)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/shortcuts.py", line 25, in render
    content = loader.render_to_string(template_name, context, request, using=using)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/template/loader.py", line 62, in render_to_string
    return template.render(context, request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/template/backends/django.py", line 107, in render
    return self.template.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/template/base.py", line 169, in render
    with context.bind_template(self):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/home/tethysdev/miniconda3/envs/tethys/lib/python3.12/site-packages/django/template/context.py", line 256, in bind_template
    context = processor(self.request)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tethysdev/tethys/tethys_portal/context_processors.py", line 38, in tethys_portal_context
    or (request.user.is_authenticated and request.user.is_active)
        ^^^^^^^^^^^^
AttributeError: 'ASGIRequest' object has no attribute 'user'

<------------- AttributeError repeated 4-5 times ------------->
```

</details>

I suspect this was caused by the following chain of events:

- ALLOWED_HOST error was raised
- The error prevented the Middleware from running that adds the user to the request
- Django tried to load the 400 error page of Tethys
- The 400 page of Tethys inherits from base.html
- The base.html includes a template from terms and conditions
- Terms and conditions requires the user to be added to the request and raises an Attribute Error if it is not found.
- This causes Django to try to load the 500 error page which triggers the Terms and Conditions Attribute Error again
- It cycles a few more times and then dies

### Changes Made to Code
 - Added check for `request.user` in the `if` block that includes the TOS template in the `base.html` and `app_base.html` templates.
 - Adds `{% block tos_override %}{% endblock %}` override to the `error.html` base template for the error pages, so terms and conditions is never loaded on the error pages.
 - Add check for `request.user` to context processor that could cause similar issue

### Related PRs, Issues, and Discussions
- N/A

### Additional Notes
-  N/A

### Quality Checks
 - [x] At least one new test has been written for new code
 - [x] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
