### PR TITLE
Bugfix: feature_id.includes is not a function when feature_id is a number

### DIFF
--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -304,7 +304,7 @@ var MAP_LAYOUT = (function() {
         let feature_id = feature.getId();
 
         if (feature_id) {
-            if (feature_id.includes('.fid')) {
+            if (feature_id.includes != undefined && feature_id.includes('.fid')) {
                 // Derive fid from ID assigned by GeoServer (<layer_name>.<fid>)
                 // e.g.: 0958cc07-c194-4af9-81c5-118a77d335ac_stream_links.fid--72787a80_169a16811e6_-7aa6
                 feature_id = feature_id.split('.')[1];


### PR DESCRIPTION
### Description
When `feature_id` is a number, it doesn't have the method `includes()`, which will trigger the error ` feature_id.includes is not a function`.

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
