### PR TITLE
image tag 5.4 for unidata/thredds-docker no longer available

### DIFF
--- a/docs/installation/production/docker/docker_compose.rst
+++ b/docs/installation/production/docker/docker_compose.rst
@@ -181,7 +181,7 @@ Add the following definition for the ``thredds`` service in the :file:`docker-co
 .. code-block:: yaml
 
     thredds:
-      image: unidata/thredds-docker:5.5
+      image: unidata/thredds-docker:5.6
       restart: always
       networks:
         - "internal"

--- a/tests/unit_tests/test_tethys_cli/test_docker_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_docker_commands.py
@@ -585,7 +585,7 @@ class TestDockerCommands(unittest.TestCase):
         mock_port_bindings_prop.return_value = mock_port_bindings
         expected_options = dict(
             name="tethys_thredds",
-            image="unidata/thredds-docker:5.4",
+            image="unidata/thredds-docker:5.6",
             environment=dict(
                 TDM_PW="CHANGEME!",
                 TDS_HOST="http://localhost",

--- a/tethys_cli/docker_commands.py
+++ b/tethys_cli/docker_commands.py
@@ -566,7 +566,7 @@ class ThreddsContainerMetadata(ContainerMetadata):
     name = "tethys_thredds"
     display_name = "THREDDS"
     image_name = "unidata/thredds-docker"
-    tag = "5.4"
+    tag = "5.6"
     host_port = 8383
     container_port = 8080
 


### PR DESCRIPTION
### Description
This merge request addresses that the problem caused due to image tag `5.4` for `unidata/thredds-docker` no longer being available, so it is changed to `5.6`

### Changes Made to Code
 - change for thredds image tag from 5.4 to 5.6 on `tethys docker` command and test.

### Additional Notes
- Docs have been updated as well

### Quality Checks
 - [X] At least one new test has been written for new code
 - [X] New code has 100% test coverage
 - [X] Code has been formatted with Black
 - [X] Code has been linted with flake8
 - [X] Docstrings for new methods have been added
 - [X] The documentation has been updated appropriately
