### PR TITLE
Update docs/docstrings to use "geoscience" verbiage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,6 @@ Tethys Platform
     :target: http://docs.tethysplatform.org/en/stable/?badge=stable
     :alt: Documentation Status
 
-Tethys Platform provides both a development environment and a hosting environment for water resources web apps.
+Tethys Platform provides both a development environment and a hosting environment for geoscientific web apps.
 
 Documentation can be found here: `<http://docs.tethysplatform.org/>`_

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -4,13 +4,13 @@ Features
 
 **Last Updated:** May 28, 2015
 
-Tethys is a platform that can be used to develop and host engaging, interactive water resources web applications or web apps. It includes a suite of free and open source software (FOSS) that has been carefully selected to address the unique development needs of water resources web apps. Tethys web apps are developed using a Python software development kit (SDK) which includes programmatic links to each software component. Tethys Platform is powered by the `Django <https://www.djangoproject.com/>`_ Python web framework giving it a solid web foundation with excellent security and performance.
+Tethys is a platform that can be used to develop and host engaging, interactive geoscientific web applications or web apps. It includes a suite of free and open source software (FOSS) that has been carefully selected to address the unique development needs of geoscientific web apps. Tethys web apps are developed using a Python software development kit (SDK) which includes programmatic links to each software component. Tethys Platform is powered by the `Django <https://www.djangoproject.com/>`_ Python web framework giving it a solid web foundation with excellent security and performance.
 
 .. figure:: images/features/example_app_page.png
     :width: 600px
     :align: center
 
-**Tethys platform can be used to create engaging, interactive web apps for water resources.**
+**Tethys platform can be used to create engaging, interactive web apps for the geosciences.**
 
 
 Software Suite
@@ -22,7 +22,7 @@ Tethys Platform provides a suite of free and open source software. Included in t
     :width: 600px
     :align: center
 
-**Tethys Platform include software to meet water resources web app development needs.**
+**Tethys Platform include software to meet geoscientific web app development needs.**
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Tethys Platform |version|
 
 **Last Updated:** September 2024
 
-Tethys is a platform that can be used to develop and host environmental web apps. It includes a suite of free and open source software (FOSS) that has been carefully selected to address the unique development needs of environmental web apps. Tethys web apps are developed using a Python software development kit (SDK) which includes programmatic links to each software component. Tethys Platform is powered by the Django Python web framework giving it a solid web foundation with excellent security and performance. Refer to the :doc:`./features` article for an overview of the features of Tethys Platform.
+Tethys is a platform that can be used to develop and host geoscientific web apps. It includes a suite of free and open source software (FOSS) that has been carefully selected to address the unique development needs of geoscientific web apps. Tethys web apps are developed using a Python software development kit (SDK) which includes programmatic links to each software component. Tethys Platform is powered by the Django Python web framework giving it a solid web foundation with excellent security and performance. Refer to the :doc:`./features` article for an overview of the features of Tethys Platform.
 
 .. important::
 

--- a/docs/software_suite.rst
+++ b/docs/software_suite.rst
@@ -49,7 +49,7 @@ Geoprocessing
    :width: 150px
    :align: right
 
-`52°North Web Processing Service (WPS) <http://52north.org/communities/geoprocessing/wps/>`_ is supported in Tethys Platform as one means for supporting geoprocessing needs in water resources web app development. It can be linked with geoprocessing libraries such as `GRASS <https://grass.osgeo.org/>`_, `Sextante <https://www.wikiwand.com/es/articles/SEXTANTE_(SIG)>`_, and `ArcGIS® Server <https://www.esri.com/en-us/arcgis/products/arcgis-enterprise/overview?rsource=%2Fsoftware%2Farcgis%2Farcgisserver>`_ for out-of-the-box geoprocessing capabilities.
+`52°North Web Processing Service (WPS) <http://52north.org/communities/geoprocessing/wps/>`_ is supported in Tethys Platform as one means for supporting geoprocessing needs in geoscientific web app development. It can be linked with geoprocessing libraries such as `GRASS <https://grass.osgeo.org/>`_, `Sextante <https://www.wikiwand.com/es/articles/SEXTANTE_(SIG)>`_, and `ArcGIS® Server <https://www.esri.com/en-us/arcgis/products/arcgis-enterprise/overview?rsource=%2Fsoftware%2Farcgis%2Farcgisserver>`_ for out-of-the-box geoprocessing capabilities.
 
 The PostGIS extension, included in the software suite, can also provide geoprocessing capabilities on data that is stored in a spatially-enabled database. PostGIS includes SQL geoprocessing functions for splicing, dicing, morphing, reclassifying, and collecting/unioning raster and vector types. It also includes functions for vectorizing rasters, clipping rasters with vectors, and running stats on rasters by geometric region.
 
@@ -98,7 +98,7 @@ Distributed Computing
    :width: 300px
    :align: right
 
-To facilitate the large-scale computing that is often required by water resources applications, Tethys Platform leverages the computing management middleware `HTCondor <https://research.cs.wisc.edu/htcondor/>`_ and `Dask Distributed <https://distributed.dask.org/en/stable/>`_.
+To facilitate the large-scale computing that is often required by geoscientific applications, Tethys Platform leverages the computing management middleware `HTCondor <https://research.cs.wisc.edu/htcondor/>`_ and `Dask Distributed <https://distributed.dask.org/en/stable/>`_.
 
 To use the HTCondor or Dask and the computing capabilities in your app use the :doc:`./tethys_sdk/jobs`.
 

--- a/tethys_apps/base/paths.py
+++ b/tethys_apps/base/paths.py
@@ -3,7 +3,7 @@
 * Name: paths.py
 * Author: Scott Christensen
 * Created On: April 2024
-* Copyright: (c) Tethys Geospatial Foundation 2024
+* Copyright: (c) Tethys Geoscience Foundation 2024
 * License: BSD 2-Clause
 ********************************************************************************
 """

--- a/tethys_compute/tasks.py
+++ b/tethys_compute/tasks.py
@@ -3,7 +3,7 @@
 * Name: tasks.py
 * Author: Scott Christensen
 * Created On: 2024
-* Copyright: (c) Tethys Geospatial Foundation 2024
+* Copyright: (c) Tethys Geoscience Foundation 2024
 * License: BSD 2-Clause
 ********************************************************************************
 """

--- a/tethys_compute/views/__init__.py
+++ b/tethys_compute/views/__init__.py
@@ -3,7 +3,7 @@
 * Name: tethys_compute/views/__init__.py
 * Author: Scott Christensen
 * Created On: October 2024
-* Copyright: (c) Tethys Geospatial Foundation 2024
+* Copyright: (c) Tethys Geoscience Foundation 2024
 * License: BSD 2-Clause
 ********************************************************************************
 """

--- a/tethys_compute/views/update_status.py
+++ b/tethys_compute/views/update_status.py
@@ -3,7 +3,7 @@
 * Name: update_status.py
 * Author: Scott Christensen
 * Created On: 2024
-* Copyright: (c) Tethys Geospatial Foundation 2024
+* Copyright: (c) Tethys Geoscience Foundation 2024
 * License: BSD 2-Clause
 ********************************************************************************
 """

--- a/tethys_sdk/paths.py
+++ b/tethys_sdk/paths.py
@@ -3,7 +3,7 @@
 * Name: paths.py
 * Author: Scott Christensen
 * Created On: April 2024
-* Copyright: (c) Tethys Geospatial Foundation 2024
+* Copyright: (c) Tethys Geoscience Foundation 2024
 * License: BSD 2-Clause
 ********************************************************************************
 """

--- a/tethys_utils/deprecation.py
+++ b/tethys_utils/deprecation.py
@@ -3,7 +3,7 @@
 * Name: deprecation.py
 * Author: Scott Christensen
 * Created On: April 2024
-* Copyright: (c) Tethys Geospatial Foundation 2024
+* Copyright: (c) Tethys Geoscience Foundation 2024
 * License: BSD 2-Clause
 ********************************************************************************
 """


### PR DESCRIPTION
### Description
I came across a few places where we were still referring to "water resource web apps" and where "Tethys Geoscience Foundation" was being mistakenly referred to as "Tethys Geospatial Foundation". I also changed one case of "environmental web apps" to "geoscientific web apps" for consistency.

### Changes Made to Code
 - Docs and docstrings updated as described above.

### Related PRs, Issues, and Discussions
- 

### Additional Notes
-  

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
