### PR TITLE
update TethysStaticFinder.find() to be compatible with django5.2

### DIFF
--- a/.github/workflows/tethys-release.yml
+++ b/.github/workflows/tethys-release.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["3.2", "4.2", "5.1"]
+        django-version: ["3.2", "4.2", "5.2"]
     steps:
       # Checkout the source
       - name: Checkout Source

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -100,7 +100,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["3.2", "4.2", "5.1"]
+        django-version: ["3.2", "4.2", "5.2"]
     steps:
       # Checkout the source
       - name: Checkout Source
@@ -140,7 +140,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["3.2", "4.2", "5.1"]
+        django-version: ["3.2", "4.2", "5.2"]
     services:
       tethys-postgis:
         image: postgis/postgis:14-3.3

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["3.2", "4.2", "5.1"]
+        django-version: ["3.2", "4.2", "5.2"]
     steps:
       # Checkout the source
       - name: Checkout Source

--- a/tests/unit_tests/test_tethys_apps/test_static_finders.py
+++ b/tests/unit_tests/test_tethys_apps/test_static_finders.py
@@ -31,11 +31,17 @@ class TestTethysStaticFinder(unittest.TestCase):
         self.assertEqual(self.root / "css" / "main.css", str_ret)
 
     def test_find_all(self):
+        import django
         tethys_static_finder = TethysStaticFinder()
         path = Path("test_app") / "css" / "main.css"
-        path_ret = tethys_static_finder.find(path, all=True)
+        use_find_all = django.VERSION >= (5, 2)
+        if use_find_all:
+            path_ret = tethys_static_finder.find(path, find_all=True)
+            str_ret = tethys_static_finder.find(str(path), find_all=True)
+        else:
+            path_ret = tethys_static_finder.find(path, all=True)
+            str_ret = tethys_static_finder.find(str(path), all=True)
         self.assertIn(self.root / "css" / "main.css", path_ret)
-        str_ret = tethys_static_finder.find(str(path), all=True)
         self.assertIn(self.root / "css" / "main.css", str_ret)
 
     def test_find_location_with_no_prefix(self):

--- a/tests/unit_tests/test_tethys_apps/test_static_finders.py
+++ b/tests/unit_tests/test_tethys_apps/test_static_finders.py
@@ -32,6 +32,7 @@ class TestTethysStaticFinder(unittest.TestCase):
 
     def test_find_all(self):
         import django
+
         tethys_static_finder = TethysStaticFinder()
         path = Path("test_app") / "css" / "main.css"
         use_find_all = django.VERSION >= (5, 2)

--- a/tethys_apps/static_finders.py
+++ b/tethys_apps/static_finders.py
@@ -10,6 +10,7 @@
 
 from pathlib import Path
 from collections import OrderedDict as SortedDict
+import django
 from django.contrib.staticfiles import utils
 from django.contrib.staticfiles.finders import BaseFinder
 from django.core.files.storage import FileSystemStorage
@@ -39,15 +40,18 @@ class TethysStaticFinder(BaseFinder):
 
         super().__init__(*args, **kwargs)
 
-    def find(self, path, find_all=False):
+    # Django changes the argument `all` to `find_all` since the version 5.2
+    # Remove the argument `all` when Tethys doesn't support Django<5.2 anymore
+    def find(self, path, all=False, find_all=False):
         """
         Looks for files in the Tethys apps static or public directories
         """
+        find_all_files = find_all if django.VERSION >= (5, 2) else all
         matches = []
         for prefix, root in self.locations:
             matched_path = self.find_location(root, path, prefix)
             if matched_path:
-                if not find_all:
+                if not find_all_files:
                     return matched_path
                 matches.append(matched_path)
         return matches

--- a/tethys_apps/static_finders.py
+++ b/tethys_apps/static_finders.py
@@ -39,7 +39,7 @@ class TethysStaticFinder(BaseFinder):
 
         super().__init__(*args, **kwargs)
 
-    def find(self, path, all=False):
+    def find(self, path, find_all=False):
         """
         Looks for files in the Tethys apps static or public directories
         """
@@ -47,7 +47,7 @@ class TethysStaticFinder(BaseFinder):
         for prefix, root in self.locations:
             matched_path = self.find_location(root, path, prefix)
             if matched_path:
-                if not all:
+                if not find_all:
                     return matched_path
                 matches.append(matched_path)
         return matches


### PR DESCRIPTION
### Description
Django has updated the parameter for `find()` from `all` to `find_all`, see this [commit](https://github.com/django/django/commit/0fdcf1029cea2d43bd68c5270f48e0f7deab5e47#diff-10554987530a8268887edf216bf057d24f954d2d9364f7c71a0d70500e65a2c0L29) 

### Changes Made to Code
update TethysStaticFinder.find()

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
