### PR TITLE
Refactor the liveness-probe.sh to be able to check endpoints

### DIFF
--- a/docker/liveness-probe.sh
+++ b/docker/liveness-probe.sh
@@ -1,30 +1,63 @@
 #!/bin/sh
 
+# liveness-probe.sh
+# Usage: ./liveness-probe.sh [--check-endpoints|-c] [--debug|-d]
+#
+# This script checks the health of supervisord, nginx, and tethys asgi server processes.
+# If the --check-endpoints or -c flag is provided, it will also check if the nginx and asgi endpoints respond.
+#
+# Exit code 0: All checks passed
+# Exit code 1: One or more checks failed
 
-check_process_is_running() { 
-	if [ "$(ps $1 | wc -l)" -ne 2 ]; then 
-		echo The $2 process \($1\) is  not running. 1>&2
-	else
-		echo "ok"
-	fi 
+# Parse arguments for --check-endpoints/-c and --debug/-d flags
+CHECK_ENDPOINTS=false
+DEBUG=false
+for arg in "$@"; do
+    if [ "$arg" = "--check-endpoints" ] || [ "$arg" = "-c" ]; then
+        CHECK_ENDPOINTS=true
+    fi
+    if [ "$arg" = "--debug" ] || [ "$arg" = "-d" ]; then
+        DEBUG=true
+    fi
+done
+
+if [ "$DEBUG" = true ]; then
+    set -x
+fi
+
+check_process_is_running() {
+    if [ "$(ps $1 | wc -l)" -ne 2 ]; then 
+        echo The $2 process \($1\) is  not running. 1>&2
+    else
+        echo "ok"
+    fi 
 }
 
 
-get_pid_from_file() { 
-	if [ -f $1 ]; then
-		echo $(cat $1)
-	else 
-		echo pid file for $2 does not exist at $1
-		exit 1
-	fi
+get_pid_from_file() {
+    if [ -f $1 ]; then
+        echo $(cat $1)
+    else 
+        echo pid file for $2 does not exist at $1
+        exit 1
+    fi
 }
 
 
-check_pid_is_number() { 
-	case $1 in
-		''|*[!0-9]*) echo pid found for $2 is not a number: $1 ; exit 1;;
-		*) ;;
-	esac
+check_pid_is_number() {
+    case $1 in
+        ''|*[!0-9]*) echo pid found for $2 is not a number: $1 ; exit 1;;
+        *) ;;
+    esac
+}
+
+
+check_endpoint() {
+    if curl -s --max-time "${3:-5}" "$1" > /dev/null; then
+        echo "ok"
+    else
+        echo "$2 endpoint not responding"
+    fi
 }
 
 
@@ -51,6 +84,18 @@ ASGI_PID=$(ls -l /run/tethys_asgi0.sock.lock | awk -F'-> ' '{print $2}' 2>&1)
 check_pid_is_number "${ASGI_PID}" asgi
 ASGI_STATUS=$(check_process_is_running "${ASGI_PID}" asgi)
 
+# Set endpoint ports from environment variables, with defaults
+NGINX_PORT="${NGINX_PORT:-80}"
+TETHYS_PORT="${TETHYS_PORT:-8000}"
+
+# Only check endpoints if all process statuses are ok and flag is set
+if [ "$SUPERVISORD_STATUS" = "ok" ] && [ "$NGINX_STATUS" = "ok" ] && [ "$ASGI_STATUS" = "ok" ] && [ "$CHECK_ENDPOINTS" = true ]; then
+    NGINX_ENDPOINT_STATUS=$(check_endpoint "http://localhost:${NGINX_PORT}/" "nginx" 5)
+    ASGI_ENDPOINT_STATUS=$(check_endpoint "http://localhost:${TETHYS_PORT}/" "asgi" 5)
+else
+    NGINX_ENDPOINT_STATUS="skipped"
+    ASGI_ENDPOINT_STATUS="skipped"
+fi
 
 # print errors
 if [ "$SUPERVISORD_STATUS" != "ok" ] ; then
@@ -65,9 +110,19 @@ if [ "$ASGI_STATUS" != "ok" ] ; then
 	echo $ASGI_STATUS 1>&2
 fi
 
+if [ "$NGINX_ENDPOINT_STATUS" != "ok" ] && [ "$NGINX_ENDPOINT_STATUS" != "skipped" ]; then
+	echo $NGINX_ENDPOINT_STATUS 1>&2
+fi
+
+if [ "$ASGI_ENDPOINT_STATUS" != "ok" ] && [ "$ASGI_ENDPOINT_STATUS" != "skipped" ]; then
+	echo $ASGI_ENDPOINT_STATUS 1>&2
+fi
+
 if [ "$SUPERVISORD_STATUS" != "ok" ] || \
 	[ "$NGINX_STATUS" != "ok" ] || \
-	[ "$ASGI_STATUS" != "ok" ]; then
+	[ "$ASGI_STATUS" != "ok" ] || \
+	( [ "$NGINX_ENDPOINT_STATUS" != "ok" ] && [ "$NGINX_ENDPOINT_STATUS" != "skipped" ] ) || \
+	( [ "$ASGI_ENDPOINT_STATUS" != "ok" ] && [ "$ASGI_ENDPOINT_STATUS" != "skipped" ] ); then
 	exit 1
 else
 	echo "liveness-probe.sh: all tests passed"


### PR DESCRIPTION
The current `liveness-probe.sh` script in the Docker only checks for process ids to verify that the processes are running. However, this does not verify if the endpoints are responding. I have a case where it would be helpful to verify the latter--the process is locked up, so still running (has a pid) but the endpoints timeout/don't respond.

This PR adds a `--check-endpoints` flag to the `liveness-probe.sh` script that when enabled checks the nginx and asgi endpoints with curl. The behavior is to pass if anything is returned regardless of http error code. It only fails if the endpoint times-out or doesn't return anything in 5s.

### Description
This merge request addresses...

### Changes Made to Code
 - Adds `--check-endpoints` flag to `liveness-probe.sh`
 - Adds `--debug` flag to `liveness-probe.sh`
 - If enabled, CHECK_ENDPOINTS mode will use `curl` to check the asgi endpoint (http://localhost:$TETHYS_PORT) and nginx endpoint (http://localhost:$NGINX_PORT). Any HTTP response will cause the test to pass regardless of HTTP code. Failure to return a response within 5 seconds will cause the test to fail.
 - If enabled, DEBUG mode sets `set -x` to print out all lines with arguments for debugging purposes.

### Related PRs, Issues, and Discussions
- N/A

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
