### PR TITLE
Fix for Pip Install Overrides Django Pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,7 @@ RUN ln -s /bin/micromamba ${CONDA_HOME}/bin/conda
 # Setup Conda Environment
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml ${TETHYS_HOME}/tethys/
 COPY --chown=$MAMBA_USER:$MAMBA_USER micro_environment.yml ${TETHYS_HOME}/tethys/
+COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml ${TETHYS_HOME}/tethys/
 
 WORKDIR ${TETHYS_HOME}/tethys
 
@@ -183,25 +184,24 @@ RUN groupadd www \
   ; chown -R www: ${TETHYS_LOG} /run /var/log/supervisor /var/log/nginx /var/lib/nginx
 
 # ADD files from repo
-ADD --chown=www:www resources ${TETHYS_HOME}/tethys/resources/
-ADD --chown=www:www tethys_apps ${TETHYS_HOME}/tethys/tethys_apps/
-ADD --chown=www:www tethys_cli ${TETHYS_HOME}/tethys/tethys_cli/
-ADD --chown=www:www tethys_components ${TETHYS_HOME}/tethys/tethys_components/
-ADD --chown=www:www tethys_compute ${TETHYS_HOME}/tethys/tethys_compute/
-ADD --chown=www:www tethys_config ${TETHYS_HOME}/tethys/tethys_config/
-ADD --chown=www:www tethys_layouts ${TETHYS_HOME}/tethys/tethys_layouts/
-ADD --chown=www:www tethys_gizmos ${TETHYS_HOME}/tethys/tethys_gizmos/
-ADD --chown=www:www tethys_portal ${TETHYS_HOME}/tethys/tethys_portal/
-ADD --chown=www:www tethys_quotas ${TETHYS_HOME}/tethys/tethys_quotas/
-ADD --chown=www:www tethys_sdk ${TETHYS_HOME}/tethys/tethys_sdk/
-ADD --chown=www:www tethys_services ${TETHYS_HOME}/tethys/tethys_services/
-ADD --chown=www:www tethys_utils ${TETHYS_HOME}/tethys/tethys_utils/
-ADD --chown=www:www tests ${TETHYS_HOME}/tethys/tests/
-ADD --chown=www:www README.rst ${TETHYS_HOME}/tethys/
-ADD --chown=www:www LICENSE ${TETHYS_HOME}/tethys/
-ADD --chown=www:www *.toml ${TETHYS_HOME}/tethys/
-ADD --chown=www:www *.cfg ${TETHYS_HOME}/tethys/
-ADD --chown=www:www .git ${TETHYS_HOME}/tethys/.git/
+COPY --chown=www:www resources ${TETHYS_HOME}/tethys/resources/
+COPY --chown=www:www tethys_apps ${TETHYS_HOME}/tethys/tethys_apps/
+COPY --chown=www:www tethys_cli ${TETHYS_HOME}/tethys/tethys_cli/
+COPY --chown=www:www tethys_components ${TETHYS_HOME}/tethys/tethys_components/
+COPY --chown=www:www tethys_compute ${TETHYS_HOME}/tethys/tethys_compute/
+COPY --chown=www:www tethys_config ${TETHYS_HOME}/tethys/tethys_config/
+COPY --chown=www:www tethys_layouts ${TETHYS_HOME}/tethys/tethys_layouts/
+COPY --chown=www:www tethys_gizmos ${TETHYS_HOME}/tethys/tethys_gizmos/
+COPY --chown=www:www tethys_portal ${TETHYS_HOME}/tethys/tethys_portal/
+COPY --chown=www:www tethys_quotas ${TETHYS_HOME}/tethys/tethys_quotas/
+COPY --chown=www:www tethys_sdk ${TETHYS_HOME}/tethys/tethys_sdk/
+COPY --chown=www:www tethys_services ${TETHYS_HOME}/tethys/tethys_services/
+COPY --chown=www:www tethys_utils ${TETHYS_HOME}/tethys/tethys_utils/
+COPY --chown=www:www tests ${TETHYS_HOME}/tethys/tests/
+COPY --chown=www:www README.rst ${TETHYS_HOME}/tethys/
+COPY --chown=www:www LICENSE ${TETHYS_HOME}/tethys/
+COPY --chown=www:www *.cfg ${TETHYS_HOME}/tethys/
+COPY --chown=www:www .git ${TETHYS_HOME}/tethys/.git/
 
 # Run Installer
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
@@ -228,9 +228,9 @@ EXPOSE 80
 ###############*
 # COPY IN SALT #
 ###############*
-ADD docker/salt/ /srv/salt/
-ADD docker/run.sh ${TETHYS_HOME}/
-ADD docker/liveness-probe.sh ${TETHYS_HOME}/
+COPY docker/salt/ /srv/salt/
+COPY docker/run.sh ${TETHYS_HOME}/
+COPY docker/liveness-probe.sh ${TETHYS_HOME}/
 
 ########
 # RUN! #

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ ADD --chown=www:www .git ${TETHYS_HOME}/tethys/.git/
 
 # Run Installer
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN pip install -e .
+RUN pip install --no-deps -e .
 RUN tethys gen portal_config
 
 # Install channel-redis

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml ${TETHYS_HOME}/tethys/
 
 WORKDIR ${TETHYS_HOME}/tethys
 
-# Set the versions of Django, Channels, and Daphne if provided in environment.tyml and micro_environment.yml
+# Set the versions of Django, Channels, and Daphne if provided in environment.yml and micro_environment.yml
 RUN if [ -n "$DJANGO_VERSION" ]; then \
   sed -i "s/\s*- django[^-].*/  - django==${DJANGO_VERSION}/" environment.yml micro_environment.yml; \
   fi && \
@@ -221,7 +221,7 @@ RUN apt-get -y remove gcc \
 #########################
 # CONFIGURE  ENVIRONMENT#
 #########################
-ENV PATH ${CONDA_HOME}/miniconda/envs/tethys/bin:$PATH 
+ENV PATH=${CONDA_HOME}/miniconda/envs/tethys/bin:$PATH 
 VOLUME ["${TETHYS_PERSIST}", "${TETHYS_HOME}/keys"]
 EXPOSE 80
 
@@ -231,6 +231,10 @@ EXPOSE 80
 COPY docker/salt/ /srv/salt/
 COPY docker/run.sh ${TETHYS_HOME}/
 COPY docker/liveness-probe.sh ${TETHYS_HOME}/
+COPY docker/build-checks.sh ${TETHYS_HOME}/
+
+# Run build.sh to verify Django and Python versions
+RUN bash ${TETHYS_HOME}/build-checks.sh
 
 ########
 # RUN! #

--- a/docker/build-checks.sh
+++ b/docker/build-checks.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Status variables
+DJANGO_STATUS="not checked"
+PYTHON_STATUS="not checked"
+EXIT_CODE=0
+
+# Verify Django version in conda matches DJANGO_VERSION build arg
+if [ -n "$DJANGO_VERSION" ]; then
+    INSTALLED_DJANGO=$(micromamba run -n "$CONDA_ENV_NAME" python -c 'import django; print(django.get_version())')
+    DJANGO_VERSION_CLEAN=$(echo "$DJANGO_VERSION" | sed 's/\.[*]$//')
+    if ! echo "$INSTALLED_DJANGO" | grep -q "^$DJANGO_VERSION_CLEAN"; then
+        DJANGO_STATUS="ERROR: Installed Django version $INSTALLED_DJANGO does not match DJANGO_VERSION build arg $DJANGO_VERSION"
+        EXIT_CODE=1
+    else
+        DJANGO_STATUS="Verified: Installed Django version $INSTALLED_DJANGO matches DJANGO_VERSION build arg $DJANGO_VERSION"
+    fi
+else
+    DJANGO_STATUS="SKIPPED: DJANGO_VERSION build arg not set"
+fi
+
+# Verify Python version in conda matches PYTHON_VERSION build arg
+if [ -n "$PYTHON_VERSION" ]; then
+    INSTALLED_PYTHON=$(micromamba run -n "$CONDA_ENV_NAME" python -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+    PYTHON_VERSION_CLEAN=$(echo "$PYTHON_VERSION" | sed 's/\.[*]$//')
+    if ! echo "$INSTALLED_PYTHON" | grep -q "^$PYTHON_VERSION_CLEAN"; then
+        PYTHON_STATUS="ERROR: Installed Python version $INSTALLED_PYTHON does not match PYTHON_VERSION build arg $PYTHON_VERSION"
+        EXIT_CODE=1
+    else
+        PYTHON_STATUS="Verified: Installed Python version $INSTALLED_PYTHON matches PYTHON_VERSION build arg $PYTHON_VERSION"
+    fi
+else
+    PYTHON_STATUS="SKIPPED: PYTHON_VERSION build arg not set"
+fi
+
+echo "$PYTHON_STATUS"
+echo "$DJANGO_STATUS"
+
+exit $EXIT_CODE


### PR DESCRIPTION
### Description
The PR #1169 introduced the dependencies into the pyproject.toml to support building a PyPI package in the future. However, these changes inadvertently override the pinned versions in the Docker image that is built. This PR fixes this issue. 

![image](https://github.com/user-attachments/assets/f9f4b62b-17bf-4358-839b-0206e2a43a17)

### Changes Made to Code
 - Run the pip install in the Dockerfile without installing dependencies--they are currently installed via the environment.yml.
 - Change ADD to COPY commands per docker best practices

### Related PRs, Issues, and Discussions
- #1169 

### Additional Notes
-  In the future we will probably want to support building the docker image using pip or UV to install dependencies instead of conda, but this patch fixes it for the current approach of using Conda.

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
