### PR TITLE
Removing `template0` as the parent database from which new databases inherit. 

### DIFF
--- a/tests/unit_tests/test_tethys_cli/test_db_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_db_commands.py
@@ -297,7 +297,6 @@ class TestCommandTests(unittest.TestCase):
             "-E",
             "utf-8",
             "-T",
-            "template0",
             "-p",
             self.options["port"],
             "-O",

--- a/tests/unit_tests/test_tethys_cli/test_db_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_db_commands.py
@@ -296,7 +296,6 @@ class TestCommandTests(unittest.TestCase):
             "postgres",
             "-E",
             "utf-8",
-            "-T",
             "-p",
             self.options["port"],
             "-O",

--- a/tethys_apps/models.py
+++ b/tethys_apps/models.py
@@ -1127,7 +1127,6 @@ class PersistentStoreDatabaseSetting(TethysAppSetting):
             create_db_statement = """
                                   CREATE DATABASE "{0}"
                                   WITH OWNER {1}
-                                  TEMPLATE template0
                                   ENCODING 'UTF8'
                                   """.format(
                 namespaced_ps_name, url.username

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -317,7 +317,6 @@ def create_db_user(
         "-E",
         "utf-8",
         "-T",
-        "template0",
         "-p",
         f"{port}",
         "-O",

--- a/tethys_cli/db_commands.py
+++ b/tethys_cli/db_commands.py
@@ -316,7 +316,6 @@ def create_db_user(
         "postgres",
         "-E",
         "utf-8",
-        "-T",
         "-p",
         f"{port}",
         "-O",


### PR DESCRIPTION
## Removing `template0` as the parent database from which new databases inherit. 

### Description
This merge request removes `template0` as the parent database from which new databases inherit. 

### Changes Made to Code
 - `tethys_app/models.py` change to not use `template0` when creating databases
 - `tethys_cli/db_commands.py` change to not use `template0`

### Related PRs, Issues, and Discussions
- None

### Additional Notes
-  This allows applications to not be bound to `template0` when creating new databases

### Quality Checks
 - [X] At least one new test has been written for new code
 - [X] New code has 100% test coverage
 - [X] Code has been formatted with Black
 - [X] Code has been linted with flake8
 - [X] Docstrings for new methods have been added
 - [X] The documentation has been updated appropriately
