### PR TITLE
Fix error for missing function on ol.source.ImageWMS

### DIFF
--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.js
@@ -184,7 +184,15 @@ var MAP_LAYOUT = (function() {
                     };
 
                     // Fetch the WMS GetCapabilities for each layer
-                    $.each(source.getUrls(), function(i, url) {
+                    // Handle different URL methods for TileWMS vs ImageWMS
+                    let urls = [];
+                    if (source instanceof ol.source.TileWMS) {
+                        urls = source.getUrls();
+                    } else if (source instanceof ol.source.ImageWMS) {
+                        urls = [source.getUrl()];
+                    }
+                    
+                    $.each(urls, function(i, url) {
                         let capabilities_url = `${url}?request=GetCapabilities`;
                         
                         // Use cache if layer on same server as previous lookup


### PR DESCRIPTION
### Description
This merge request addresses the bug caused by turning off Tiling on the wms. When `TILE` is set to False  on the `build_wms_layer` function, the source becomes `ol.source.ImageWMS` on the JavaScript side. The function `getUrls` does not exists on `ol.source.ImageWMS`, but `getUrl`.

### Changes Made to Code
 - Added some if statements:
 ```
     let urls = [];
    if (source instanceof ol.source.TileWMS) {
        urls = source.getUrls();
    } else if (source instanceof ol.source.ImageWMS) {
        urls = [source.getUrl()];
    }
                    
 ```

### Related PRs, Issues, and Discussions
- None

### Additional Notes
-  None

### Quality Checks
 - [X] At least one new test has been written for new code
 - [X] New code has 100% test coverage
 - [X] Code has been formatted with Black
 - [X] Code has been linted with flake8
 - [X] Docstrings for new methods have been added
 - [X] The documentation has been updated appropriately
