### PR TITLE
Add --clear to collectstatic salt step to refresh static files

### DIFF
--- a/docker/salt/post_app.sls
+++ b/docker/salt/post_app.sls
@@ -22,7 +22,7 @@ Chown_Portal_Config_Post_App:
 
 Collect_Static:
   cmd.run:
-    - name: tethys manage collectstatic --noinput
+    - name: tethys manage collectstatic --noinput --clear
     - shell: /bin/bash
 
 Collect_Workspaces:


### PR DESCRIPTION
### Description

The static files may have changed since the last time the image was built and since they are stored in the persistent directory, they may be persisted. Use the `--clear` option to clear the STATIC_ROOT directory first each time collectstatic is called in the post_app.sls script.

### Changes Made to Code
 - Added the `--clear` option to the `tethys manage collectstatic` call in post_app.sls

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
