### PR TITLE
Documentation Fixes

### DIFF
--- a/docs/tethys_sdk/paths.rst
+++ b/docs/tethys_sdk/paths.rst
@@ -170,8 +170,8 @@ In some cases, it may be necessary (or more convenient) to use the :term:`app cl
     user_workspace = App.get_user_workspace(user)
     app_media = App.get_app_media()
     user_media = App.get_user_media(user)
-    app_public = App.public_path
-    app_resources App.resources_path
+    app_public = App().public_path
+    app_resources App().resources_path
     ...
 
 .. note::


### PR DESCRIPTION
This merge request makes a few small fixes to a code block in the Paths API documentation. 

These changes correct the use of the App class's App Public and App Resources path properties in a code block. 