### PR TITLE
PiePlot class name correction in docstring

### DIFF
--- a/tethys_gizmos/gizmo_options/plot_view.py
+++ b/tethys_gizmos/gizmo_options/plot_view.py
@@ -552,7 +552,7 @@ class PiePlot(PlotViewBase):
 
     ::
 
-        from tethys_sdk.gizmos import PieChart
+        from tethys_sdk.gizmos import PiePlot
 
         pie_plot_view = PiePlot(
             height='500px',


### PR DESCRIPTION
This pull request addresses a small error in the doc string of the PiePlot class that is generated/rendered in the gizmos documentation. This change simply corrects the name of the class used in the docstring.


