### PR TITLE
Add djangorestframework_simplejwt to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "django-bootstrap5",
     "django-model-utils",
     "django-guardian",
+    "djangorestframework_simplejwt",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Description
This merge request addresses issue #1228 

### Changes Made to Code
 - The `djangorestframework_simplejwt` package was added to the dependencies section of the pyproject.toml

### Related PRs, Issues, and Discussions
- #1228 

### Additional Notes
-  

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
