### PR TITLE
Add form_id attribute to map_view gizmo

### DIFF
--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -381,8 +381,8 @@ jobs:
       run: |
         cd ..
         . ~/miniconda/etc/profile.d/conda.sh;
-        conda create -y -c conda-forge -n conda-build conda-build anaconda-client
-        conda activate conda-build
+        conda create -y -c conda-forge -n conda-build-full conda-build anaconda-client
+        conda activate conda-build-full
         conda config --set anaconda_upload no
         mkdir -p ~/conda-bld
         conda-build -c conda-forge ./tethys/conda.recipe
@@ -393,7 +393,7 @@ jobs:
         cd ..
         . ~/miniconda/etc/profile.d/conda.sh;
         ls ~/conda-bld/noarch
-        conda activate conda-build
+        conda activate conda-build-full
         anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/tethys-platform*.* --force;
     # No Upload if Pull Request
     - name: No Upload
@@ -419,8 +419,8 @@ jobs:
       run: |
         cd ..
         . ~/miniconda/etc/profile.d/conda.sh;
-        conda create -y -c conda-forge -n conda-build conda-build anaconda-client
-        conda activate conda-build
+        conda create -y -c conda-forge -n conda-build-micro conda-build anaconda-client
+        conda activate conda-build-micro
         conda config --set anaconda_upload no
         mkdir -p ~/conda-bld
         conda-build -c conda-forge ./tethys/conda.recipe
@@ -431,7 +431,7 @@ jobs:
         cd ..
         . ~/miniconda/etc/profile.d/conda.sh;
         ls ~/conda-bld/noarch
-        conda activate conda-build
+        conda activate conda-build-micro
         anaconda -t "${{ secrets.CONDA_UPLOAD_TOKEN }}" upload -u ${{ secrets.CONDA_UPLOAD_USER }} -l dev $CONDA_BLD_PATH/noarch/micro-tethys-platform*.* --force;
     # No Upload if Pull Request
     - name: No Upload - micro

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -188,6 +188,7 @@ jobs:
         pip install coveralls reactpy_django pytest pytest-django pytest-cov
 
     - name: Show pyopenssl and cryptography versions
+      if: always()
       shell: bash -l {0}
       run: |
         conda activate tethys

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -186,6 +186,12 @@ jobs:
         conda list
         tethys db start
         pip install coveralls reactpy_django pytest pytest-django pytest-cov
+
+    - name: Show pyopenssl and cryptography versions
+      shell: bash -l {0}
+      run: |
+        conda activate tethys
+        conda list | grep -iE "pyopenssl|cryptography"
     # Test Tethys
     - name: Test Tethys
       run: |

--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -186,13 +186,6 @@ jobs:
         conda list
         tethys db start
         pip install coveralls reactpy_django pytest pytest-django pytest-cov
-
-    - name: Show pyopenssl and cryptography versions
-      if: always()
-      shell: bash -l {0}
-      run: |
-        conda activate tethys
-        conda list | grep -iE "pyopenssl|cryptography"
     # Test Tethys
     - name: Test Tethys
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - python>=3.8
 
   # system dependencies
-  - pyopenssl
+  - pyopenssl>=24.0.0
   - openssl
 
   # core dependencies

--- a/micro_environment.yml
+++ b/micro_environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - python>=3.8
 
   # system dependencies
-  - pyopenssl
+  - pyopenssl>=24.0.0
   - openssl
 
   # core dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">= 3.10"
 dependencies = [
-    "pyopenssl",
+    "pyopenssl>=24.0.0",
   # core dependencies
     "django>=4.2,<6",
     "tornado>=6.5,<7",

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -45,7 +45,7 @@ class MapView(TethysGizmoOptions):
         disable_basemap(bool): Render the map without a base map.
         feature_selection(bool): A dictionary of global feature selection options. See below.
         show_clicks (bool): Show a point on the map where the user clicks if True. Defaults to False. Use the TETHYS_MAP_VIEW.mapClicked() JavaScript API endpoint to provide a callback that will be called each time the map is clicked on. Use the TETHYS_MAP_VIEW.clearClickedPoint() to remove the clicked point.
-        form_id(str): The id of a form on the page to which the hidden geometry text field will be added. 
+        form_id(str): The id of a form on the page to which the hidden geometry text field will be linked.
 
     **Options Dictionaries**
 

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -353,7 +353,7 @@ class MapView(TethysGizmoOptions):
         disable_basemap=False,
         feature_selection=None,
         show_clicks=False,
-        target_form=None,
+        form_id=None,
     ):
         """
         Constructor
@@ -395,7 +395,7 @@ class MapView(TethysGizmoOptions):
         self.disable_basemap = disable_basemap
         self.feature_selection = feature_selection
         self.show_clicks = show_clicks
-        self.target_form = target_form
+        self.form_id = form_id
 
     @classmethod
     def get_vendor_js(cls):

--- a/tethys_gizmos/gizmo_options/map_view.py
+++ b/tethys_gizmos/gizmo_options/map_view.py
@@ -45,6 +45,7 @@ class MapView(TethysGizmoOptions):
         disable_basemap(bool): Render the map without a base map.
         feature_selection(bool): A dictionary of global feature selection options. See below.
         show_clicks (bool): Show a point on the map where the user clicks if True. Defaults to False. Use the TETHYS_MAP_VIEW.mapClicked() JavaScript API endpoint to provide a callback that will be called each time the map is clicked on. Use the TETHYS_MAP_VIEW.clearClickedPoint() to remove the clicked point.
+        form_id(str): The id of a form on the page to which the hidden geometry text field will be added. 
 
     **Options Dictionaries**
 
@@ -352,6 +353,7 @@ class MapView(TethysGizmoOptions):
         disable_basemap=False,
         feature_selection=None,
         show_clicks=False,
+        target_form=None,
     ):
         """
         Constructor
@@ -393,6 +395,7 @@ class MapView(TethysGizmoOptions):
         self.disable_basemap = disable_basemap
         self.feature_selection = feature_selection
         self.show_clicks = show_clicks
+        self.target_form = target_form
 
     @classmethod
     def get_vendor_js(cls):

--- a/tethys_gizmos/templates/tethys_gizmos/gizmos/map_view.html
+++ b/tethys_gizmos/templates/tethys_gizmos/gizmos/map_view.html
@@ -47,6 +47,6 @@
          {% if disable_basemap %}data-disable-base-map="{{ disable_basemap|jsonify }}"{% endif %}
          {% if feature_selection %}data-feature-selection="{{ feature_selection|jsonify }}"{% endif %}
          data-show-clicks="{{ show_clicks|jsonify }}"></div>
-    <textarea id="map_view_geometry" name="geometry" rows="4" cols="180" hidden></textarea>
+    <textarea id="map_view_geometry" name="geometry" rows="4" cols="180" hidden {% if form_id %}form="{{ form_id }}"{% endif %}></textarea>
   </div>
 </div> <!-- end outerContainer -->


### PR DESCRIPTION
### Description
This merge request adds support for linking the map_view_geometry hidden text area with a specific form.  

### Changes Made to Code
 - a `form_id` option was added to the `MapView` gizmo class, which sets the `form` attribute on the gizmo's hidden geometry textarea. This allows the geometry data to be submitted with a form somewhere else on the page, rather than requiring the map to be placed inside the form.

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [x] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
