### PR TITLE
Fixes two issues: #1266 and another

### DIFF
--- a/tests/unit_tests/test_tethys_components/test_utils.py
+++ b/tests/unit_tests/test_tethys_components/test_utils.py
@@ -1,8 +1,9 @@
 import pytest
-from unittest import mock
-from tethys_components import utils
 from pathlib import Path
+from unittest import mock
 from urllib.parse import urlencode, urljoin
+
+from tethys_components import utils
 
 THIS_DIR = Path(__file__).parent
 TEST_APP_DIR = (
@@ -384,36 +385,32 @@ def test_fetch():
         assert data == test_content
 
 
-def test_transform_coordinate():
+@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+def test_transform_coordinate(mock_pyproj):
     coordinate = [0, 0]
     src_proj = "EPSG:3857"
     target_proj = "EPSG:4326"
 
-    with mock.patch("builtins.__import__") as mock_import:
-        result = utils.transform_coordinate(coordinate, src_proj, target_proj)
+    result = utils.transform_coordinate(coordinate, src_proj, target_proj)
 
     assert (
-        mock_import.return_value.Transformer.from_crs.return_value.transform.return_value
-        == result
+        mock_pyproj.Transformer.from_crs.return_value.transform.return_value == result
     )
-    mock_import.return_value.CRS.assert_has_calls(
-        [mock.call(src_proj), mock.call(target_proj)]
-    )
+    mock_pyproj.CRS.assert_has_calls([mock.call(src_proj), mock.call(target_proj)])
 
 
-def test_transform_coordinate_custom_projections():
+@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+def test_transform_coordinate_custom_projections(mock_pyproj):
     coordinate = [0, 0]
     src_proj = {"definition": "test src proj"}
     target_proj = {"definition": "test src proj"}
 
-    with mock.patch("builtins.__import__") as mock_import:
-        result = utils.transform_coordinate(coordinate, src_proj, target_proj)
+    result = utils.transform_coordinate(coordinate, src_proj, target_proj)
 
     assert (
-        mock_import.return_value.Transformer.from_crs.return_value.transform.return_value
-        == result
+        mock_pyproj.Transformer.from_crs.return_value.transform.return_value == result
     )
-    mock_import.return_value.CRS.assert_has_calls(
+    mock_pyproj.CRS.assert_has_calls(
         [mock.call(src_proj["definition"]), mock.call(target_proj["definition"])]
     )
 
@@ -423,16 +420,17 @@ def test_transform_coordinate_invalid_src_proj():
     src_proj = 1234
     target_proj = {"definition": "test src proj"}
 
-    with mock.patch("builtins.__import__"), pytest.raises(ValueError):
+    with pytest.raises(ValueError):
         utils.transform_coordinate(coordinate, src_proj, target_proj)
 
 
-def test_transform_coordinate_invalid_target_proj():
+@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+def test_transform_coordinate_invalid_target_proj(_):
     coordinate = [0, 0]
     src_proj = {"definition": "test src proj"}
     target_proj = 1234
 
-    with mock.patch("builtins.__import__"), pytest.raises(ValueError):
+    with pytest.raises(ValueError):
         utils.transform_coordinate(coordinate, src_proj, target_proj)
 
 
@@ -585,7 +583,8 @@ def test_get_legend_url_basic_with_single_layer_in_layers():
         assert "LAYER=layer1" in url
 
 
-def test_get_legend_url_with_resolution_and_scale():
+@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+def test_get_legend_url_with_resolution_and_scale(mock_pyproj):
     vdom = {
         "tagName": "ImageWMSSource",
         "attributes": {
@@ -599,10 +598,9 @@ def test_get_legend_url_with_resolution_and_scale():
     with mock.patch("builtins.__import__") as mock_import:
         mock_import.return_value.urljoin = urljoin
         mock_import.return_value.urlencode = urlencode
-        mock_crs = mock_import.return_value.CRS
         mock_axis = mock.MagicMock()
         mock_axis.unit_conversion_factor = 2
-        mock_crs.return_value.axis_info = [mock_axis]
+        mock_pyproj.CRS.return_value.axis_info = [mock_axis]
 
         # Call with resolution so SCALE is computed
         result = utils._get_legend_url_(vdom, resolution=100)
@@ -635,7 +633,8 @@ def test_get_feature_info_url_not_implemented_for_diff_projections():
             utils._get_feature_info_url_(vdom, [0, 0], 1, "EPSG:3857", "EPSG:4326")
 
 
-def test_get_feature_info_url_success():
+@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+def test_get_feature_info_url_success(mock_pyproj):
     vdom = {
         "tagName": "ImageWMSSource",
         "attributes": {
@@ -650,12 +649,11 @@ def test_get_feature_info_url_success():
     with mock.patch("builtins.__import__") as mock_import:
         mock_import.return_value.urljoin = urljoin
         mock_import.return_value.urlencode = urlencode
-        mock_crs = mock_import.return_value.CRS
         mock_axis1 = mock.MagicMock()
         mock_axis1.direction = "north"
         mock_axis2 = mock.MagicMock()
         mock_axis2.direction = "east"
-        mock_crs.return_value.axis_info = [mock_axis1, mock_axis2]
+        mock_pyproj.CRS.return_value.axis_info = [mock_axis1, mock_axis2]
 
         feature_url = utils._get_feature_info_url_(
             vdom,

--- a/tests/unit_tests/test_tethys_components/test_utils.py
+++ b/tests/unit_tests/test_tethys_components/test_utils.py
@@ -14,6 +14,17 @@ MOCK_APP = mock.MagicMock()
 MOCK_USER = mock.MagicMock()
 
 
+class MockOptionalPackage(mock.MagicMock):
+    def __getattr__(self, name):
+        if name in ["CRS", "Transformer", "from_crs", "transform", "_mock_methods"]:
+            return super().__getattr__(name)
+        # Allow internal Python/Mock attributes to avoid setup crashes
+        if name.startswith("__") and name.endswith("__"):
+            return super().__getattr__(name)
+        # Raise your desired exception for all other attribute access
+        raise Exception(f"Accessing pyproj.{name} is restricted in this test.")
+
+
 @mock.patch("tethys_components.utils.inspect")
 @pytest.mark.django_db
 def test_infer_app_from_stack_trace_works(mock_inspect):
@@ -385,7 +396,7 @@ def test_fetch():
         assert data == test_content
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
 def test_transform_coordinate(mock_pyproj):
     coordinate = [0, 0]
     src_proj = "EPSG:3857"
@@ -399,7 +410,7 @@ def test_transform_coordinate(mock_pyproj):
     mock_pyproj.CRS.assert_has_calls([mock.call(src_proj), mock.call(target_proj)])
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
 def test_transform_coordinate_custom_projections(mock_pyproj):
     coordinate = [0, 0]
     src_proj = {"definition": "test src proj"}
@@ -424,7 +435,7 @@ def test_transform_coordinate_invalid_src_proj():
         utils.transform_coordinate(coordinate, src_proj, target_proj)
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
 def test_transform_coordinate_invalid_target_proj(_):
     coordinate = [0, 0]
     src_proj = {"definition": "test src proj"}
@@ -583,7 +594,7 @@ def test_get_legend_url_basic_with_single_layer_in_layers():
         assert "LAYER=layer1" in url
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
 def test_get_legend_url_with_resolution_and_scale(mock_pyproj):
     vdom = {
         "tagName": "ImageWMSSource",
@@ -633,7 +644,7 @@ def test_get_feature_info_url_not_implemented_for_diff_projections():
             utils._get_feature_info_url_(vdom, [0, 0], 1, "EPSG:3857", "EPSG:4326")
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=mock.MagicMock)
+@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
 def test_get_feature_info_url_success(mock_pyproj):
     vdom = {
         "tagName": "ImageWMSSource",

--- a/tests/unit_tests/test_tethys_components/test_utils.py
+++ b/tests/unit_tests/test_tethys_components/test_utils.py
@@ -12,17 +12,7 @@ TEST_APP_DIR = (
 
 MOCK_APP = mock.MagicMock()
 MOCK_USER = mock.MagicMock()
-
-
-class MockOptionalPackage(mock.MagicMock):
-    def __getattr__(self, name):
-        if name in ["CRS", "Transformer", "from_crs", "transform", "_mock_methods"]:
-            return super().__getattr__(name)
-        # Allow internal Python/Mock attributes to avoid setup crashes
-        if name.startswith("__") and name.endswith("__"):
-            return super().__getattr__(name)
-        # Raise your desired exception for all other attribute access
-        raise Exception(f"Accessing pyproj.{name} is restricted in this test.")
+mock_pyproj = mock.MagicMock()
 
 
 @mock.patch("tethys_components.utils.inspect")
@@ -396,8 +386,8 @@ def test_fetch():
         assert data == test_content
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
-def test_transform_coordinate(mock_pyproj):
+@mock.patch("tethys_components.utils.pyproj", new=mock_pyproj)
+def test_transform_coordinate():
     coordinate = [0, 0]
     src_proj = "EPSG:3857"
     target_proj = "EPSG:4326"
@@ -410,8 +400,8 @@ def test_transform_coordinate(mock_pyproj):
     mock_pyproj.CRS.assert_has_calls([mock.call(src_proj), mock.call(target_proj)])
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
-def test_transform_coordinate_custom_projections(mock_pyproj):
+@mock.patch("tethys_components.utils.pyproj", new=mock_pyproj)
+def test_transform_coordinate_custom_projections():
     coordinate = [0, 0]
     src_proj = {"definition": "test src proj"}
     target_proj = {"definition": "test src proj"}
@@ -435,8 +425,8 @@ def test_transform_coordinate_invalid_src_proj():
         utils.transform_coordinate(coordinate, src_proj, target_proj)
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
-def test_transform_coordinate_invalid_target_proj(_):
+@mock.patch("tethys_components.utils.pyproj", new=mock_pyproj)
+def test_transform_coordinate_invalid_target_proj():
     coordinate = [0, 0]
     src_proj = {"definition": "test src proj"}
     target_proj = 1234
@@ -594,8 +584,8 @@ def test_get_legend_url_basic_with_single_layer_in_layers():
         assert "LAYER=layer1" in url
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
-def test_get_legend_url_with_resolution_and_scale(mock_pyproj):
+@mock.patch("tethys_components.utils.pyproj", new=mock_pyproj)
+def test_get_legend_url_with_resolution_and_scale():
     vdom = {
         "tagName": "ImageWMSSource",
         "attributes": {
@@ -644,8 +634,8 @@ def test_get_feature_info_url_not_implemented_for_diff_projections():
             utils._get_feature_info_url_(vdom, [0, 0], 1, "EPSG:3857", "EPSG:4326")
 
 
-@mock.patch("tethys_components.utils.pyproj", new_callable=MockOptionalPackage)
-def test_get_feature_info_url_success(mock_pyproj):
+@mock.patch("tethys_components.utils.pyproj", new=mock_pyproj)
+def test_get_feature_info_url_success():
     vdom = {
         "tagName": "ImageWMSSource",
         "attributes": {

--- a/tethys_apps/static/tethys_apps/js/ol-mods/source/Vector.js
+++ b/tethys_apps/static/tethys_apps/js/ol-mods/source/Vector.js
@@ -24,7 +24,7 @@ export default function VectorSource (...props) {
     
     if (props.features || props.options.features) {
         features = props.features || props.options.features;
-        if (Array.isArray(features) && features.length > 0 && features[0] instanceof Feature) {
+        if (Array.isArray(features) && (features.length == 0 || features[0] instanceof Feature)) {
             'pass';
         } else {
             if (!format) {

--- a/tethys_components/library.py
+++ b/tethys_components/library.py
@@ -728,18 +728,18 @@ class CustomComponentManager:
 
 
 class DynamicPackageManager:
-    from reactpy import web
-
     def __init__(
         self,
         library: ComponentLibrary = None,
         package: Package = None,
         component: str = "",
     ):
+        from reactpy import web
 
         self.library = library
         self.package = package
         self.component = component
+        self.web = web
 
     def __getattr__(self, attr):
         component = f"{self.component}.{attr}" if self.component else attr

--- a/tethys_components/utils.py
+++ b/tethys_components/utils.py
@@ -5,6 +5,7 @@ import tokenize
 from tethys_components import layouts
 from typing import Any
 from pathlib import Path
+from tethys_portal.optional_dependencies import optional_import
 from tethys_apps.harvester import SingletonHarvester
 from tethys_apps.base.paths import (
     _get_user_workspace,
@@ -13,6 +14,11 @@ from tethys_apps.base.paths import (
     _get_user_media,
 )
 from concurrent.futures import ThreadPoolExecutor
+
+pyproj = optional_import(
+    "pyproj",
+    error_message="The `pyproj` package is required for the utility function you are accessing.",
+)
 
 
 class DotNotationDict(dict):
@@ -319,27 +325,38 @@ def background_execute(
 
 
 def transform_coordinate(coordinate, src_proj, target_proj):
-    from pyproj import Transformer, CRS
+    """
+    Transforms a coordinate from a source projection to a target projection using pyproj.
 
+    Args:
+        coordinate (list): A list representing the coordinate to be transformed, in the format [x, y].
+        src_proj (str or dict): The source projection, either as a string (e.g. "EPSG:4326") or a dictionary with a "definition" key containing the projection string.
+        target_proj (str or dict): The target projection, either as a string (e.g. "EPSG:3857") or a dictionary with a "definition" key containing the projection string.
+    Returns:
+        A list representing the transformed coordinate in the target projection, in the format [x, y].
+    Raises:
+        ValueError: If src_proj or target_proj are not in the expected formats.
+        tethys_portal.optional_dependencies.MissingOptionalDependency: If the pyproj library is not installed.
+    """
     if isinstance(src_proj, dict):
-        source_crs = CRS(src_proj["definition"])
+        source_crs = pyproj.CRS(src_proj["definition"])
     elif isinstance(src_proj, str):
-        source_crs = CRS(src_proj)
+        source_crs = pyproj.CRS(src_proj)
     else:
         raise ValueError(
             "src_proj must be a string or dictionary with a definition key"
         )
 
     if isinstance(target_proj, dict):
-        target_crs = CRS(target_proj["definition"])
+        target_crs = pyproj.CRS(target_proj["definition"])
     elif isinstance(target_proj, str):
-        target_crs = CRS(target_proj)
+        target_crs = pyproj.CRS(target_proj)
     else:
         raise ValueError(
             "target_proj must be a string or dictionary with a definition key"
         )
 
-    transformer = Transformer.from_crs(source_crs, target_crs)
+    transformer = pyproj.Transformer.from_crs(source_crs, target_crs)
     return transformer.transform(coordinate[0], coordinate[1])
 
 
@@ -349,7 +366,7 @@ class Props(dict):
     They are converted back to ReactPy propery dictionaries when accessed.
 
     Example:
-        Instead of lib.html.div({"backgroundColor": "red", "fontSize": "12px"}, "Hello"), you can use lib.html.div(Props(background_color="red, font_size="12px"), "Hello")
+        Instead of lib.html.div({"backgroundColor": "red", "fontSize": "12px"}, "Hello"), you can use lib.html.div(Props(background_color="red", font_size="12px"), "Hello")
     """
 
     def _snake_to_camel(self, snake):
@@ -443,7 +460,6 @@ def _get_legend_url_(vdom_element, resolution=None, params=None):
         )
 
     from urllib.parse import urlencode, urljoin
-    from pyproj import CRS
 
     if not params:
         params = {}
@@ -468,7 +484,7 @@ def _get_legend_url_(vdom_element, resolution=None, params=None):
 
     if resolution:
         mpu = (
-            CRS(
+            pyproj.CRS(
                 source_params["projection"]
                 if "projection" in source_params
                 else "EPSG:3857"
@@ -493,7 +509,6 @@ def _get_feature_info_url_(
         )
 
     from urllib.parse import urlencode, urljoin
-    from pyproj import CRS
 
     if not params:
         params = {}
@@ -516,7 +531,7 @@ def _get_feature_info_url_(
     x = round(math.floor((map_coordinate[0] - extent[0]) / map_resolution), DECIMALS)
     y = round(math.floor((extent[3] - map_coordinate[1]) / map_resolution), DECIMALS)
 
-    axisOrientation = "".join([a.direction[0] for a in CRS(map_proj).axis_info])
+    axisOrientation = "".join([a.direction[0] for a in pyproj.CRS(map_proj).axis_info])
     bbox = (
         [extent[1], extent[0], extent[3], extent[2]]
         if axisOrientation == "ne"


### PR DESCRIPTION
### Description
This PR fixes the following errors:
- #1266 
- `lib.tethys.Map` not rendering at all if `lib.ol.source.Vector`  contains empty list of features.

### Changes Made to Code
 - **tethys_components/library.py** - I moved an import of reactpy out of the class definition and into the `__init__` function so that the error will only be thrown when instances are initialized, not on server start up
 - **tethys_apps/static/tethys_apps/js/ol-mods/source/Vector.js** - I add a condition to check if the list of features is empty or not

### Related PRs, Issues, and Discussions
- #1266

### Additional Notes
-  

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
