### PR TITLE
Fix for Git LFS Check Failures

### DIFF
--- a/.github/workflows/tethys.yml
+++ b/.github/workflows/tethys.yml
@@ -121,10 +121,14 @@ jobs:
         HEAD="${{ github.sha }}"
 
         if [[ "$EVENT" == "pull_request" ]]; then
-          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+          git fetch origin "${{ github.event.pull_request.base.ref }}"
           BASE="$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")"
         elif [[ "$EVENT" == "push" ]]; then
-          BASE="${{ github.event.before }}"
+          if [[ "${{ github.event.before }}" =~ ^0+$ ]]; then
+            BASE="$(git rev-parse HEAD^)"
+          else
+            BASE="${{ github.event.before }}"
+          fi
         else
           BASE="$(git rev-parse HEAD^)"
         fi


### PR DESCRIPTION
### Description
This merge request addresses failures in the CI in the Git LFS check step. 

### Changes Made to Code
 - Removed --depth=1 so the full base ancestry is fetched.
 - Make sure that if github.event.before is all zeroes to make sure the lfs check doesn't get a bad SHA.

