### PR TITLE
Docs Copy Button Fix

### DIFF
--- a/docs/_static/css/tethys.css
+++ b/docs/_static/css/tethys.css
@@ -56,3 +56,7 @@ pre {
     padding-right: 1rem;
 }
 
+pre button.copy .sr-only {
+    user-select: none;
+    -webkit-user-select: none;  
+}


### PR DESCRIPTION
### Description
This merge request addresses an issue in the Tethys documentation where when pressing the "copy" button in code blocks, a "copy code" text was being added to the copied code

### Changes Made to Code
 - Updated css to prevent the copy button's screen reader text from being included in the code block when copying everything.