### PR TITLE
Fixes in Tethys CLI for Creating THREDDS Services

### DIFF
--- a/tests/unit_tests/test_tethys_cli/test_services_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_services_commands.py
@@ -469,7 +469,46 @@ class ServicesCommandsTest(unittest.TestCase):
 
     @mock.patch("tethys_cli.services_commands.pretty_output")
     @mock.patch("tethys_services.models.SpatialDatasetService")
-    def test_services_create_spatial_command_thredds(
+    def test_services_create_spatial_command_thredds_with_endpoint(
+        self, mock_service, mock_pretty_output
+    ):
+        """
+        Test for services_create_spatial_command
+        For going through the function and saving
+        :param mock_service:  mock for SpatialDatasetService
+        :param mock_pretty_output:  mock for pretty_output text
+        :return:
+        """
+        mock_args = mock.MagicMock(
+            endpoint="http://localhost:8181/thredds/catalog.xml",
+            public_endpoint="https://www.example.com:443/thredds/catalog.xml",
+            apikey="apikey123",
+            type="THREDDS",
+        )
+        mock_args.name = "test_thredds"
+
+        services_create_spatial_command(mock_args)
+
+        mock_service.assert_called()
+
+        po_call_args = mock_pretty_output().__enter__().write.call_args_list
+        self.assertEqual(1, len(po_call_args))
+        self.assertEqual(
+            "Successfully created new Spatial Dataset Service!", po_call_args[0][0][0]
+        )
+        mock_service.assert_called_with(
+            name="test_thredds",
+            endpoint="http://localhost:8181/thredds/catalog.xml",
+            public_endpoint="https://www.example.com:443/thredds/catalog.xml",
+            apikey="apikey123",
+            username="",
+            password="",
+            engine=mock_service.THREDDS,
+        )
+
+    @mock.patch("tethys_cli.services_commands.pretty_output")
+    @mock.patch("tethys_services.models.SpatialDatasetService")
+    def test_services_create_spatial_command_thredds_with_connection(
         self, mock_service, mock_pretty_output
     ):
         """

--- a/tests/unit_tests/test_tethys_cli/test_services_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_services_commands.py
@@ -484,9 +484,9 @@ class ServicesCommandsTest(unittest.TestCase):
             public_endpoint="https://www.example.com:443/thredds/catalog.xml",
             apikey="apikey123",
             type="THREDDS",
+            connection=None,
         )
         mock_args.name = "test_thredds"
-
         services_create_spatial_command(mock_args)
 
         mock_service.assert_called()

--- a/tests/unit_tests/test_tethys_cli/test_services_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_services_commands.py
@@ -569,7 +569,10 @@ class ServicesCommandsTest(unittest.TestCase):
 
         po_call_args = mock_pretty_output().__enter__().write.call_args_list
         self.assertEqual(1, len(po_call_args))
-        self.assertIn("Either connection or endpoint argument must be provided.", po_call_args[0][0][0])
+        self.assertIn(
+            "Either connection or endpoint argument must be provided.",
+            po_call_args[0][0][0],
+        )
 
     @mock.patch("tethys_cli.services_commands.pretty_output")
     @mock.patch("tethys_cli.services_commands.exit")

--- a/tests/unit_tests/test_tethys_cli/test_services_commands.py
+++ b/tests/unit_tests/test_tethys_cli/test_services_commands.py
@@ -546,6 +546,32 @@ class ServicesCommandsTest(unittest.TestCase):
         )
 
     @mock.patch("tethys_cli.services_commands.pretty_output")
+    @mock.patch("tethys_services.models.SpatialDatasetService")
+    def test_services_create_spatial_command_thredds_no_connection_no_endpoint(
+        self, mock_service, mock_pretty_output
+    ):
+        """
+        Test for services_create_spatial_command
+        For when neither connection nor endpoint is provided
+        :param mock_service:  mock for SpatialDatasetService
+        :param mock_pretty_output:  mock for pretty_output text
+        :return:
+        """
+        mock_args = mock.MagicMock(
+            connection=None,
+            endpoint=None,
+            public_endpoint=None,
+            apikey=None,
+            type="THREDDS",
+        )
+        mock_args.name = "test_thredds"
+        services_create_spatial_command(mock_args)
+
+        po_call_args = mock_pretty_output().__enter__().write.call_args_list
+        self.assertEqual(1, len(po_call_args))
+        self.assertIn("Either connection or endpoint argument must be provided.", po_call_args[0][0][0])
+
+    @mock.patch("tethys_cli.services_commands.pretty_output")
     @mock.patch("tethys_cli.services_commands.exit")
     @mock.patch("tethys_services.models.WebProcessingService")
     def test_services_remove_wps_command_Exceptions(

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -341,6 +341,9 @@ def services_create_spatial_command(args):
             endpoint = parts[1]
         else:
             endpoint = args.endpoint
+            service_username = ""
+            service_password = ""
+            
         public_endpoint = args.public_endpoint or ""
         apikey = args.apikey or ""
         service_type = args.type

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -143,10 +143,18 @@ def add_services_parser(subparsers):
     services_create_sd.add_argument(
         "-c",
         "--connection",
-        required=True,
+        required=False,
         type=str,
         help="The connection of the Service in the form "
         '"<username>:<password>@<protocol>//<host>:<port>"',
+    )
+    services_create_sd.add_argument(
+        "-e",
+        "--endpoint",
+        required=False,
+        type=str,
+        help="The endpoint of the Service of the form, if connection argument is not provided, "
+        '"<host>:<port>"',
     )
     services_create_sd.add_argument(
         "-p",
@@ -325,11 +333,14 @@ def services_create_spatial_command(args):
     try:
         name = args.name
         connection = args.connection
-        parts = connection.split("@")
-        cred_parts = parts[0].split(":")
-        service_username = cred_parts[0]
-        service_password = cred_parts[1]
-        endpoint = parts[1]
+        if connection:
+            parts = connection.split("@")
+            cred_parts = parts[0].split(":")
+            service_username = cred_parts[0]
+            service_password = cred_parts[1]
+            endpoint = parts[1]
+        else:
+            endpoint = args.endpoint
         public_endpoint = args.public_endpoint or ""
         apikey = args.apikey or ""
         service_type = args.type

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -343,7 +343,7 @@ def services_create_spatial_command(args):
             endpoint = args.endpoint
             service_username = ""
             service_password = ""
-            
+
         public_endpoint = args.public_endpoint or ""
         apikey = args.apikey or ""
         service_type = args.type

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -16,6 +16,10 @@ class FormatError(Exception):
     def __init__(self):
         Exception.__init__(self)
 
+class MissingArgumentError(Exception):
+    def __init__(self, error_message):
+        Exception.__init__(self, error_message)
+
 
 def add_services_parser(subparsers):
     # SERVICES COMMANDS
@@ -333,16 +337,20 @@ def services_create_spatial_command(args):
     try:
         name = args.name
         connection = args.connection
+        endpoint = args.endpoint
+
+        if connection is None and endpoint is None:
+            raise MissingArgumentError("Either connection or endpoint argument must be provided.")
+
+        service_username = ""
+        service_password = ""
+
         if connection:
             parts = connection.split("@")
             cred_parts = parts[0].split(":")
             service_username = cred_parts[0]
             service_password = cred_parts[1]
             endpoint = parts[1]
-        else:
-            endpoint = args.endpoint
-            service_username = ""
-            service_password = ""
 
         public_endpoint = args.public_endpoint or ""
         apikey = args.apikey or ""
@@ -398,6 +406,10 @@ def services_create_spatial_command(args):
                     name
                 )
             )
+
+    except MissingArgumentError as e:
+        with pretty_output(FG_RED) as p:
+            p.write(str(e))
 
 
 def services_create_dataset_command(args):

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -16,6 +16,7 @@ class FormatError(Exception):
     def __init__(self):
         Exception.__init__(self)
 
+
 class MissingArgumentError(Exception):
     def __init__(self, error_message):
         Exception.__init__(self, error_message)
@@ -340,7 +341,9 @@ def services_create_spatial_command(args):
         endpoint = args.endpoint
 
         if connection is None and endpoint is None:
-            raise MissingArgumentError("Either connection or endpoint argument must be provided.")
+            raise MissingArgumentError(
+                "Either connection or endpoint argument must be provided."
+            )
 
         service_username = ""
         service_password = ""


### PR DESCRIPTION
### Description
This merge request addresses an inconsistency in the CLI command for creating a spatial dataset service. This addresses issues in creating THREDDS services as they don't often require usernames and passwords that are a required part of the `connection` argument. 
### Changes Made to Code
 - Made the `connection` argument no longer required
 - Added an `endpoint` requirement to be used instead of including the endpoint in a `connection` argument.

### Quality Checks
 - [x] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
