### PR TITLE
Fix touch command syntax for Windows

### DIFF
--- a/tethys_portal/views/app_lifecycle.py
+++ b/tethys_portal/views/app_lifecycle.py
@@ -25,7 +25,7 @@ from tethys_portal.forms import AppScaffoldForm, AppImportForm
 from tethys_portal import settings
 
 TOUCH_COMMAND = (
-    f"copy /b \"{settings.__file__}\"+,, \"{settings.__file__}\""
+    f'copy /b "{settings.__file__}"+,, "{settings.__file__}"'
     if platform.system() == "Windows"
     else f"touch {settings.__file__}"
 )

--- a/tethys_portal/views/app_lifecycle.py
+++ b/tethys_portal/views/app_lifecycle.py
@@ -25,7 +25,7 @@ from tethys_portal.forms import AppScaffoldForm, AppImportForm
 from tethys_portal import settings
 
 TOUCH_COMMAND = (
-    f"copy /b {settings.__file__}+,, {settings.__file__}"
+    f"copy /b \"{settings.__file__}\"+,, \"{settings.__file__}\""
     if platform.system() == "Windows"
     else f"touch {settings.__file__}"
 )


### PR DESCRIPTION
### Description
This fixes a bug that occurs when the settings.__file__ has spaces in the path.

### Changes Made to Code
 - Small change, see diff

### Related PRs, Issues, and Discussions
- 

### Additional Notes
-  

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
