### PR TITLE
Component app.py tags fix

### DIFF
--- a/tethys_cli/scaffold_templates/app_templates/component/tethysapp/+project+/app.py_tmpl
+++ b/tethys_cli/scaffold_templates/app_templates/component/tethysapp/+project+/app.py_tmpl
@@ -13,7 +13,7 @@ class App(ComponentBase):
     icon = f"{package}/images/icon.png"
     root_url = "{{project_url}}"
     color = "{{color}}"
-    tags = "{{tags}}"
+    tags = '{{tags}}'
     enable_feedback = False
     feedback_emails = []
     exit_url = "/apps/"


### PR DESCRIPTION
### Description
This merge request addresses #1275 where when scaffolding a new component app, the tags line in app.py would be generated with " " surrounding the tags instead of ' '. This caused issues when installing this new component app

### Changes Made to Code
 - Updated component app scaffold template file for app.py to be the same as other app templates for react and default.

### Related PRs, Issues, and Discussions
- #1275 

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
