### PR TITLE
Enforces lower-case project_name & shows proj path

### DIFF
--- a/tests/unit_tests/test_tethys_portal/test_forms.py
+++ b/tests/unit_tests/test_tethys_portal/test_forms.py
@@ -594,3 +594,11 @@ class TethysPortalFormsTests(TestCase):
         self.assertFalse(app_import_form.is_valid())
 
         self.assertRaises(forms.ValidationError, app_import_form.clean)
+
+    def test_AppScaffoldForm_capitalized_project(self):
+        form_data = {"project_name": "My Project", "app_name": "My Project"}
+
+        app_scaffold_form = tp_forms.AppScaffoldForm(data=form_data)
+
+        self.assertFalse(app_scaffold_form.is_valid())
+        self.assertIn("project_name", app_scaffold_form.errors)

--- a/tethys_portal/forms.py
+++ b/tethys_portal/forms.py
@@ -351,8 +351,8 @@ class AppScaffoldForm(forms.Form):
         ),
         validators=[
             RegexValidator(
-                r"^\w+$",
-                "The project name must contain only letters, numbers, and underscores.",
+                r"^[a-z0-9_]+$",
+                "The project name must contain only lower-case letters, numbers, and underscores.",
             ),
             lambda v: (Path.cwd() / f"{APP_PREFIX}-{v}").exists()
             and exec(

--- a/tethys_portal/templates/tethys_portal/create_app.html
+++ b/tethys_portal/templates/tethys_portal/create_app.html
@@ -19,5 +19,5 @@
   {% else %}
     {% include "./lifecycle_progress.html" with action="Creating" app_name=app_name app_package=app_package %}
   {% endif %}
-
+  <p>Note: Project will be created in the current working directory of your running server: {{project_location}}</p>
 {% endblock %}

--- a/tethys_portal/views/app_lifecycle.py
+++ b/tethys_portal/views/app_lifecycle.py
@@ -221,6 +221,7 @@ def create_app(request):
         "author": request.user.get_full_name(),
         "author_email": request.user.email,
     }
+    project_name = None
     context = {"form": AppScaffoldForm(initial=initial)}
     command_message_tuples = []
 
@@ -266,7 +267,9 @@ def create_app(request):
             context["app_package"] = project_name
             del context["form"]
 
-    context["project_location"] = Path.cwd() / f"{APP_PREFIX}-<Project Name>"
+    context["project_location"] = (
+        Path.cwd() / f"{APP_PREFIX}-{project_name or '<project_name>'}"
+    )
 
     return render(request, "tethys_portal/create_app.html", context)
 


### PR DESCRIPTION
### Description
This merge request addresses a bug and lack of clarity with the GUI Scaffold. 

The bug was that the GUI was allowing and storing uppercase characters in the project name, even though the CLI was forcing it to lowercase, which would then break with "folder not found" when trying to change into the scaffolded app directory for the install.

The lack of clarity was with knowing where exactly the new app project code was being created to. This was fixed by providing a simple message to the user.

### Changes Made to Code
 - `project_name` validator updated to only allow lowercase
 -  The `project_location` is now pulled from the context to display on the create_app.html page

### Related PRs, Issues, and Discussions
- 

### Additional Notes
-  

### Quality Checks
 - [x] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
