### PR TITLE
Fix app with service setting install bug

### DIFF
--- a/tethys_cli/install_commands.py
+++ b/tethys_cli/install_commands.py
@@ -455,7 +455,7 @@ def run_interactive_services(app_name):
                 setattr(args, conf, False)
 
             setattr(args, get_setting_type(setting), True)
-            services = services_list_command(args)[0]
+            services = [service for service_group in services_list_command(args) for service in service_group]
 
             if len(services) <= 0:
                 write_warning(

--- a/tethys_cli/install_commands.py
+++ b/tethys_cli/install_commands.py
@@ -455,7 +455,11 @@ def run_interactive_services(app_name):
                 setattr(args, conf, False)
 
             setattr(args, get_setting_type(setting), True)
-            services = [service for service_group in services_list_command(args) for service in service_group]
+            services = [
+                service
+                for service_group in services_list_command(args)
+                for service in service_group
+            ]
 
             if len(services) <= 0:
                 write_warning(

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -706,9 +706,8 @@ def services_list_command(args):
     if list_persistent:
         postgres_entries = PostgresPersistentStoreService.objects.order_by("id").all()
         sqlite_entries = SQLitePersistentStoreService.objects.order_by("id").all()
-        entries.append(postgres_entries)
-        entries.append(sqlite_entries)
         if len(postgres_entries) > 0:
+            entries.append(postgres_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nPostgreSQL Persistent Store Services:")
             is_first_entry = True
@@ -731,6 +730,7 @@ def services_list_command(args):
                     )
                 )
         if len(sqlite_entries) > 0:
+            entries.append(sqlite_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nSQLite Persistent Store Services:")
             is_first_entry = True
@@ -752,8 +752,8 @@ def services_list_command(args):
 
     if list_spatial:
         spatial_entries = SpatialDatasetService.objects.order_by("id").all()
-        entries.append(spatial_entries)
         if len(spatial_entries) > 0:
+            entries.append(spatial_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nSpatial Dataset Services:")
             is_first_entry = True
@@ -778,8 +778,8 @@ def services_list_command(args):
                 )
     if list_dataset:
         dataset_entries = DatasetService.objects.order_by("id").all()
-        entries.append(dataset_entries)
         if len(dataset_entries) > 0:
+            entries.append(dataset_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nDataset Services:")
             is_first_entry = True
@@ -804,8 +804,8 @@ def services_list_command(args):
                 )
     if list_wps:
         service_entries = WebProcessingService.objects.order_by("id").all()
-        entries.append(service_entries)
         if len(service_entries) > 0:
+            entries.append(service_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nWeb Processing Services:")
             is_first_entry = True

--- a/tethys_cli/services_commands.py
+++ b/tethys_cli/services_commands.py
@@ -706,8 +706,9 @@ def services_list_command(args):
     if list_persistent:
         postgres_entries = PostgresPersistentStoreService.objects.order_by("id").all()
         sqlite_entries = SQLitePersistentStoreService.objects.order_by("id").all()
+        entries.append(postgres_entries)
+        entries.append(sqlite_entries)
         if len(postgres_entries) > 0:
-            entries.append(postgres_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nPostgreSQL Persistent Store Services:")
             is_first_entry = True
@@ -730,7 +731,6 @@ def services_list_command(args):
                     )
                 )
         if len(sqlite_entries) > 0:
-            entries.append(sqlite_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nSQLite Persistent Store Services:")
             is_first_entry = True
@@ -752,8 +752,8 @@ def services_list_command(args):
 
     if list_spatial:
         spatial_entries = SpatialDatasetService.objects.order_by("id").all()
+        entries.append(spatial_entries)
         if len(spatial_entries) > 0:
-            entries.append(spatial_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nSpatial Dataset Services:")
             is_first_entry = True
@@ -778,8 +778,8 @@ def services_list_command(args):
                 )
     if list_dataset:
         dataset_entries = DatasetService.objects.order_by("id").all()
+        entries.append(dataset_entries)
         if len(dataset_entries) > 0:
-            entries.append(dataset_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nDataset Services:")
             is_first_entry = True
@@ -804,8 +804,8 @@ def services_list_command(args):
                 )
     if list_wps:
         service_entries = WebProcessingService.objects.order_by("id").all()
+        entries.append(service_entries)
         if len(service_entries) > 0:
-            entries.append(service_entries)
             with pretty_output(BOLD) as p:
                 p.write("\nWeb Processing Services:")
             is_first_entry = True


### PR DESCRIPTION
### Description
This merge request addresses a bug where when installing an app that has a service setting, but there are no existing services, an error would show up. 

### Changes Made to Code
 - Updated the run_interactive_services function to not just look for the first service query ([0]), but to flatten out the query(ies) to avoid errors and to make sure it's checking for multiple query sets such as in the case of persistent store services

### Related PRs, Issues, and Discussions
- #1283 

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
