### PR TITLE
Fix Read the Docs builds broken by Ubuntu 26.04 image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-latest"
   jobs:
     post_checkout:
       # Get the tags


### PR DESCRIPTION
### Description
This merge request fixes the Read the Docs build, which has been failing for every PR since late June (e.g. #1277, #1282, #1284, #1285, #1287, #1288). Read the Docs flipped its `ubuntu-lts-latest` alias to Ubuntu 26.04, and that image only supports the `miniforge3-*` conda toolchain. The deprecated `mambaforge-4.10` pinned in `.readthedocs.yaml` fails to install on it:

```
asdf install python mambaforge-4.10.3-10
...
EnvironmentLocationNotFound: Not a conda environment: .../conda/<version>
BUILD FAILED (Ubuntu 26.04 using python-build 2.8.0)
```

conda-forge retired Mambaforge in favor of Miniforge3 (functionally identical since Miniforge3-23.3.1-0), and Read the Docs deprecated all `mambaforge-*` values. A Read the Docs maintainer confirmed `miniforge3-*` is the supported replacement on the new image (readthedocs/readthedocs.org#13149); other projects hit by the same break applied the same one-line fix (e.g. MDAnalysis/mdanalysis#5410).

### Changes Made to Code
- `.readthedocs.yaml`: `build.tools.python` changed from deprecated `mambaforge-4.10` to `miniforge3-latest`.

### Related PRs, Issues, and Discussions
- readthedocs/readthedocs.org#13149
- readthedocs/readthedocs.org#11690 (Mambaforge retirement)
- Unblocks the `docs/readthedocs.org` check (and therefore Merge Gatekeeper) on all open PRs, including #1288.

### Additional Notes
- The `docs/readthedocs.org:tethys-platform` check on this PR is the real verification — it builds with this config.

### Quality Checks
 - [ ] At least one new test has been written for new code (N/A — CI config only)
 - [ ] New code has 100% test coverage (N/A)
 - [ ] Code has been formatted with Black (N/A)
 - [ ] Code has been linted with flake8 (N/A)
 - [ ] Docstrings for new methods have been added (N/A)
 - [ ] The documentation has been updated appropriately (N/A — config change fixes the docs build itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)