### PR TITLE
Add node_modules to STATICFILES_DIRS when STATICFILES_USE_NPM is enabled

### DIFF
--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -506,7 +506,7 @@ if has_module(bokeh_settings):
         bokeh_js_dir = bokeh_settings.bokehjsdir()
     STATICFILES_DIRS.append(bokeh_js_dir)
 
-STATICFILES_USE_NPM = TETHYS_PORTAL_CONFIG.pop("STATICFILES_USE_NPM", False)
+STATICFILES_USE_NPM = TETHYS_PORTAL_CONFIG.pop("STATICFILES_USE_NPM", False) or "STATICFILES_USE_NPM" in portal_config_settings.keys()
 if STATICFILES_USE_NPM:
     STATICFILES_DIRS.append(BASE_DIR / "static" / "node_modules")
 

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -506,7 +506,10 @@ if has_module(bokeh_settings):
         bokeh_js_dir = bokeh_settings.bokehjsdir()
     STATICFILES_DIRS.append(bokeh_js_dir)
 
-STATICFILES_USE_NPM = TETHYS_PORTAL_CONFIG.pop("STATICFILES_USE_NPM", False) or "STATICFILES_USE_NPM" in portal_config_settings.keys()
+STATICFILES_USE_NPM = (
+    TETHYS_PORTAL_CONFIG.pop("STATICFILES_USE_NPM", False)
+    or "STATICFILES_USE_NPM" in portal_config_settings.keys()
+)
 if STATICFILES_USE_NPM:
     STATICFILES_DIRS.append(BASE_DIR / "static" / "node_modules")
 


### PR DESCRIPTION
### Description
Fixes the issue where putting `STATICFILES_USE_NPM: true`  under settings in `portal_config.yml` causes the tethys portal to be unable to find the css and js static files.

`tethys_portal/settings.py` was checking for `STATICFILES_USE_NPM` under `TETHYS_PORTAL_CONFIG` only when adding the static files paths resulting in the path not being added when `STATICFILES_USE_NPM` is located at the top level. The setting still applied in this scenario resulting in the portal not being able to find the static files.

Putting `STATICFILES_USE_NPM` either under the top level or `TETHYS_PORTAL_CONFIG` both properly add the static files path.

### Changes Made to Code

 - Add a check for `STATICFILES_USE_NPM` under the top level when adding the static files path

### Related PRs, Issues, and Discussions
- 

### Additional Notes
-  

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [ ] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
