### PR TITLE
Login/Register Form Fixes

### DIFF
--- a/tethys_portal/templates/tethys_portal/accounts/login.html
+++ b/tethys_portal/templates/tethys_portal/accounts/login.html
@@ -23,7 +23,7 @@
     {% endif %}
     {% csrf_token %}
     {% bootstrap_field form.username show_label=False %}
-    {% bootstrap_field form.password show_label=False%}
+    {% bootstrap_field form.password show_label=False %}
     <button type="submit" id="login-submit" class="btn btn-primary mb-3" name="login-submit">Log In</button>
     {% if signup_enabled %}
       <span class="d-block">Don't have an account? <a href="{% url 'accounts:register' %}">Sign Up</a></span>

--- a/tethys_portal/templates/tethys_portal/accounts/login.html
+++ b/tethys_portal/templates/tethys_portal/accounts/login.html
@@ -22,7 +22,8 @@
       </div>
     {% endif %}
     {% csrf_token %}
-    {% bootstrap_form form %}
+    {% bootstrap_field form.username show_label=False %}
+    {% bootstrap_field form.password show_label=False%}
     <button type="submit" id="login-submit" class="btn btn-primary mb-3" name="login-submit">Log In</button>
     {% if signup_enabled %}
       <span class="d-block">Don't have an account? <a href="{% url 'accounts:register' %}">Sign Up</a></span>

--- a/tethys_portal/templates/tethys_portal/accounts/register.html
+++ b/tethys_portal/templates/tethys_portal/accounts/register.html
@@ -22,7 +22,10 @@
     </div>
   {% endif %}
   {% csrf_token %}
-  {% bootstrap_form form %}
+  {% bootstrap_field form.username show_label=False %}
+  {% bootstrap_field form.email show_label=False %}
+  {% bootstrap_field form.password1 show_label=False %}
+  {% bootstrap_field form.password2 show_label=False %}
   <button type="submit" id="register-submit" class="btn btn-primary mb-3" name="register-submit">Sign Up</button>
   <span class="d-block">Already have an account? <a href="{% url 'accounts:login' %}">Login</a></span>
 </form>


### PR DESCRIPTION
### Description
This merge request addresses the issue of empty whitespace above fields in the login and register forms in the Tethys Portal.

### Changes Made to Code
 - Hid labels inside both forms to remove the unnecessary whitespace above inputs.

See the before and after of each form below:

<img width="350"  alt="Screenshot 2026-07-30 221237" src="https://github.com/user-attachments/assets/3df57d0a-82ff-4bc3-89f2-02e44c98f018" />
<img width="350"  alt="Screenshot 2026-07-30 221228" src="https://github.com/user-attachments/assets/faaa7381-3e10-4c34-8758-803299c469be" />
<img width="370" alt="Screenshot 2026-07-30 221145" src="https://github.com/user-attachments/assets/8dc98c86-0492-4d6d-9e15-be821fc2b2d1" />
<img width="370"  alt="Screenshot 2026-07-30 221158" src="https://github.com/user-attachments/assets/ab06d079-fb08-48e4-a7e1-82e0493e416f" />

### Quality Checks
 - [x] At least one new test has been written for new code
 - [x] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
