### PR TITLE
Render the captcha field on the login and register pages

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -42,6 +42,7 @@ See: :doc:`tethys_sdk/gizmos/time_picker`
 Bug Fixes
 ---------
 
+* Captcha field rendering fix for the login and register pages: `PR 1297 <https://github.com/tethysplatform/tethys/pull/1297>`_
 * Login and register form fixes: `PR 1293 <https://github.com/tethysplatform/tethys/pull/1293>`_
 * Static file discovery fix for ``STATICFILES_USE_NPM``: `PR 1291 <https://github.com/tethysplatform/tethys/pull/1291>`_
 * Django 5 app initialization warning fix: `PR 1288 <https://github.com/tethysplatform/tethys/pull/1288>`_

--- a/tests/unit_tests/test_tethys_portal/test_views/test_accounts_captcha.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_accounts_captcha.py
@@ -1,0 +1,69 @@
+from importlib import reload
+from unittest import mock
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+import tethys_portal.forms as tp_forms
+
+
+class TethysPortalAccountsCaptchaRenderingTest(TestCase):
+    def tearDown(self):
+        reload(tp_forms)
+
+    def render_login(self):
+        with mock.patch("tethys_portal.views.accounts.LoginForm", tp_forms.LoginForm):
+            return self.client.get(reverse("accounts:login"))
+
+    def render_register(self):
+        with mock.patch(
+            "tethys_portal.views.accounts.RegisterForm", tp_forms.RegisterForm
+        ):
+            return self.client.get(reverse("accounts:register"))
+
+    @override_settings(
+        ENABLE_CAPTCHA=True, RECAPTCHA_PRIVATE_KEY="", RECAPTCHA_PUBLIC_KEY=""
+    )
+    def test_login_page_renders_captcha_when_enabled(self):
+        reload(tp_forms)
+        self.assertIn("captcha", tp_forms.LoginForm().fields)
+
+        response = self.render_login()
+
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, 'name="captcha_1"')
+
+    @override_settings(ENABLE_CAPTCHA=False)
+    def test_login_page_omits_captcha_when_disabled(self):
+        reload(tp_forms)
+        self.assertNotIn("captcha", tp_forms.LoginForm().fields)
+
+        response = self.render_login()
+
+        self.assertEqual(200, response.status_code)
+        self.assertNotContains(response, 'name="captcha_1"')
+
+    @override_settings(
+        ENABLE_CAPTCHA=True,
+        ENABLE_OPEN_SIGNUP=True,
+        RECAPTCHA_PRIVATE_KEY="",
+        RECAPTCHA_PUBLIC_KEY="",
+    )
+    def test_register_page_renders_captcha_when_enabled(self):
+        reload(tp_forms)
+        self.assertIn("captcha", tp_forms.RegisterForm().fields)
+
+        response = self.render_register()
+
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, 'name="captcha_1"')
+
+    @override_settings(ENABLE_CAPTCHA=False, ENABLE_OPEN_SIGNUP=True)
+    def test_register_page_omits_captcha_when_disabled(self):
+        reload(tp_forms)
+        self.assertNotIn("captcha", tp_forms.RegisterForm().fields)
+
+        response = self.render_register()
+
+        self.assertEqual(200, response.status_code)
+        self.assertNotContains(response, 'name="captcha_1"')

--- a/tests/unit_tests/test_tethys_portal/test_views/test_accounts_captcha.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_accounts_captcha.py
@@ -22,7 +22,10 @@ class TethysPortalAccountsCaptchaRenderingTest(TestCase):
             return self.client.get(reverse("accounts:register"))
 
     @override_settings(
-        ENABLE_CAPTCHA=True, RECAPTCHA_PRIVATE_KEY="", RECAPTCHA_PUBLIC_KEY=""
+        ENABLE_CAPTCHA=True,
+        RECAPTCHA_PRIVATE_KEY="",
+        RECAPTCHA_PUBLIC_KEY="",
+        SHOW_PUBLIC_IF_NO_TENANT_FOUND=True,
     )
     def test_login_page_renders_captcha_when_enabled(self):
         reload(tp_forms)
@@ -33,7 +36,7 @@ class TethysPortalAccountsCaptchaRenderingTest(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertContains(response, 'name="captcha_1"')
 
-    @override_settings(ENABLE_CAPTCHA=False)
+    @override_settings(ENABLE_CAPTCHA=False, SHOW_PUBLIC_IF_NO_TENANT_FOUND=True)
     def test_login_page_omits_captcha_when_disabled(self):
         reload(tp_forms)
         self.assertNotIn("captcha", tp_forms.LoginForm().fields)
@@ -48,6 +51,7 @@ class TethysPortalAccountsCaptchaRenderingTest(TestCase):
         ENABLE_OPEN_SIGNUP=True,
         RECAPTCHA_PRIVATE_KEY="",
         RECAPTCHA_PUBLIC_KEY="",
+        SHOW_PUBLIC_IF_NO_TENANT_FOUND=True,
     )
     def test_register_page_renders_captcha_when_enabled(self):
         reload(tp_forms)
@@ -58,7 +62,11 @@ class TethysPortalAccountsCaptchaRenderingTest(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertContains(response, 'name="captcha_1"')
 
-    @override_settings(ENABLE_CAPTCHA=False, ENABLE_OPEN_SIGNUP=True)
+    @override_settings(
+        ENABLE_CAPTCHA=False,
+        ENABLE_OPEN_SIGNUP=True,
+        SHOW_PUBLIC_IF_NO_TENANT_FOUND=True,
+    )
     def test_register_page_omits_captcha_when_disabled(self):
         reload(tp_forms)
         self.assertNotIn("captcha", tp_forms.RegisterForm().fields)

--- a/tethys_portal/templates/tethys_portal/accounts/login.html
+++ b/tethys_portal/templates/tethys_portal/accounts/login.html
@@ -24,6 +24,7 @@
     {% csrf_token %}
     {% bootstrap_field form.username show_label=False %}
     {% bootstrap_field form.password show_label=False %}
+    {% if form.captcha %}{% bootstrap_field form.captcha show_label=False %}{% endif %}
     <button type="submit" id="login-submit" class="btn btn-primary mb-3" name="login-submit">Log In</button>
     {% if signup_enabled %}
       <span class="d-block">Don't have an account? <a href="{% url 'accounts:register' %}">Sign Up</a></span>

--- a/tethys_portal/templates/tethys_portal/accounts/register.html
+++ b/tethys_portal/templates/tethys_portal/accounts/register.html
@@ -26,6 +26,7 @@
   {% bootstrap_field form.email show_label=False %}
   {% bootstrap_field form.password1 show_label=False %}
   {% bootstrap_field form.password2 show_label=False %}
+  {% if form.captcha %}{% bootstrap_field form.captcha show_label=False %}{% endif %}
   <button type="submit" id="register-submit" class="btn btn-primary mb-3" name="register-submit">Sign Up</button>
   <span class="d-block">Already have an account? <a href="{% url 'accounts:login' %}">Login</a></span>
 </form>


### PR DESCRIPTION
### Description

#1293 switched the login and register forms to an explicit field list to hide labels, which dropped the captcha. With `ENABLE_CAPTCHA` enabled the field is still required but never rendered, so every submission fails validation and the page re-renders, locking users out. Released in 4.6.0.

### Changes Made to Code

- Render `form.captcha`, guarded since `get_captcha()` returns `None` when disabled.
- Add tests rendering both pages with captcha enabled and disabled.
