### PR TITLE
Map Layout Zoom Control Spacing Fix

### DIFF
--- a/tethys_layouts/static/tethys_layouts/map_layout/flat_map.css
+++ b/tethys_layouts/static/tethys_layouts/map_layout/flat_map.css
@@ -64,13 +64,13 @@
 }
 
 .ol-zoom-extent {
-    top: 45px;
+    top: 2.75em;
     border-radius: 0;
 }
 
 .ol-zoom-extent button {
     border-radius: 0;
-    height: 2.15em;
+    height: 2.25em;
 }
 
 

--- a/tethys_layouts/static/tethys_layouts/map_layout/map_layout.css
+++ b/tethys_layouts/static/tethys_layouts/map_layout/map_layout.css
@@ -10,8 +10,16 @@
     height: 100%;
 }
 
-#app-content-wrapper #app-content #app-navigation .nav {
+#app-content-wrapper #app-content #app-navigation {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+#app-content-wrapper #app-content #app-navigation .nav,
+#app-content-wrapper #app-content #app-navigation #nav-header {
     height: auto;
+    flex: 0 0 auto;
 }
 
 #inner-app-content {
@@ -26,14 +34,16 @@
 
 /* Map Tabs */
 .map-tabs {
-    height: calc(100% - 100px);
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 .map-tabs .tab-content {
     overflow-y: auto;
-    max-height: 95%;
-    min-height: 90%;
-    height: auto;
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 /* Layer Selector */


### PR DESCRIPTION
### Description
This merge request addresses two spacing issues in MapLayout:
- A gap between the "fit to extent" and zoom out buttons in the map zoom controls.
- Extra empty space at the bottom of the page when the MapLayout has a subtitle or a multi-line title

See images below:

### Changes Made to Code
 - Adjust styling to remove empty space between the 'fit to extent' and zoom out buttons.
 - Adjust styling to remove empty space along the bottom of the page.

Before:
<img width="294" height="274" alt="image" src="https://github.com/user-attachments/assets/8f65209b-4f23-4626-99b1-2d80cb60f023" />


After:
<img width="404" height="298" alt="image" src="https://github.com/user-attachments/assets/f84b8f90-ce63-4d31-92a1-62ecae90ed26" />

Before:
<img width="1361" height="624" alt="Screenshot 2026-08-19 100211" src="https://github.com/user-attachments/assets/22ea9653-02c8-46ce-a823-cf24ef4f3f97" />

After:
<img width="1361" height="627" alt="Screenshot 2026-08-19 100120" src="https://github.com/user-attachments/assets/3b974186-42c3-48e0-8ab4-048220847f8f" />



### Quality Checks
 - [x] At least one new test has been written for new code
 - [x] New code has 100% test coverage
 - [x] Code has been formatted with Black
 - [x] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [x] The documentation has been updated appropriately
