### PR TITLE
Airgap Tethys when STATICFILES_USE_NPM is true

### DIFF
--- a/tethys_apps/templatetags/dependency.py
+++ b/tethys_apps/templatetags/dependency.py
@@ -1,0 +1,133 @@
+from django import template
+from django.conf import settings
+from django.templatetags.static import static
+from django.utils.html import format_html
+
+register = template.Library()
+
+# npm CDNs whose URL layout maps 1:1 to node_modules (<cdn>/<pkg>@<version>/<path>)
+NPM_CDNS = (
+    "https://cdn.jsdelivr.net/npm/",
+    "https://unpkg.com/",
+)
+
+
+def _local_path(cdn_url, app_package):
+    """Convert a jsDelivr or unpkg npm URL to a local path in the app's node_modules directory.
+
+    Requires a "<cdn>/<pkg>@<version>/<path>" URL (version and path required).
+    The local path will be <app>/node_modules/<pkg>/<path>.
+
+    Args:
+        cdn_url (str): The jsDelivr or unpkg npm URL.
+        app_package (str): The package name of the active Tethys app.
+
+    Returns:
+        str: The local path to the file in the app's node_modules directory.
+    """
+    # Strip whichever npm-CDN prefix matched, leaving "<pkg>@<version>/<path>"
+    for prefix in NPM_CDNS:
+        if cdn_url.startswith(prefix):
+            rest = cdn_url[len(prefix):]
+            break
+
+    # Scoped packages (@scope/pkg) carry their own "@", so peel the scope off first
+    if rest.startswith("@"):
+        # Separate the scope from the rest
+        scope, rest = rest[1:].split("/", 1)
+        # Separate the package name from the version/path
+        name, tail = rest.split("@", 1)
+        # Rebuild the full scoped package name
+        pkg = f"@{scope}/{name}"
+    else:
+        # Unscoped: separate the package name from the version/path
+        name, tail = rest.split("@", 1)
+        pkg = name
+
+    # Keep the path; the version is unused (node_modules has whatever was installed)
+    _version, path = tail.split("/", 1)
+
+    # Build the local path within the app's node_modules directory
+    return f"{app_package}/node_modules/{pkg}/{path}"
+
+
+def _resolve(context, cdn_url, local_path=None):
+    """Resolve the appropriate URL for a dependency based on the STATICFILES_USE_NPM setting.
+
+    Args:
+        context (dict): The template context.
+        cdn_url (str): The CDN URL to the dependency.
+        local_path (str, optional): Explicit local static path, used offline when
+            the CDN URL can't be auto-derived (i.e. not a jsDelivr/unpkg npm URL).
+
+    Returns:
+        str: The resolved URL, either local or CDN.
+    """
+    # Online mode: use the CDN URL as-is
+    if not settings.STATICFILES_USE_NPM:
+        return cdn_url
+
+    # Offline mode: try to auto-derive the local path from a jsDelivr/unpkg npm URL
+    app = (context.get("tethys_app") or {}).get("package")
+    if app and cdn_url.startswith(NPM_CDNS):
+        try:
+            return static(_local_path(cdn_url, app))
+        except ValueError:
+            pass  # malformed npm URL: fall through to the explicit local_path/CDN
+
+    # Fall back to an explicit local path (for other CDNs, or when derivation failed)
+    if local_path:
+        return static(local_path)
+
+    # Nothing to localize with: use the CDN (won't work offline)
+    return cdn_url
+
+
+@register.simple_tag(takes_context=True)
+def dependency_script(context, cdn_url, local_path=None):
+    """
+    Returns a script tag for the given local or CDN path depending on the STATICFILES_USE_NPM setting.
+
+    For jsDelivr/unpkg URLs the local path is derived automatically; for other
+    CDNs, pass local_path explicitly.
+    
+    Example Usage:
+        {% load tethys %}
+        {% dependency_script "https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.js" %}
+        {% dependency_script "https://unpkg.com/axios@0.21.1/dist/axios.min.js" %}
+        {% dependency_script "https://example.com/some-library.js" local_path="my_app/js/some-library.js" %}
+
+    Args:
+        context (dict): The template context.
+        cdn_url (str): The CDN URL to the script.
+        local_path (str, optional): Explicit local static path for non-jsDelivr/unpkg CDNs.
+
+    Returns:
+        str: A script tag with the appropriate src attribute.
+    """
+    return format_html('<script src="{}"></script>', _resolve(context, cdn_url, local_path))
+
+
+@register.simple_tag(takes_context=True)
+def dependency_link(context, cdn_url, local_path=None):
+    """
+    Returns a link tag for the given local or CDN path depending on the STATICFILES_USE_NPM setting.
+
+    For jsDelivr/unpkg URLs the local path is derived automatically; for other
+    CDNs, pass local_path explicitly.
+    
+    Example Usage:
+        {% load tethys %}
+        {% dependency_link "https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.css" %}
+        {% dependency_link "https://unpkg.com/axios@0.21.1/dist/axios.min.css" %}
+        {% dependency_link "https://example.com/some-library.css" local_path="my_app/css/some-library.css" %}
+
+    Args:
+        context (dict): The template context.
+        cdn_url (str): The CDN URL to the stylesheet.
+        local_path (str, optional): Explicit local static path for non-jsDelivr/unpkg CDNs.
+
+    Returns:
+        str: A link tag with the appropriate href attribute.
+    """
+    return format_html('<link rel="stylesheet" href="{}">', _resolve(context, cdn_url, local_path))

--- a/tethys_layouts/templates/tethys_layouts/map_layout/map_layout.html
+++ b/tethys_layouts/templates/tethys_layouts/map_layout/map_layout.html
@@ -6,7 +6,11 @@
   <!-- Bootstrap Select2 Theme -->
   {{ tethys.select2_bootstrap_5_theme.link_tag|safe }}
   <!-- Plotly -->
-  <script src="https://cdn.plot.ly/plotly-{{ plotly_version }}.min.js"></script>
+  {% if staticfiles_use_npm %}
+    {% import_gizmo_dependency plotly_view %}
+  {% else %}
+    <script src="https://cdn.plot.ly/plotly-{{ plotly_version }}.min.js"></script>
+  {% endif %}
 {% endblock %}
 
 {% block app_navigation %}

--- a/tethys_layouts/templates/tethys_layouts/map_layout/map_layout.html
+++ b/tethys_layouts/templates/tethys_layouts/map_layout/map_layout.html
@@ -3,7 +3,9 @@
 
 {% block import_gizmos %}
   {% import_gizmo_dependency select_input %}
-  <link href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.2.0/dist/select2-bootstrap-5-theme.min.css" rel="stylesheet">
+  <!-- Bootstrap Select2 Theme -->
+  {{ tethys.select2_bootstrap_5_theme.link_tag|safe }}
+  <!-- Plotly -->
   <script src="https://cdn.plot.ly/plotly-{{ plotly_version }}.min.js"></script>
 {% endblock %}
 

--- a/tethys_layouts/templates/tethys_layouts/tethys_layout.html
+++ b/tethys_layouts/templates/tethys_layouts/tethys_layout.html
@@ -21,6 +21,5 @@
 
 {% block content_dependent_styles %}
     {{ block.super }}
-    <!-- TODO: Why is this here - remove Hard-coded CDNs? -->
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" integrity="sha384-gfdkjb5BdAXd+lj+gudLWI+BXq4IuLW5IT+brZEZsLFm++aCMlF1V92rMkPaX4PP" crossorigin="anonymous">
+    {{ tethys.fontawesome.link_tag|safe }}
 {% endblock %}

--- a/tethys_layouts/views/map_layout.py
+++ b/tethys_layouts/views/map_layout.py
@@ -19,6 +19,7 @@ import tempfile
 import uuid
 from zipfile import ZipFile
 
+from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.utils.functional import classproperty
@@ -384,6 +385,7 @@ class MapLayout(TethysLayout, MapLayoutMixin):
                 "show_properties_popup": self.show_properties_popup,
                 "show_map_click_popup": self.show_map_click_popup,
                 "show_legends": self.show_legends,
+                "staticfiles_use_npm": settings.STATICFILES_USE_NPM,
                 "wide_nav": self.wide_nav,
                 "workspace": self.geoserver_workspace,
             }

--- a/tethys_portal/dependencies.py
+++ b/tethys_portal/dependencies.py
@@ -228,6 +228,11 @@ vendor_static_dependencies = {
         js_path="cookies_min.js",
         debug_path_converter=lambda path: path.replace("_min", ""),
     ),
+    "fontawesome": JsDelivrStaticDependency(
+        npm_name="@fortawesome/fontawesome-free",
+        version="5.6.1",
+        css_path="css/all.min.css",
+    ),
     "graphlib": JsDelivrStaticDependency(
         npm_name="graphlib",
         version="2.1.8",

--- a/tethys_portal/dependencies.py
+++ b/tethys_portal/dependencies.py
@@ -65,9 +65,9 @@ class StaticDependency:
         elif not self.use_cdn:
             logger.warning(
                 f'The "STATICFILES_USE_NPM" setting is set to True, but the custom version "{self.npm_name}={version}" '
-                f"is not supported. A CDN will be used to attempt to provide the custom version ({self.version})."
+                f"is not available locally. Serving the installed version ({self.version}) instead."
             )
-            use_cdn = True
+            version = self.version
         return self._get_url(url_type, version, debug=debug, use_cdn=use_cdn)
 
     def get_js_urls(self, version=None):

--- a/tethys_portal/dependencies.py
+++ b/tethys_portal/dependencies.py
@@ -172,6 +172,11 @@ vendor_static_dependencies = {
         version="1.11.3",
         css_path="font/bootstrap-icons.min.css",
     ),
+    "bootstrap_select2_5_theme": JsDelivrStaticDependency(
+        npm_name="select2-bootstrap-5-theme",
+        version="1.2.0",
+        css_path="dist/select2-bootstrap-5-theme.min.css",
+    ),
     "bootstrap-switch": JsDelivrStaticDependency(
         npm_name="bootstrap-switch",
         version="4.0.0-alpha.1",

--- a/tethys_sdk/templatetags/tethys.py
+++ b/tethys_sdk/templatetags/tethys.py
@@ -9,6 +9,7 @@
 """
 
 from tethys_apps.templatetags.app_theme import register as app_theme_library
+from tethys_apps.templatetags.dependency import register as dependency_library
 from tethys_apps.templatetags.humanize import register as humanize_library
 from tethys_apps.templatetags.site_settings import register as site_settings_library
 from tethys_apps.templatetags.tags import register as tags_library
@@ -18,6 +19,7 @@ from django import template
 
 libraries = (
     app_theme_library,
+    dependency_library,
     humanize_library,
     site_settings_library,
     tags_library,


### PR DESCRIPTION
### Description

Remove hard coded requests to CDNs so the static dependencies are served through Tethys when `STATICFILES_USE_NPM` is true. Additionally, add convenience tags `{% dependency_script %}` and `{% dependency_link %}` so app creators don't have to use conditionals in templates to determine when `STATICFILES_USE_NPM` is true or false.

### Changes Made to Code
 
- tethys_portal/dependencies.py
  - Added `select2-bootstrap-5-theme` and Font Awesome (`@fortawesome/fontawesome-free`) to `vendor_static_dependencies` so they can be served locally.
  - Updated `StaticDependency.get_custom_version_url` to serve the locally-installed (default) version instead of falling back to a CDN when `STATICFILES_USE_NPM` is true and a non-installed version is requested (the old CDN fallback fails in an air-gapped environment). Online behavior is unchanged — the requested version is still fetched from the CDN.
- tethys_layouts/MapLayout
  - `map_layout.html`: replaced the hard coded `select2-bootstrap-5-theme` CDN `<link>` with the vendored dependency; load Plotly locally (inlined from the installed Python package via the `plotly_view` gizmo dependency) when `STATICFILES_USE_NPM` is true, and from the CDN otherwise (still version-configurable in the controller).
  - `map_layout.py`: added `staticfiles_use_npm` to the template context to drive the Plotly conditional.
- tethys_layouts/TethysLayout
  - `tethys_layout.html`: replaced the hard coded Font Awesome CDN `<link>` with the vendored dependency.
- New convenience template tags
  - `tethys_apps/templatetags/dependency.py`: added `{% dependency_script %}` and `{% dependency_link %}`. They emit a `<script>`/`<link>` that resolves to the app's local `node_modules` when `STATICFILES_USE_NPM` is true and to the CDN otherwise. The local path is derived automatically from jsDelivr/unpkg npm URLs; an optional `local_path` argument covers other CDNs (e.g. cdnjs).
  - `tethys_sdk/templatetags/tethys.py`: registered the new tags in the aggregated `tethys` library so they're available via `{% load tethys %}`.

### Related PRs, Issues, and Discussions
- 

### Additional Notes
-  

### Quality Checks
 - [ ] At least one new test has been written for new code
 - [ ] New code has 100% test coverage
 - [ ] Code has been formatted with Black
 - [ ] Code has been linted with flake8
 - [x] Docstrings for new methods have been added
 - [ ] The documentation has been updated appropriately
